### PR TITLE
Bootstrap the validation-first site generator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+dist
+node_modules
+coverage
+

--- a/content/site.json
+++ b/content/site.json
@@ -1,0 +1,84 @@
+{
+  "site": {
+    "name": "LaunchKit",
+    "baseUrl": "https://launchkit.example",
+    "theme": "app-announcement"
+  },
+  "pages": [
+    {
+      "slug": "/",
+      "title": "LaunchKit",
+      "metadata": {
+        "description": "Strict JSON, stable markup, and theme-driven static pages."
+      },
+      "components": [
+        {
+          "type": "hero",
+          "headline": "Announce your app with clean structure",
+          "subheadline": "Strict JSON, fixed components, and theme-driven presentation.",
+          "primaryCta": {
+            "label": "Start now",
+            "href": "/start"
+          },
+          "secondaryCta": {
+            "label": "See demo",
+            "href": "/demo"
+          },
+          "align": "start"
+        },
+        {
+          "type": "feature-grid",
+          "title": "Why this approach works",
+          "items": [
+            {
+              "title": "Strict validation",
+              "body": "Unknown keys fail the build."
+            },
+            {
+              "title": "Stable markup",
+              "body": "Components own structure, not content JSON."
+            },
+            {
+              "title": "Theme discipline",
+              "body": "Themes define exactly one token contract."
+            }
+          ]
+        },
+        {
+          "type": "cta-band",
+          "headline": "Build reviewable static pages",
+          "body": "Run validation before every build and keep the markup intentionally boring.",
+          "primaryCta": {
+            "label": "Read docs",
+            "href": "/docs"
+          }
+        }
+      ]
+    },
+    {
+      "slug": "/pricing",
+      "title": "Pricing",
+      "components": [
+        {
+          "type": "hero",
+          "headline": "Launch with less front-end drift",
+          "subheadline": "A narrow framework is easier to validate, review, and keep consistent.",
+          "primaryCta": {
+            "label": "Start free",
+            "href": "/signup"
+          },
+          "align": "center"
+        },
+        {
+          "type": "cta-band",
+          "headline": "Need a stricter content pipeline?",
+          "primaryCta": {
+            "label": "Contact sales",
+            "href": "/contact"
+          }
+        }
+      ]
+    }
+  ]
+}
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,1677 @@
+{
+  "name": "cruftless-site-gen",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "cruftless-site-gen",
+      "version": "0.1.0",
+      "dependencies": {
+        "zod": "^3.23.8"
+      },
+      "devDependencies": {
+        "@types/node": "^22.10.2",
+        "tsx": "^4.19.2",
+        "typescript": "^5.7.2",
+        "vitest": "^3.0.5"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.4.tgz",
+      "integrity": "sha512-cQPwL2mp2nSmHHJlCyoXgHGhbEPMrEEU5xhkcy3Hs/O7nGZqEpZ2sUtLaL9MORLtDfRvVl2/3PAuEkYZH0Ty8Q==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.4.tgz",
+      "integrity": "sha512-X9bUgvxiC8CHAGKYufLIHGXPJWnr0OCdR0anD2e21vdvgCI8lIfqFbnoeOz7lBjdrAGUhqLZLcQo6MLhTO2DKQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.4.tgz",
+      "integrity": "sha512-gdLscB7v75wRfu7QSm/zg6Rx29VLdy9eTr2t44sfTW7CxwAtQghZ4ZnqHk3/ogz7xao0QAgrkradbBzcqFPasw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.4.tgz",
+      "integrity": "sha512-PzPFnBNVF292sfpfhiyiXCGSn9HZg5BcAz+ivBuSsl6Rk4ga1oEXAamhOXRFyMcjwr2DVtm40G65N3GLeH1Lvw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.4.tgz",
+      "integrity": "sha512-b7xaGIwdJlht8ZFCvMkpDN6uiSmnxxK56N2GDTMYPr2/gzvfdQN8rTfBsvVKmIVY/X7EM+/hJKEIbbHs9oA4tQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.4.tgz",
+      "integrity": "sha512-sR+OiKLwd15nmCdqpXMnuJ9W2kpy0KigzqScqHI3Hqwr7IXxBp3Yva+yJwoqh7rE8V77tdoheRYataNKL4QrPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.4.tgz",
+      "integrity": "sha512-jnfpKe+p79tCnm4GVav68A7tUFeKQwQyLgESwEAUzyxk/TJr4QdGog9sqWNcUbr/bZt/O/HXouspuQDd9JxFSw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.4.tgz",
+      "integrity": "sha512-2kb4ceA/CpfUrIcTUl1wrP/9ad9Atrp5J94Lq69w7UwOMolPIGrfLSvAKJp0RTvkPPyn6CIWrNy13kyLikZRZQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.4.tgz",
+      "integrity": "sha512-aBYgcIxX/wd5n2ys0yESGeYMGF+pv6g0DhZr3G1ZG4jMfruU9Tl1i2Z+Wnj9/KjGz1lTLCcorqE2viePZqj4Eg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.4.tgz",
+      "integrity": "sha512-7nQOttdzVGth1iz57kxg9uCz57dxQLHWxopL6mYuYthohPKEK0vU0C3O21CcBK6KDlkYVcnDXY099HcCDXd9dA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.4.tgz",
+      "integrity": "sha512-oPtixtAIzgvzYcKBQM/qZ3R+9TEUd1aNJQu0HhGyqtx6oS7qTpvjheIWBbes4+qu1bNlo2V4cbkISr8q6gRBFA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.4.tgz",
+      "integrity": "sha512-8mL/vh8qeCoRcFH2nM8wm5uJP+ZcVYGGayMavi8GmRJjuI3g1v6Z7Ni0JJKAJW+m0EtUuARb6Lmp4hMjzCBWzA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.4.tgz",
+      "integrity": "sha512-1RdrWFFiiLIW7LQq9Q2NES+HiD4NyT8Itj9AUeCl0IVCA459WnPhREKgwrpaIfTOe+/2rdntisegiPWn/r/aAw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.4.tgz",
+      "integrity": "sha512-tLCwNG47l3sd9lpfyx9LAGEGItCUeRCWeAx6x2Jmbav65nAwoPXfewtAdtbtit/pJFLUWOhpv0FpS6GQAmPrHA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.4.tgz",
+      "integrity": "sha512-BnASypppbUWyqjd1KIpU4AUBiIhVr6YlHx/cnPgqEkNoVOhHg+YiSVxM1RLfiy4t9cAulbRGTNCKOcqHrEQLIw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.4.tgz",
+      "integrity": "sha512-+eUqgb/Z7vxVLezG8bVB9SfBie89gMueS+I0xYh2tJdw3vqA/0ImZJ2ROeWwVJN59ihBeZ7Tu92dF/5dy5FttA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.4.tgz",
+      "integrity": "sha512-S5qOXrKV8BQEzJPVxAwnryi2+Iq5pB40gTEIT69BQONqR7JH1EPIcQ/Uiv9mCnn05jff9umq/5nqzxlqTOg9NA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.4.tgz",
+      "integrity": "sha512-xHT8X4sb0GS8qTqiwzHqpY00C95DPAq7nAwX35Ie/s+LO9830hrMd3oX0ZMKLvy7vsonee73x0lmcdOVXFzd6Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.4.tgz",
+      "integrity": "sha512-RugOvOdXfdyi5Tyv40kgQnI0byv66BFgAqjdgtAKqHoZTbTF2QqfQrFwa7cHEORJf6X2ht+l9ABLMP0dnKYsgg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.4.tgz",
+      "integrity": "sha512-2MyL3IAaTX+1/qP0O1SwskwcwCoOI4kV2IBX1xYnDDqthmq5ArrW94qSIKCAuRraMgPOmG0RDTA74mzYNQA9ow==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.4.tgz",
+      "integrity": "sha512-u8fg/jQ5aQDfsnIV6+KwLOf1CmJnfu1ShpwqdwC0uA7ZPwFws55Ngc12vBdeUdnuWoQYx/SOQLGDcdlfXhYmXQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.4.tgz",
+      "integrity": "sha512-JkTZrl6VbyO8lDQO3yv26nNr2RM2yZzNrNHEsj9bm6dOwwu9OYN28CjzZkH57bh4w0I2F7IodpQvUAEd1mbWXg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.4.tgz",
+      "integrity": "sha512-/gOzgaewZJfeJTlsWhvUEmUG4tWEY2Spp5M20INYRg2ZKl9QPO3QEEgPeRtLjEWSW8FilRNacPOg8R1uaYkA6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.4.tgz",
+      "integrity": "sha512-Z9SExBg2y32smoDQdf1HRwHRt6vAHLXcxD2uGgO/v2jK7Y718Ix4ndsbNMU/+1Qiem9OiOdaqitioZwxivhXYg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.4.tgz",
+      "integrity": "sha512-DAyGLS0Jz5G5iixEbMHi5KdiApqHBWMGzTtMiJ72ZOLhbu/bzxgAe8Ue8CTS3n3HbIUHQz/L51yMdGMeoxXNJw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.4.tgz",
+      "integrity": "sha512-+knoa0BDoeXgkNvvV1vvbZX4+hizelrkwmGJBdT17t8FNPwG2lKemmuMZlmaNQ3ws3DKKCxpb4zRZEIp3UxFCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.0.tgz",
+      "integrity": "sha512-WOhNW9K8bR3kf4zLxbfg6Pxu2ybOUbB2AjMDHSQx86LIF4rH4Ft7vmMwNt0loO0eonglSNy4cpD3MKXXKQu0/A==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.0.tgz",
+      "integrity": "sha512-u6JHLll5QKRvjciE78bQXDmqRqNs5M/3GVqZeMwvmjaNODJih/WIrJlFVEihvV0MiYFmd+ZyPr9wxOVbPAG2Iw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.0.tgz",
+      "integrity": "sha512-qEF7CsKKzSRc20Ciu2Zw1wRrBz4g56F7r/vRwY430UPp/nt1x21Q/fpJ9N5l47WWvJlkNCPJz3QRVw008fi7yA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.0.tgz",
+      "integrity": "sha512-WADYozJ4QCnXCH4wPB+3FuGmDPoFseVCUrANmA5LWwGmC6FL14BWC7pcq+FstOZv3baGX65tZ378uT6WG8ynTw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.0.tgz",
+      "integrity": "sha512-6b8wGHJlDrGeSE3aH5mGNHBjA0TTkxdoNHik5EkvPHCt351XnigA4pS7Wsj/Eo9Y8RBU6f35cjN9SYmCFBtzxw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.0.tgz",
+      "integrity": "sha512-h25Ga0t4jaylMB8M/JKAyrvvfxGRjnPQIR8lnCayyzEjEOx2EJIlIiMbhpWxDRKGKF8jbNH01NnN663dH638mA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.0.tgz",
+      "integrity": "sha512-RzeBwv0B3qtVBWtcuABtSuCzToo2IEAIQrcyB/b2zMvBWVbjo8bZDjACUpnaafaxhTw2W+imQbP2BD1usasK4g==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.0.tgz",
+      "integrity": "sha512-Sf7zusNI2CIU1HLzuu9Tc5YGAHEZs5Lu7N1ssJG4Tkw6e0MEsN7NdjUDDfGNHy2IU+ENyWT+L2obgWiguWibWQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.0.tgz",
+      "integrity": "sha512-DX2x7CMcrJzsE91q7/O02IJQ5/aLkVtYFryqCjduJhUfGKG6yJV8hxaw8pZa93lLEpPTP/ohdN4wFz7yp/ry9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.0.tgz",
+      "integrity": "sha512-09EL+yFVbJZlhcQfShpswwRZ0Rg+z/CsSELFCnPt3iK+iqwGsI4zht3secj5vLEs957QvFFXnzAT0FFPIxSrkQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.0.tgz",
+      "integrity": "sha512-i9IcCMPr3EXm8EQg5jnja0Zyc1iFxJjZWlb4wr7U2Wx/GrddOuEafxRdMPRYVaXjgbhvqalp6np07hN1w9kAKw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.0.tgz",
+      "integrity": "sha512-DGzdJK9kyJ+B78MCkWeGnpXJ91tK/iKA6HwHxF4TAlPIY7GXEvMe8hBFRgdrR9Ly4qebR/7gfUs9y2IoaVEyog==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.0.tgz",
+      "integrity": "sha512-RwpnLsqC8qbS8z1H1AxBA1H6qknR4YpPR9w2XX0vo2Sz10miu57PkNcnHVaZkbqyw/kUWfKMI73jhmfi9BRMUQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.0.tgz",
+      "integrity": "sha512-Z8pPf54Ly3aqtdWC3G4rFigZgNvd+qJlOE52fmko3KST9SoGfAdSRCwyoyG05q1HrrAblLbk1/PSIV+80/pxLg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.0.tgz",
+      "integrity": "sha512-3a3qQustp3COCGvnP4SvrMHnPQ9d1vzCakQVRTliaz8cIp/wULGjiGpbcqrkv0WrHTEp8bQD/B3HBjzujVWLOA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.0.tgz",
+      "integrity": "sha512-pjZDsVH/1VsghMJ2/kAaxt6dL0psT6ZexQVrijczOf+PeP2BUqTHYejk3l6TlPRydggINOeNRhvpLa0AYpCWSQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.0.tgz",
+      "integrity": "sha512-3ObQs0BhvPgiUVZrN7gqCSvmFuMWvWvsjG5ayJ3Lraqv+2KhOsp+pUbigqbeWqueGIsnn+09HBw27rJ+gYK4VQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.0.tgz",
+      "integrity": "sha512-EtylprDtQPdS5rXvAayrNDYoJhIz1/vzN2fEubo3yLE7tfAw+948dO0g4M0vkTVFhKojnF+n6C8bDNe+gDRdTg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.0.tgz",
+      "integrity": "sha512-k09oiRCi/bHU9UVFqD17r3eJR9bn03TyKraCrlz5ULFJGdJGi7VOmm9jl44vOJvRJ6P7WuBi/s2A97LxxHGIdw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.0.tgz",
+      "integrity": "sha512-1o/0/pIhozoSaDJoDcec+IVLbnRtQmHwPV730+AOD29lHEEo4F5BEUB24H0OBdhbBBDwIOSuf7vgg0Ywxdfiiw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.0.tgz",
+      "integrity": "sha512-pESDkos/PDzYwtyzB5p/UoNU/8fJo68vcXM9ZW2V0kjYayj1KaaUfi1NmTUTUpMn4UhU4gTuK8gIaFO4UGuMbA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.0.tgz",
+      "integrity": "sha512-hj1wFStD7B1YBeYmvY+lWXZ7ey73YGPcViMShYikqKT1GtstIKQAtfUI6yrzPjAy/O7pO0VLXGmUVWXQMaYgTQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.0.tgz",
+      "integrity": "sha512-SyaIPFoxmUPlNDq5EHkTbiKzmSEmq/gOYFI/3HHJ8iS/v1mbugVa7dXUzcJGQfoytp9DJFLhHH4U3/eTy2Bq4w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.0.tgz",
+      "integrity": "sha512-RdcryEfzZr+lAr5kRm2ucN9aVlCCa2QNq4hXelZxb8GG0NJSazq44Z3PCCc8wISRuCVnGs0lQJVX5Vp6fKA+IA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.0.tgz",
+      "integrity": "sha512-PrsWNQ8BuE00O3Xsx3ALh2Df8fAj9+cvvX9AIA6o4KpATR98c9mud4XtDWVvsEuyia5U4tVSTKygawyJkjm60w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.15",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.15.tgz",
+      "integrity": "sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
+      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
+      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
+      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
+      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.4",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
+      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
+      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
+      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.4.tgz",
+      "integrity": "sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.4",
+        "@esbuild/android-arm": "0.27.4",
+        "@esbuild/android-arm64": "0.27.4",
+        "@esbuild/android-x64": "0.27.4",
+        "@esbuild/darwin-arm64": "0.27.4",
+        "@esbuild/darwin-x64": "0.27.4",
+        "@esbuild/freebsd-arm64": "0.27.4",
+        "@esbuild/freebsd-x64": "0.27.4",
+        "@esbuild/linux-arm": "0.27.4",
+        "@esbuild/linux-arm64": "0.27.4",
+        "@esbuild/linux-ia32": "0.27.4",
+        "@esbuild/linux-loong64": "0.27.4",
+        "@esbuild/linux-mips64el": "0.27.4",
+        "@esbuild/linux-ppc64": "0.27.4",
+        "@esbuild/linux-riscv64": "0.27.4",
+        "@esbuild/linux-s390x": "0.27.4",
+        "@esbuild/linux-x64": "0.27.4",
+        "@esbuild/netbsd-arm64": "0.27.4",
+        "@esbuild/netbsd-x64": "0.27.4",
+        "@esbuild/openbsd-arm64": "0.27.4",
+        "@esbuild/openbsd-x64": "0.27.4",
+        "@esbuild/openharmony-arm64": "0.27.4",
+        "@esbuild/sunos-x64": "0.27.4",
+        "@esbuild/win32-arm64": "0.27.4",
+        "@esbuild/win32-ia32": "0.27.4",
+        "@esbuild/win32-x64": "0.27.4"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.13.7",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.7.tgz",
+      "integrity": "sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.8",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
+      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.0.tgz",
+      "integrity": "sha512-yqjxruMGBQJ2gG4HtjZtAfXArHomazDHoFwFFmZZl0r7Pdo7qCIXKqKHZc8yeoMgzJJ+pO6pEEHa+V7uzWlrAQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.0",
+        "@rollup/rollup-android-arm64": "4.60.0",
+        "@rollup/rollup-darwin-arm64": "4.60.0",
+        "@rollup/rollup-darwin-x64": "4.60.0",
+        "@rollup/rollup-freebsd-arm64": "4.60.0",
+        "@rollup/rollup-freebsd-x64": "4.60.0",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.0",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.0",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.0",
+        "@rollup/rollup-linux-arm64-musl": "4.60.0",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.0",
+        "@rollup/rollup-linux-loong64-musl": "4.60.0",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.0",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.0",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.0",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.0",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.0",
+        "@rollup/rollup-linux-x64-gnu": "4.60.0",
+        "@rollup/rollup-linux-x64-musl": "4.60.0",
+        "@rollup/rollup-openbsd-x64": "4.60.0",
+        "@rollup/rollup-openharmony-arm64": "4.60.0",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.0",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.0",
+        "@rollup/rollup-win32-x64-gnu": "4.60.0",
+        "@rollup/rollup-win32-x64-msvc": "4.60.0",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vite": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
+      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
+      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.4",
+        "@vitest/mocker": "3.2.4",
+        "@vitest/pretty-format": "^3.2.4",
+        "@vitest/runner": "3.2.4",
+        "@vitest/snapshot": "3.2.4",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.4",
+        "@vitest/ui": "3.2.4",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "cruftless-site-gen",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "engines": {
+    "node": ">=20"
+  },
+  "scripts": {
+    "build": "tsx src/build/build.ts",
+    "validate": "tsx src/build/validate.ts",
+    "lint:ts": "tsc --noEmit",
+    "test": "vitest run",
+    "check": "npm run lint:ts && npm run test && npm run validate && npm run build"
+  },
+  "dependencies": {
+    "zod": "^3.23.8"
+  },
+  "devDependencies": {
+    "@types/node": "^22.10.2",
+    "tsx": "^4.19.2",
+    "typescript": "^5.7.2",
+    "vitest": "^3.0.5"
+  }
+}
+

--- a/src/build/build.ts
+++ b/src/build/build.ts
@@ -1,0 +1,27 @@
+import path from "node:path";
+
+import {
+  ValidationFailure,
+  buildSiteFromFile,
+  defaultContentPath,
+  defaultOutDir,
+} from "./framework.js";
+
+const [, , contentArg, outArg] = process.argv;
+const contentPath = contentArg ? path.resolve(process.cwd(), contentArg) : defaultContentPath;
+const outDir = outArg ? path.resolve(process.cwd(), outArg) : defaultOutDir;
+
+try {
+  const siteContent = await buildSiteFromFile(contentPath, outDir);
+  console.log(
+    `Built ${siteContent.pages.length} page(s) into ${path.relative(process.cwd(), outDir)}`,
+  );
+} catch (error) {
+  if (error instanceof ValidationFailure) {
+    console.error(error.message);
+    process.exitCode = 1;
+  } else {
+    throw error;
+  }
+}
+

--- a/src/build/framework.ts
+++ b/src/build/framework.ts
@@ -1,0 +1,269 @@
+import { existsSync } from "node:fs";
+import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import type { ZodIssue } from "zod";
+
+import {
+  componentDefinitions,
+  renderComponent,
+} from "../components/index.js";
+import {
+  SiteContentSchema,
+  type SiteContentData,
+} from "../schemas/site.schema.js";
+import { renderPageDocument } from "../renderer/render-page.js";
+import { emitThemeCss } from "../themes/emit-theme-css.js";
+import { themes } from "../themes/index.js";
+import { validateComponentRegistry } from "../validation/component-registry-validation.js";
+import {
+  collectSiteValidationIssues,
+  type ValidationIssue,
+} from "../validation/site-validation.js";
+import {
+  validateCssTokenUsage,
+  validateThemeDefinition,
+} from "../validation/theme-validation.js";
+
+export const defaultContentPath = path.resolve(process.cwd(), "content/site.json");
+export const defaultOutDir = path.resolve(process.cwd(), "dist");
+
+const baseCssPath = fileURLToPath(new URL("../styles/base.css", import.meta.url));
+
+export class ValidationFailure extends Error {
+  constructor(
+    readonly filePath: string,
+    readonly issues: readonly ValidationIssue[],
+  ) {
+    super(formatValidationFailure(filePath, issues));
+    this.name = "ValidationFailure";
+  }
+}
+
+const formatPath = (pathSegments: Array<string | number>): string => {
+  if (pathSegments.length === 0) {
+    return "";
+  }
+
+  return pathSegments.reduce<string>((pathString, segment) => {
+    if (typeof segment === "number") {
+      return `${pathString}[${segment}]`;
+    }
+
+    return pathString ? `${pathString}.${segment}` : segment;
+  }, "");
+};
+
+const readValueAtPath = (value: unknown, pathSegments: Array<string | number>): unknown => {
+  let currentValue = value;
+  for (const pathSegment of pathSegments) {
+    if (typeof pathSegment === "number") {
+      if (!Array.isArray(currentValue)) {
+        return undefined;
+      }
+
+      currentValue = currentValue[pathSegment];
+      continue;
+    }
+
+    if (typeof currentValue !== "object" || currentValue === null) {
+      return undefined;
+    }
+
+    currentValue = (currentValue as Record<string, unknown>)[pathSegment];
+  }
+
+  return currentValue;
+};
+
+const getComponentTypeForIssue = (
+  rawData: unknown,
+  pathSegments: Array<string | number>,
+): string | undefined => {
+  if (
+    pathSegments[0] !== "pages" ||
+    typeof pathSegments[1] !== "number" ||
+    pathSegments[2] !== "components" ||
+    typeof pathSegments[3] !== "number"
+  ) {
+    return undefined;
+  }
+
+  const component = readValueAtPath(rawData, pathSegments.slice(0, 4));
+  if (typeof component !== "object" || component === null) {
+    return undefined;
+  }
+
+  const componentType = (component as Record<string, unknown>).type;
+  return typeof componentType === "string" ? componentType : undefined;
+};
+
+const formatZodIssue = (issue: ZodIssue, rawData: unknown): ValidationIssue => {
+  const componentType = getComponentTypeForIssue(rawData, issue.path);
+
+  if (issue.code === "unrecognized_keys") {
+    const keyLabel = issue.keys.length === 1 ? "key" : "keys";
+    return {
+      path: issue.path,
+      componentType,
+      message: `unknown ${keyLabel} ${issue.keys.map((key) => `'${key}'`).join(", ")}`,
+    };
+  }
+
+  if (issue.code === "invalid_union_discriminator" && componentType) {
+    return {
+      path: issue.path,
+      componentType,
+      message: `unknown component type '${componentType}'`,
+    };
+  }
+
+  if (issue.code === "invalid_union_discriminator") {
+    const value = readValueAtPath(rawData, issue.path);
+    return {
+      path: issue.path,
+      message: `unknown discriminator value '${String(value)}'`,
+    };
+  }
+
+  return {
+    path: issue.path,
+    componentType,
+    message: issue.message,
+  };
+};
+
+const formatValidationFailure = (
+  filePath: string,
+  issues: readonly ValidationIssue[],
+): string => {
+  const lines = [`Validation failed in ${filePath}`];
+
+  issues.forEach((issue) => {
+    if (issue.source) {
+      lines.push(`${issue.source}: ${issue.message}`);
+      return;
+    }
+
+    const pathString = formatPath(issue.path);
+    if (pathString) {
+      const componentLabel = issue.componentType ? ` (${issue.componentType})` : "";
+      lines.push(`${pathString}${componentLabel}: ${issue.message}`);
+      return;
+    }
+
+    lines.push(issue.message);
+  });
+
+  return lines.join("\n");
+};
+
+export const loadValidatedSite = async (
+  contentPath: string = defaultContentPath,
+): Promise<SiteContentData> => {
+  if (!existsSync(contentPath)) {
+    throw new ValidationFailure(contentPath, [
+      {
+        path: [],
+        message: "content file does not exist",
+      },
+    ]);
+  }
+
+  const rawJson = await readFile(contentPath, "utf8");
+  let rawData: unknown;
+
+  try {
+    rawData = JSON.parse(rawJson) as unknown;
+  } catch (error) {
+    throw new ValidationFailure(contentPath, [
+      {
+        path: [],
+        message: error instanceof Error ? `invalid JSON: ${error.message}` : String(error),
+      },
+    ]);
+  }
+
+  const frameworkIssues: ValidationIssue[] = [
+    ...validateComponentRegistry(componentDefinitions),
+    ...Object.entries(themes).flatMap(([themeName, theme]) =>
+      validateThemeDefinition(themeName, theme),
+    ),
+    ...(await validateCssTokenUsage([baseCssPath, ...componentDefinitions.map((component) => component.cssPath)])),
+  ];
+
+  const parsed = SiteContentSchema.safeParse(rawData);
+  if (!parsed.success) {
+    throw new ValidationFailure(contentPath, [
+      ...frameworkIssues,
+      ...parsed.error.issues.map((issue) => formatZodIssue(issue, rawData)),
+    ]);
+  }
+
+  const contentIssues = collectSiteValidationIssues(parsed.data);
+  if (frameworkIssues.length > 0 || contentIssues.length > 0) {
+    throw new ValidationFailure(contentPath, [...frameworkIssues, ...contentIssues]);
+  }
+
+  return parsed.data;
+};
+
+const pageSlugToOutputPath = (slug: string, outDir: string): string => {
+  if (slug === "/") {
+    return path.join(outDir, "index.html");
+  }
+
+  return path.join(outDir, slug.replace(/^\//, ""), "index.html");
+};
+
+const renderSiteCss = async (themeName: keyof typeof themes): Promise<string> => {
+  const componentCssChunks = await Promise.all(
+    componentDefinitions.map(async (componentDefinition) => {
+      const css = await readFile(componentDefinition.cssPath, "utf8");
+      return `/* ${componentDefinition.type} */\n${css}`;
+    }),
+  );
+
+  const baseCss = await readFile(baseCssPath, "utf8");
+
+  return [
+    "/* theme */",
+    emitThemeCss(themes[themeName]),
+    "/* base */",
+    baseCss,
+    ...componentCssChunks,
+  ].join("\n\n");
+};
+
+export const buildSite = async (
+  siteContent: SiteContentData,
+  outDir: string = defaultOutDir,
+): Promise<void> => {
+  await rm(outDir, { recursive: true, force: true });
+  await mkdir(path.join(outDir, "assets"), { recursive: true });
+
+  const css = await renderSiteCss(siteContent.site.theme);
+  await writeFile(path.join(outDir, "assets", "site.css"), css, "utf8");
+
+  for (const page of siteContent.pages) {
+    const bodyHtml = page.components.map((component) => renderComponent(component)).join("\n");
+    const documentHtml = renderPageDocument({
+      site: siteContent.site,
+      page,
+      bodyHtml,
+      stylesheetHref: path.posix.join("/assets", "site.css"),
+    });
+    const outputPath = pageSlugToOutputPath(page.slug, outDir);
+    await mkdir(path.dirname(outputPath), { recursive: true });
+    await writeFile(outputPath, documentHtml, "utf8");
+  }
+};
+
+export const buildSiteFromFile = async (
+  contentPath: string = defaultContentPath,
+  outDir: string = defaultOutDir,
+): Promise<SiteContentData> => {
+  const siteContent = await loadValidatedSite(contentPath);
+  await buildSite(siteContent, outDir);
+  return siteContent;
+};

--- a/src/build/validate.ts
+++ b/src/build/validate.ts
@@ -1,0 +1,21 @@
+import path from "node:path";
+
+import { ValidationFailure, defaultContentPath, loadValidatedSite } from "./framework.js";
+
+const [, , contentArg] = process.argv;
+const contentPath = contentArg ? path.resolve(process.cwd(), contentArg) : defaultContentPath;
+
+try {
+  const siteContent = await loadValidatedSite(contentPath);
+  console.log(
+    `Validated ${siteContent.pages.length} page(s) from ${path.relative(process.cwd(), contentPath)}`,
+  );
+} catch (error) {
+  if (error instanceof ValidationFailure) {
+    console.error(error.message);
+    process.exitCode = 1;
+  } else {
+    throw error;
+  }
+}
+

--- a/src/components/cta-band/cta-band.css
+++ b/src/components/cta-band/cta-band.css
@@ -1,0 +1,38 @@
+.c-cta-band {
+  padding-block: var(--space-7);
+}
+
+.c-cta-band__inner {
+  width: min(calc(100% - (2 * var(--space-5))), var(--container-max));
+  margin-inline: auto;
+  padding: var(--space-6);
+  display: grid;
+  gap: var(--space-4);
+  border: var(--border-width-1) solid var(--color-border);
+  border-radius: var(--radius-xl);
+  background: linear-gradient(
+    135deg,
+    var(--color-primary),
+    var(--color-accent)
+  );
+  color: var(--color-primary-contrast);
+  box-shadow: var(--shadow-md);
+}
+
+.c-cta-band__headline,
+.c-cta-band__body {
+  margin: 0;
+}
+
+.c-cta-band__headline {
+  font-family: var(--font-family-heading);
+  font-size: var(--font-size-4);
+  line-height: var(--line-height-heading);
+}
+
+.c-cta-band__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-3);
+}
+

--- a/src/components/cta-band/cta-band.render.ts
+++ b/src/components/cta-band/cta-band.render.ts
@@ -1,0 +1,41 @@
+import type { CtaBandData } from "./cta-band.schema.js";
+import { escapeHtml } from "../../renderer/escape-html.js";
+
+export const ctaBandClassNames = [
+  "c-cta-band",
+  "c-cta-band__inner",
+  "c-cta-band__headline",
+  "c-cta-band__body",
+  "c-cta-band__actions",
+] as const;
+
+export const renderCtaBand = (data: CtaBandData): string => {
+  const ctas = [data.primaryCta, data.secondaryCta].filter(
+    (cta): cta is NonNullable<typeof cta> => Boolean(cta),
+  );
+
+  const actionsHtml = ctas
+    .map((cta, index) => {
+      const variant = index === 0 ? "primary" : "secondary";
+
+      return `<a class="c-button c-button--${variant}" href="${escapeHtml(
+        cta.href,
+      )}">${escapeHtml(cta.label)}</a>`;
+    })
+    .join("");
+
+  return [
+    '<section class="c-cta-band">',
+    '  <div class="c-cta-band__inner">',
+    `    <h2 class="c-cta-band__headline">${escapeHtml(data.headline)}</h2>`,
+    data.body
+      ? `    <p class="c-cta-band__body">${escapeHtml(data.body)}</p>`
+      : "",
+    `    <div class="c-cta-band__actions">${actionsHtml}</div>`,
+    "  </div>",
+    "</section>",
+  ]
+    .filter(Boolean)
+    .join("\n");
+};
+

--- a/src/components/cta-band/cta-band.schema.ts
+++ b/src/components/cta-band/cta-band.schema.ts
@@ -1,0 +1,16 @@
+import { z } from "zod";
+
+import { LinkSchema } from "../../schemas/shared.js";
+
+export const CtaBandSchema = z
+  .object({
+    type: z.literal("cta-band"),
+    headline: z.string().min(1).max(120),
+    body: z.string().min(1).max(240).optional(),
+    primaryCta: LinkSchema,
+    secondaryCta: LinkSchema.optional(),
+  })
+  .strict();
+
+export type CtaBandData = z.infer<typeof CtaBandSchema>;
+

--- a/src/components/cta-band/cta-band.test.ts
+++ b/src/components/cta-band/cta-band.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+
+import { renderCtaBand } from "./cta-band.render.js";
+import { CtaBandSchema } from "./cta-band.schema.js";
+
+describe("CtaBandSchema", () => {
+  it("accepts valid content and renders a CTA section", () => {
+    const parsed = CtaBandSchema.parse({
+      type: "cta-band",
+      headline: "Build reviewable static pages",
+      body: "Validation first.",
+      primaryCta: {
+        label: "Read docs",
+        href: "/docs",
+      },
+    });
+
+    const html = renderCtaBand(parsed);
+
+    expect(html).toContain('<section class="c-cta-band">');
+    expect(html).toContain("Read docs");
+  });
+
+  it("rejects unknown fields and missing primaryCta", () => {
+    const extraField = CtaBandSchema.safeParse({
+      type: "cta-band",
+      headline: "Build reviewable static pages",
+      primaryCta: {
+        label: "Read docs",
+        href: "/docs",
+      },
+      tone: "loud",
+    });
+
+    expect(extraField.success).toBe(false);
+    if (extraField.success) {
+      return;
+    }
+
+    expect(extraField.error.issues[0]?.code).toBe("unrecognized_keys");
+
+    const missingPrimary = CtaBandSchema.safeParse({
+      type: "cta-band",
+      headline: "Build reviewable static pages",
+    });
+
+    expect(missingPrimary.success).toBe(false);
+    if (missingPrimary.success) {
+      return;
+    }
+
+    expect(
+      missingPrimary.error.issues.some(
+        (issue) => String(issue.path.join(".")) === "primaryCta",
+      ),
+    ).toBe(true);
+  });
+});
+

--- a/src/components/feature-grid/feature-grid.css
+++ b/src/components/feature-grid/feature-grid.css
@@ -1,0 +1,45 @@
+.c-feature-grid {
+  padding-block: var(--space-7);
+}
+
+.c-feature-grid__inner {
+  width: min(calc(100% - (2 * var(--space-5))), var(--container-max));
+  margin-inline: auto;
+  display: grid;
+  gap: var(--space-5);
+}
+
+.c-feature-grid__title {
+  margin: 0;
+  font-family: var(--font-family-heading);
+  font-size: var(--font-size-4);
+  line-height: var(--line-height-heading);
+}
+
+.c-feature-grid__items {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(14rem, 1fr));
+  gap: var(--space-4);
+  padding: 0;
+  margin: 0;
+  list-style: none;
+}
+
+.c-feature-grid__item {
+  padding: var(--space-5);
+  border: var(--border-width-1) solid var(--color-border);
+  border-radius: var(--radius-lg);
+  background: var(--color-surface);
+  box-shadow: var(--shadow-sm);
+}
+
+.c-feature-grid__item-title {
+  margin: 0 0 var(--space-2);
+  font-size: var(--font-size-3);
+}
+
+.c-feature-grid__item-body {
+  margin: 0;
+  color: var(--color-text-muted);
+}
+

--- a/src/components/feature-grid/feature-grid.render.ts
+++ b/src/components/feature-grid/feature-grid.render.ts
@@ -1,0 +1,37 @@
+import type { FeatureGridData } from "./feature-grid.schema.js";
+import { escapeHtml } from "../../renderer/escape-html.js";
+
+export const featureGridClassNames = [
+  "c-feature-grid",
+  "c-feature-grid__inner",
+  "c-feature-grid__title",
+  "c-feature-grid__items",
+  "c-feature-grid__item",
+  "c-feature-grid__item-title",
+  "c-feature-grid__item-body",
+] as const;
+
+export const renderFeatureGrid = (data: FeatureGridData): string => {
+  const itemsHtml = data.items
+    .map(
+      (item) => [
+        '      <li class="c-feature-grid__item">',
+        `        <h3 class="c-feature-grid__item-title">${escapeHtml(item.title)}</h3>`,
+        `        <p class="c-feature-grid__item-body">${escapeHtml(item.body)}</p>`,
+        "      </li>",
+      ].join("\n"),
+    )
+    .join("\n");
+
+  return [
+    '<section class="c-feature-grid">',
+    '  <div class="c-feature-grid__inner">',
+    `    <h2 class="c-feature-grid__title">${escapeHtml(data.title)}</h2>`,
+    '    <ul class="c-feature-grid__items">',
+    itemsHtml,
+    "    </ul>",
+    "  </div>",
+    "</section>",
+  ].join("\n");
+};
+

--- a/src/components/feature-grid/feature-grid.schema.ts
+++ b/src/components/feature-grid/feature-grid.schema.ts
@@ -1,0 +1,19 @@
+import { z } from "zod";
+
+export const FeatureGridItemSchema = z
+  .object({
+    title: z.string().min(1),
+    body: z.string().min(1),
+  })
+  .strict();
+
+export const FeatureGridSchema = z
+  .object({
+    type: z.literal("feature-grid"),
+    title: z.string().min(1).max(120),
+    items: z.array(FeatureGridItemSchema).min(1).max(6),
+  })
+  .strict();
+
+export type FeatureGridData = z.infer<typeof FeatureGridSchema>;
+

--- a/src/components/feature-grid/feature-grid.test.ts
+++ b/src/components/feature-grid/feature-grid.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+
+import { renderFeatureGrid } from "./feature-grid.render.js";
+import { FeatureGridSchema } from "./feature-grid.schema.js";
+
+describe("FeatureGridSchema", () => {
+  it("accepts valid content and renders list markup", () => {
+    const parsed = FeatureGridSchema.parse({
+      type: "feature-grid",
+      title: "Why it works",
+      items: [
+        {
+          title: "Strict validation",
+          body: "Unknown keys fail.",
+        },
+      ],
+    });
+
+    const html = renderFeatureGrid(parsed);
+
+    expect(html).toContain('<section class="c-feature-grid">');
+    expect(html).toContain('<ul class="c-feature-grid__items">');
+    expect(html).toContain("Strict validation");
+  });
+
+  it("rejects nested unknown fields", () => {
+    const result = FeatureGridSchema.safeParse({
+      type: "feature-grid",
+      title: "Why it works",
+      items: [
+        {
+          title: "Strict validation",
+          body: "Unknown keys fail.",
+          eyebrow: "Bad field",
+        },
+      ],
+    });
+
+    expect(result.success).toBe(false);
+    if (result.success) {
+      return;
+    }
+
+    expect(
+      result.error.issues.some(
+        (issue) =>
+          issue.code === "unrecognized_keys" &&
+          String(issue.path.join(".")) === "items.0",
+      ),
+    ).toBe(true);
+  });
+});
+

--- a/src/components/hero/hero.css
+++ b/src/components/hero/hero.css
@@ -1,0 +1,37 @@
+.c-hero {
+  padding-block: var(--space-8);
+}
+
+.c-hero__body {
+  width: min(calc(100% - (2 * var(--space-5))), var(--content-max));
+  margin-inline: auto;
+  display: grid;
+  gap: var(--space-5);
+}
+
+.c-hero--align-center .c-hero__body {
+  text-align: center;
+}
+
+.c-hero__headline {
+  margin: 0;
+  font-family: var(--font-family-heading);
+  font-size: clamp(var(--font-size-5), 5vw, var(--font-size-6));
+  line-height: var(--line-height-heading);
+  letter-spacing: var(--letter-spacing-tight);
+}
+
+.c-hero__subheadline {
+  margin: 0;
+  color: var(--color-text-muted);
+  font-size: var(--font-size-2);
+  line-height: var(--line-height-loose);
+}
+
+.c-hero__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-3);
+  justify-content: inherit;
+}
+

--- a/src/components/hero/hero.render.ts
+++ b/src/components/hero/hero.render.ts
@@ -1,0 +1,43 @@
+import type { HeroData } from "./hero.schema.js";
+import { escapeHtml } from "../../renderer/escape-html.js";
+
+export const heroClassNames = [
+  "c-hero",
+  "c-hero--align-start",
+  "c-hero--align-center",
+  "c-hero__body",
+  "c-hero__headline",
+  "c-hero__subheadline",
+  "c-hero__actions",
+] as const;
+
+export const renderHero = (data: HeroData): string => {
+  const ctas = [data.primaryCta, data.secondaryCta].filter(
+    (cta): cta is NonNullable<typeof cta> => Boolean(cta),
+  );
+
+  const actionHtml = ctas
+    .map((cta, index) => {
+      const variant = index === 0 ? "primary" : "secondary";
+
+      return `<a class="c-button c-button--${variant}" href="${escapeHtml(
+        cta.href,
+      )}">${escapeHtml(cta.label)}</a>`;
+    })
+    .join("");
+
+  return [
+    `<section class="c-hero c-hero--align-${escapeHtml(data.align)}">`,
+    '  <div class="c-hero__body">',
+    `    <h1 class="c-hero__headline">${escapeHtml(data.headline)}</h1>`,
+    data.subheadline
+      ? `    <p class="c-hero__subheadline">${escapeHtml(data.subheadline)}</p>`
+      : "",
+    `    <div class="c-hero__actions">${actionHtml}</div>`,
+    "  </div>",
+    "</section>",
+  ]
+    .filter(Boolean)
+    .join("\n");
+};
+

--- a/src/components/hero/hero.schema.ts
+++ b/src/components/hero/hero.schema.ts
@@ -1,0 +1,25 @@
+import { z } from "zod";
+
+import { LinkSchema } from "../../schemas/shared.js";
+
+export const HeroSchemaBase = z
+  .object({
+    type: z.literal("hero"),
+    headline: z.string().min(1).max(120),
+    subheadline: z.string().min(1).max(240).optional(),
+    primaryCta: LinkSchema.optional(),
+    secondaryCta: LinkSchema.optional(),
+    align: z.enum(["start", "center"]).default("start"),
+  })
+  .strict();
+
+export const HeroSchema = HeroSchemaBase.superRefine((value, ctx) => {
+    if (!value.primaryCta && !value.secondaryCta) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "At least one CTA is required",
+      });
+    }
+  });
+
+export type HeroData = z.infer<typeof HeroSchema>;

--- a/src/components/hero/hero.test.ts
+++ b/src/components/hero/hero.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+
+import { renderHero } from "./hero.render.js";
+import { HeroSchema } from "./hero.schema.js";
+
+describe("HeroSchema", () => {
+  it("accepts valid hero data and renders escaped semantic markup", () => {
+    const parsed = HeroSchema.parse({
+      type: "hero",
+      headline: "Launch <faster>",
+      subheadline: "Strict validation for teams.",
+      primaryCta: {
+        label: "Get started",
+        href: "/start?x=<tag>",
+      },
+      align: "center",
+    });
+
+    const html = renderHero(parsed);
+
+    expect(html).toContain('<section class="c-hero c-hero--align-center">');
+    expect(html).toContain("&lt;faster&gt;");
+    expect(html).toContain('/start?x=&lt;tag&gt;');
+    expect(html).not.toContain("<faster>");
+  });
+
+  it("rejects unknown fields and missing CTAs", () => {
+    const extraField = HeroSchema.safeParse({
+      type: "hero",
+      headline: "Launch faster",
+      buttonText2: "Bad field",
+      primaryCta: {
+        label: "Start",
+        href: "/start",
+      },
+    });
+
+    expect(extraField.success).toBe(false);
+    if (extraField.success) {
+      return;
+    }
+
+    expect(extraField.error.issues[0]?.code).toBe("unrecognized_keys");
+
+    const noCta = HeroSchema.safeParse({
+      type: "hero",
+      headline: "Launch faster",
+    });
+
+    expect(noCta.success).toBe(false);
+    if (noCta.success) {
+      return;
+    }
+
+    expect(noCta.error.issues.some((issue) => issue.message.includes("CTA"))).toBe(
+      true,
+    );
+  });
+});
+

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,0 +1,90 @@
+import { fileURLToPath } from "node:url";
+import { z } from "zod";
+
+import { CtaBandSchema } from "./cta-band/cta-band.schema.js";
+import { ctaBandClassNames, renderCtaBand } from "./cta-band/cta-band.render.js";
+import {
+  FeatureGridSchema,
+} from "./feature-grid/feature-grid.schema.js";
+import {
+  featureGridClassNames,
+  renderFeatureGrid,
+} from "./feature-grid/feature-grid.render.js";
+import { HeroSchema, HeroSchemaBase } from "./hero/hero.schema.js";
+import { heroClassNames, renderHero } from "./hero/hero.render.js";
+
+export const ComponentSchemaBase = z.discriminatedUnion("type", [
+  HeroSchemaBase,
+  FeatureGridSchema,
+  CtaBandSchema,
+]);
+
+export const ComponentSchema = ComponentSchemaBase.superRefine((value, ctx) => {
+  if (value.type !== "hero") {
+    return;
+  }
+
+  const parsedHero = HeroSchema.safeParse(value);
+  if (parsedHero.success) {
+    return;
+  }
+
+  for (const issue of parsedHero.error.issues) {
+    ctx.addIssue(issue);
+  }
+});
+
+export type ComponentData = z.infer<typeof ComponentSchemaBase>;
+export type ComponentType = ComponentData["type"];
+
+export interface ComponentDefinition {
+  type: ComponentType;
+  render: (data: ComponentData) => string;
+  cssPath: string;
+  classNames: readonly string[];
+}
+
+export const sharedClassNames = [
+  "c-button",
+  "c-button--primary",
+  "c-button--secondary",
+] as const;
+
+export const componentDefinitions: readonly ComponentDefinition[] = [
+  {
+    type: "hero",
+    render: (data) => renderHero(HeroSchema.parse(data)),
+    cssPath: fileURLToPath(new URL("./hero/hero.css", import.meta.url)),
+    classNames: heroClassNames,
+  },
+  {
+    type: "feature-grid",
+    render: (data) => renderFeatureGrid(FeatureGridSchema.parse(data)),
+    cssPath: fileURLToPath(new URL("./feature-grid/feature-grid.css", import.meta.url)),
+    classNames: featureGridClassNames,
+  },
+  {
+    type: "cta-band",
+    render: (data) => renderCtaBand(CtaBandSchema.parse(data)),
+    cssPath: fileURLToPath(new URL("./cta-band/cta-band.css", import.meta.url)),
+    classNames: ctaBandClassNames,
+  },
+];
+
+export const componentTypeNames = componentDefinitions.map(
+  (componentDefinition) => componentDefinition.type,
+);
+
+export const renderComponent = (data: ComponentData): string => {
+  switch (data.type) {
+    case "hero":
+      return renderHero(data);
+    case "feature-grid":
+      return renderFeatureGrid(data);
+    case "cta-band":
+      return renderCtaBand(data);
+    default: {
+      throw new Error(`No renderer exists for component '${JSON.stringify(data)}'`);
+    }
+  }
+};

--- a/src/renderer/escape-html.ts
+++ b/src/renderer/escape-html.ts
@@ -1,0 +1,8 @@
+export const escapeHtml = (value: string): string =>
+  value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;");
+

--- a/src/renderer/render-page.ts
+++ b/src/renderer/render-page.ts
@@ -1,0 +1,46 @@
+import type { PageData, SiteData } from "../schemas/site.schema.js";
+import { escapeHtml } from "./escape-html.js";
+
+export const renderPageDocument = ({
+  site,
+  page,
+  bodyHtml,
+  stylesheetHref,
+}: {
+  site: SiteData;
+  page: PageData;
+  bodyHtml: string;
+  stylesheetHref: string;
+}): string => {
+  const title =
+    page.slug === "/" ? escapeHtml(site.name) : `${escapeHtml(page.title)} | ${escapeHtml(site.name)}`;
+  const description = page.metadata?.description
+    ? `<meta name="description" content="${escapeHtml(page.metadata.description)}" />`
+    : "";
+  const canonicalUrl = page.metadata?.canonicalUrl ?? new URL(page.slug, site.baseUrl).toString();
+
+  return [
+    "<!doctype html>",
+    `<html lang="en">`,
+    "  <head>",
+    '    <meta charset="utf-8" />',
+    '    <meta name="viewport" content="width=device-width, initial-scale=1" />',
+    `    <title>${title}</title>`,
+    description,
+    `    <link rel="canonical" href="${escapeHtml(canonicalUrl)}" />`,
+    `    <link rel="stylesheet" href="${escapeHtml(stylesheetHref)}" />`,
+    "  </head>",
+    `  <body data-theme="${escapeHtml(site.theme)}">`,
+    '    <main class="l-page">',
+    bodyHtml
+      .split("\n")
+      .map((line) => `      ${line}`)
+      .join("\n"),
+    "    </main>",
+    "  </body>",
+    "</html>",
+  ]
+    .filter(Boolean)
+    .join("\n");
+};
+

--- a/src/schemas/shared.ts
+++ b/src/schemas/shared.ts
@@ -1,0 +1,11 @@
+import { z } from "zod";
+
+export const LinkSchema = z
+  .object({
+    label: z.string().min(1),
+    href: z.string().min(1),
+  })
+  .strict();
+
+export type LinkData = z.infer<typeof LinkSchema>;
+

--- a/src/schemas/site.schema.ts
+++ b/src/schemas/site.schema.ts
@@ -1,0 +1,40 @@
+import { z } from "zod";
+
+import { ComponentSchema } from "../components/index.js";
+import { themeNames } from "../themes/index.js";
+
+export const PageMetadataSchema = z
+  .object({
+    description: z.string().min(1).max(200).optional(),
+    canonicalUrl: z.string().url().optional(),
+  })
+  .strict();
+
+export const PageSchema = z
+  .object({
+    slug: z.string().min(1).regex(/^\/(?:[a-z0-9-]+(?:\/[a-z0-9-]+)*)?$/i),
+    title: z.string().min(1).max(80),
+    metadata: PageMetadataSchema.optional(),
+    components: z.array(ComponentSchema).min(1),
+  })
+  .strict();
+
+export const SiteSchema = z
+  .object({
+    name: z.string().min(1).max(80),
+    baseUrl: z.string().url(),
+    theme: z.enum(themeNames),
+  })
+  .strict();
+
+export const SiteContentSchema = z
+  .object({
+    site: SiteSchema,
+    pages: z.array(PageSchema).min(1),
+  })
+  .strict();
+
+export type PageData = z.infer<typeof PageSchema>;
+export type SiteData = z.infer<typeof SiteSchema>;
+export type SiteContentData = z.infer<typeof SiteContentSchema>;
+

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -1,0 +1,75 @@
+:root {
+  color-scheme: light;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+html {
+  font-family: var(--font-family-body);
+  line-height: var(--line-height-body);
+  background: var(--color-bg);
+  color: var(--color-text);
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: var(--color-bg);
+  color: var(--color-text);
+}
+
+a {
+  color: var(--color-link);
+}
+
+a:hover {
+  color: var(--color-link-hover);
+}
+
+a:focus-visible,
+button:focus-visible {
+  outline: var(--border-width-2) solid var(--color-focus-ring);
+  outline-offset: 2px;
+}
+
+.l-page {
+  display: grid;
+  gap: 0;
+}
+
+.c-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: var(--button-height);
+  padding-inline: var(--space-4);
+  border: var(--border-width-1) solid transparent;
+  border-radius: var(--radius-md);
+  font-weight: var(--font-weight-semibold);
+  text-decoration: none;
+  transition:
+    background-color var(--duration-normal) var(--ease-standard),
+    border-color var(--duration-normal) var(--ease-standard),
+    color var(--duration-normal) var(--ease-standard),
+    transform var(--duration-fast) var(--ease-standard);
+}
+
+.c-button:hover {
+  transform: translateY(-1px);
+}
+
+.c-button--primary {
+  background: var(--color-primary);
+  color: var(--color-primary-contrast);
+}
+
+.c-button--secondary {
+  border-color: currentColor;
+  background: transparent;
+  color: inherit;
+}
+

--- a/src/themes/app-announcement.ts
+++ b/src/themes/app-announcement.ts
@@ -1,0 +1,26 @@
+import { createThemeDefinition } from "./tokens.js";
+
+export const appAnnouncementTheme = createThemeDefinition({
+  "--color-bg": "#fff9f1",
+  "--color-surface": "#ffffff",
+  "--color-surface-alt": "#fff1df",
+  "--color-text": "#231815",
+  "--color-text-muted": "#64544c",
+  "--color-border": "#efcfb0",
+  "--color-primary": "#ff6b2c",
+  "--color-primary-contrast": "#fff8f1",
+  "--color-accent": "#1b998b",
+  "--color-link": "#c64a12",
+  "--color-link-hover": "#9b3709",
+  "--color-focus-ring": "#ff6b2c",
+  "--font-family-body": "\"Plus Jakarta Sans\", Arial, sans-serif",
+  "--font-family-heading": "\"Sora\", Arial, sans-serif",
+  "--font-size-5": "2.5rem",
+  "--font-size-6": "3.5rem",
+  "--radius-lg": "1rem",
+  "--radius-xl": "1.5rem",
+  "--shadow-sm": "0 3px 8px rgb(60 33 16 / 0.08)",
+  "--shadow-md": "0 12px 28px rgb(60 33 16 / 0.14)",
+  "--shadow-lg": "0 20px 48px rgb(60 33 16 / 0.18)",
+});
+

--- a/src/themes/brutalism.ts
+++ b/src/themes/brutalism.ts
@@ -1,0 +1,28 @@
+import { createThemeDefinition } from "./tokens.js";
+
+export const brutalismTheme = createThemeDefinition({
+  "--color-bg": "#fff7e8",
+  "--color-surface": "#ffffff",
+  "--color-surface-alt": "#ffe0a8",
+  "--color-text": "#0b0b0b",
+  "--color-text-muted": "#2d2d2d",
+  "--color-border": "#0b0b0b",
+  "--color-primary": "#ff4d00",
+  "--color-primary-contrast": "#111111",
+  "--color-accent": "#ffd400",
+  "--color-link": "#111111",
+  "--color-link-hover": "#ff4d00",
+  "--color-focus-ring": "#ff4d00",
+  "--font-family-body": "\"IBM Plex Sans\", Arial, sans-serif",
+  "--font-family-heading": "\"Space Grotesk\", Arial, sans-serif",
+  "--radius-sm": "0",
+  "--radius-md": "0",
+  "--radius-lg": "0",
+  "--radius-xl": "0",
+  "--border-width-2": "3px",
+  "--border-width-3": "4px",
+  "--shadow-sm": "4px 4px 0 rgb(0 0 0 / 1)",
+  "--shadow-md": "8px 8px 0 rgb(0 0 0 / 1)",
+  "--shadow-lg": "12px 12px 0 rgb(0 0 0 / 1)",
+});
+

--- a/src/themes/corporate.ts
+++ b/src/themes/corporate.ts
@@ -1,0 +1,24 @@
+import { createThemeDefinition } from "./tokens.js";
+
+export const corporateTheme = createThemeDefinition({
+  "--color-bg": "#f7f8fb",
+  "--color-surface": "#ffffff",
+  "--color-surface-alt": "#eef2f7",
+  "--color-text": "#132033",
+  "--color-text-muted": "#516074",
+  "--color-border": "#c8d2df",
+  "--color-primary": "#004e8f",
+  "--color-primary-contrast": "#ffffff",
+  "--color-accent": "#4f7cac",
+  "--color-link": "#004e8f",
+  "--color-link-hover": "#003765",
+  "--color-focus-ring": "#2f80ed",
+  "--font-family-body": "\"Source Sans 3\", Arial, sans-serif",
+  "--font-family-heading": "\"Merriweather Sans\", Arial, sans-serif",
+  "--radius-lg": "0.5rem",
+  "--radius-xl": "0.75rem",
+  "--shadow-sm": "0 1px 2px rgb(16 24 40 / 0.05)",
+  "--shadow-md": "0 6px 18px rgb(16 24 40 / 0.1)",
+  "--shadow-lg": "0 16px 40px rgb(16 24 40 / 0.12)",
+});
+

--- a/src/themes/dark-saas.ts
+++ b/src/themes/dark-saas.ts
@@ -1,0 +1,23 @@
+import { createThemeDefinition } from "./tokens.js";
+
+export const darkSaasTheme = createThemeDefinition({
+  "--color-bg": "#0d1117",
+  "--color-surface": "#161b22",
+  "--color-surface-alt": "#1f2630",
+  "--color-text": "#e6edf3",
+  "--color-text-muted": "#9da7b3",
+  "--color-border": "#2f3945",
+  "--color-primary": "#4da3ff",
+  "--color-primary-contrast": "#081018",
+  "--color-accent": "#8b7dff",
+  "--color-link": "#6cb6ff",
+  "--color-link-hover": "#9cccff",
+  "--color-success": "#2da44e",
+  "--color-warning": "#bf8700",
+  "--color-danger": "#f85149",
+  "--color-focus-ring": "#6cb6ff",
+  "--shadow-sm": "0 1px 2px rgb(0 0 0 / 0.25)",
+  "--shadow-md": "0 6px 18px rgb(0 0 0 / 0.35)",
+  "--shadow-lg": "0 12px 32px rgb(0 0 0 / 0.45)",
+});
+

--- a/src/themes/emit-theme-css.ts
+++ b/src/themes/emit-theme-css.ts
@@ -1,0 +1,10 @@
+import type { ThemeDefinition } from "./tokens.js";
+
+export const emitThemeCss = (theme: ThemeDefinition): string => {
+  const declarations = Object.entries(theme)
+    .map(([tokenName, tokenValue]) => `  ${tokenName}: ${tokenValue};`)
+    .join("\n");
+
+  return `:root {\n${declarations}\n}\n`;
+};
+

--- a/src/themes/index.ts
+++ b/src/themes/index.ts
@@ -1,0 +1,22 @@
+import type { ThemeDefinition } from "./tokens.js";
+import { appAnnouncementTheme } from "./app-announcement.js";
+import { brutalismTheme } from "./brutalism.js";
+import { corporateTheme } from "./corporate.js";
+import { darkSaasTheme } from "./dark-saas.js";
+
+export const themeNames = [
+  "brutalism",
+  "dark-saas",
+  "corporate",
+  "app-announcement",
+] as const;
+
+export type ThemeName = (typeof themeNames)[number];
+
+export const themes: Record<ThemeName, ThemeDefinition> = {
+  brutalism: brutalismTheme,
+  "dark-saas": darkSaasTheme,
+  corporate: corporateTheme,
+  "app-announcement": appAnnouncementTheme,
+};
+

--- a/src/themes/theme-validation.test.ts
+++ b/src/themes/theme-validation.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+
+import { themes } from "./index.js";
+import { assertExactThemeTokens } from "./tokens.js";
+import { findUnknownCssVarTokens, validateThemeDefinition } from "../validation/theme-validation.js";
+
+describe("theme validation", () => {
+  it("accepts the registered themes", () => {
+    for (const [themeName, theme] of Object.entries(themes)) {
+      expect(validateThemeDefinition(themeName, theme)).toEqual([]);
+      expect(() => assertExactThemeTokens(theme)).not.toThrow();
+    }
+  });
+
+  it("rejects extra theme tokens and unknown CSS variable usage", () => {
+    expect(() =>
+      assertExactThemeTokens({
+        ...themes["dark-saas"],
+        "--hero-glow-color": "#fff",
+      }),
+    ).toThrow(/Extra theme tokens/);
+
+    expect(findUnknownCssVarTokens(".demo { color: var(--not-a-token); }")).toEqual([
+      "--not-a-token",
+    ]);
+  });
+});
+

--- a/src/themes/tokens.ts
+++ b/src/themes/tokens.ts
@@ -1,0 +1,124 @@
+const canonicalThemeTokens = {
+  "--color-bg": "#ffffff",
+  "--color-surface": "#f8f8f8",
+  "--color-surface-alt": "#efefef",
+  "--color-text": "#111111",
+  "--color-text-muted": "#555555",
+  "--color-border": "#d0d0d0",
+  "--color-primary": "#0057ff",
+  "--color-primary-contrast": "#ffffff",
+  "--color-accent": "#7a3cff",
+  "--color-link": "#0057ff",
+  "--color-link-hover": "#0041c4",
+  "--color-success": "#127a38",
+  "--color-warning": "#a15c00",
+  "--color-danger": "#b42318",
+  "--color-focus-ring": "#1f6fff",
+  "--font-family-body": "Inter, Arial, sans-serif",
+  "--font-family-heading": "Inter, Arial, sans-serif",
+  "--font-family-mono": "\"SFMono-Regular\", Consolas, monospace",
+  "--font-size-0": "0.875rem",
+  "--font-size-1": "1rem",
+  "--font-size-2": "1.125rem",
+  "--font-size-3": "1.375rem",
+  "--font-size-4": "1.75rem",
+  "--font-size-5": "2.25rem",
+  "--font-size-6": "3rem",
+  "--line-height-tight": "1.1",
+  "--line-height-heading": "1.2",
+  "--line-height-body": "1.5",
+  "--line-height-loose": "1.7",
+  "--font-weight-regular": "400",
+  "--font-weight-medium": "500",
+  "--font-weight-semibold": "600",
+  "--font-weight-bold": "700",
+  "--letter-spacing-tight": "-0.02em",
+  "--letter-spacing-normal": "0",
+  "--letter-spacing-wide": "0.04em",
+  "--space-0": "0",
+  "--space-1": "0.25rem",
+  "--space-2": "0.5rem",
+  "--space-3": "0.75rem",
+  "--space-4": "1rem",
+  "--space-5": "1.5rem",
+  "--space-6": "2rem",
+  "--space-7": "3rem",
+  "--space-8": "4rem",
+  "--container-max": "72rem",
+  "--content-max": "48rem",
+  "--nav-height": "4rem",
+  "--button-height": "2.75rem",
+  "--input-height": "2.75rem",
+  "--icon-size-sm": "1rem",
+  "--icon-size-md": "1.25rem",
+  "--icon-size-lg": "1.5rem",
+  "--radius-none": "0",
+  "--radius-sm": "0.25rem",
+  "--radius-md": "0.5rem",
+  "--radius-lg": "0.75rem",
+  "--radius-xl": "1rem",
+  "--border-width-1": "1px",
+  "--border-width-2": "2px",
+  "--border-width-3": "3px",
+  "--shadow-none": "none",
+  "--shadow-sm": "0 1px 2px rgb(0 0 0 / 0.08)",
+  "--shadow-md": "0 6px 18px rgb(0 0 0 / 0.12)",
+  "--shadow-lg": "0 12px 32px rgb(0 0 0 / 0.18)",
+  "--duration-fast": "120ms",
+  "--duration-normal": "180ms",
+  "--duration-slow": "260ms",
+  "--ease-standard": "ease",
+  "--ease-emphasized": "cubic-bezier(0.2, 0, 0, 1)",
+  "--z-base": "1",
+  "--z-header": "10",
+  "--z-overlay": "100",
+  "--z-modal": "1000",
+} as const;
+
+export type ThemeTokenName = keyof typeof canonicalThemeTokens;
+export type ThemeDefinition = Record<ThemeTokenName, string>;
+
+export const themeTokenNames = Object.keys(canonicalThemeTokens) as ThemeTokenName[];
+export const themeTokenSet = new Set<ThemeTokenName>(themeTokenNames);
+
+export const allowedThemeOverrideTokens = [
+  "--color-primary",
+  "--color-primary-contrast",
+  "--color-accent",
+  "--color-link",
+  "--color-link-hover",
+  "--color-focus-ring",
+] as const satisfies readonly ThemeTokenName[];
+
+export const defaultThemeTokens: ThemeDefinition = { ...canonicalThemeTokens };
+
+export const assertExactThemeTokens: (
+  theme: Record<string, string>,
+) => asserts theme is ThemeDefinition = (theme) => {
+  const keys = Object.keys(theme);
+  const missing = themeTokenNames.filter((name) => !(name in theme));
+  const extra = keys.filter((key) => !themeTokenSet.has(key as ThemeTokenName));
+
+  if (missing.length > 0 || extra.length > 0) {
+    throw new Error(
+      [
+        missing.length > 0 ? `Missing theme tokens: ${missing.join(", ")}` : "",
+        extra.length > 0 ? `Extra theme tokens: ${extra.join(", ")}` : "",
+      ]
+        .filter(Boolean)
+        .join("\n"),
+    );
+  }
+};
+
+export const createThemeDefinition = (
+  overrides: Partial<ThemeDefinition>,
+): ThemeDefinition => {
+  const theme: ThemeDefinition = {
+    ...defaultThemeTokens,
+    ...overrides,
+  };
+
+  assertExactThemeTokens(theme);
+  return theme;
+};

--- a/src/validation/component-registry-validation.ts
+++ b/src/validation/component-registry-validation.ts
@@ -1,0 +1,41 @@
+import { existsSync } from "node:fs";
+
+import type { ComponentDefinition, ComponentType } from "../components/index.js";
+import type { ValidationIssue } from "./site-validation.js";
+
+export const validateComponentRegistry = (
+  componentDefinitions: readonly ComponentDefinition[],
+): ValidationIssue[] => {
+  const issues: ValidationIssue[] = [];
+  const seenTypes = new Set<ComponentType>();
+
+  componentDefinitions.forEach((componentDefinition) => {
+    if (seenTypes.has(componentDefinition.type)) {
+      issues.push({
+        path: [],
+        source: "component-registry",
+        message: `duplicate component type '${componentDefinition.type}'`,
+      });
+    } else {
+      seenTypes.add(componentDefinition.type);
+    }
+
+    if (!componentDefinition.classNames.length) {
+      issues.push({
+        path: [],
+        source: "component-registry",
+        message: `component '${componentDefinition.type}' has no declared class contract`,
+      });
+    }
+
+    if (!existsSync(componentDefinition.cssPath)) {
+      issues.push({
+        path: [],
+        source: "component-registry",
+        message: `component '${componentDefinition.type}' is missing CSS at ${componentDefinition.cssPath}`,
+      });
+    }
+  });
+
+  return issues;
+};

--- a/src/validation/site-validation.ts
+++ b/src/validation/site-validation.ts
@@ -1,0 +1,47 @@
+import type { SiteContentData } from "../schemas/site.schema.js";
+
+export interface ValidationIssue {
+  path: Array<string | number>;
+  message: string;
+  componentType?: string;
+  source?: string;
+}
+
+export const collectSiteValidationIssues = (
+  siteContent: SiteContentData,
+): ValidationIssue[] => {
+  const issues: ValidationIssue[] = [];
+  const slugIndexMap = new Map<string, number>();
+
+  siteContent.pages.forEach((page, pageIndex) => {
+    const existingPageIndex = slugIndexMap.get(page.slug);
+
+    if (typeof existingPageIndex === "number") {
+      issues.push({
+        path: ["pages", pageIndex, "slug"],
+        message: `duplicate slug '${page.slug}' also used by pages[${existingPageIndex}]`,
+      });
+    } else {
+      slugIndexMap.set(page.slug, pageIndex);
+    }
+
+    let heroCount = 0;
+    page.components.forEach((component, componentIndex) => {
+      if (component.type !== "hero") {
+        return;
+      }
+
+      heroCount += 1;
+      if (heroCount > 1) {
+        issues.push({
+          path: ["pages", pageIndex, "components", componentIndex],
+          componentType: "hero",
+          message: "only one hero is allowed per page",
+        });
+      }
+    });
+  });
+
+  return issues;
+};
+

--- a/src/validation/theme-validation.ts
+++ b/src/validation/theme-validation.ts
@@ -1,0 +1,60 @@
+import { readFile } from "node:fs/promises";
+
+import type { ThemeDefinition, ThemeTokenName } from "../themes/tokens.js";
+import { assertExactThemeTokens, themeTokenSet } from "../themes/tokens.js";
+import type { ValidationIssue } from "./site-validation.js";
+
+const CSS_VAR_PATTERN = /var\((--[a-z0-9-]+)/gi;
+
+export const findUnknownCssVarTokens = (css: string): string[] => {
+  const foundTokens = new Set<string>();
+
+  for (const match of css.matchAll(CSS_VAR_PATTERN)) {
+    foundTokens.add(match[1]);
+  }
+
+  return [...foundTokens].filter(
+    (tokenName) => !themeTokenSet.has(tokenName as ThemeTokenName),
+  );
+};
+
+export const validateThemeDefinition = (
+  themeName: string,
+  theme: ThemeDefinition,
+): ValidationIssue[] => {
+  try {
+    assertExactThemeTokens(theme);
+    return [];
+  } catch (error) {
+    return [
+      {
+        path: [],
+        source: `theme:${themeName}`,
+        message: error instanceof Error ? error.message : String(error),
+      },
+    ];
+  }
+};
+
+export const validateCssTokenUsage = async (
+  cssPaths: readonly string[],
+): Promise<ValidationIssue[]> => {
+  const issues: ValidationIssue[] = [];
+
+  for (const cssPath of cssPaths) {
+    const css = await readFile(cssPath, "utf8");
+    const unknownTokens = findUnknownCssVarTokens(css);
+
+    if (unknownTokens.length === 0) {
+      continue;
+    }
+
+    issues.push({
+      path: [],
+      source: cssPath,
+      message: `unknown theme token reference(s): ${unknownTokens.join(", ")}`,
+    });
+  }
+
+  return issues;
+};

--- a/tests/site-validation.test.ts
+++ b/tests/site-validation.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+
+import { SiteContentSchema } from "../src/schemas/site.schema.js";
+import { collectSiteValidationIssues } from "../src/validation/site-validation.js";
+
+const validSite = SiteContentSchema.parse({
+  site: {
+    name: "LaunchKit",
+    baseUrl: "https://launchkit.example",
+    theme: "app-announcement",
+  },
+  pages: [
+    {
+      slug: "/",
+      title: "Home",
+      components: [
+        {
+          type: "hero",
+          headline: "Launch faster",
+          primaryCta: {
+            label: "Get started",
+            href: "/start",
+          },
+        },
+      ],
+    },
+  ],
+});
+
+describe("collectSiteValidationIssues", () => {
+  it("passes a valid site", () => {
+    expect(collectSiteValidationIssues(validSite)).toEqual([]);
+  });
+
+  it("rejects duplicate slugs and more than one hero per page", () => {
+    const invalidSite = SiteContentSchema.parse({
+      ...validSite,
+      pages: [
+        {
+          ...validSite.pages[0],
+          components: [
+            validSite.pages[0].components[0],
+            {
+              type: "hero",
+              headline: "Another hero",
+              primaryCta: {
+                label: "Read more",
+                href: "/more",
+              },
+            },
+          ],
+        },
+        {
+          ...validSite.pages[0],
+        },
+      ],
+    });
+
+    const issues = collectSiteValidationIssues(invalidSite);
+
+    expect(issues).toHaveLength(2);
+    expect(issues.some((issue) => issue.message.includes("duplicate slug"))).toBe(true);
+    expect(issues.some((issue) => issue.message.includes("only one hero"))).toBe(true);
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022"],
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "verbatimModuleSyntax": true,
+    "types": ["node", "vitest/globals"]
+  },
+  "include": ["src/**/*.ts", "tests/**/*.ts", "vitest.config.ts"]
+}
+

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["src/**/*.test.ts", "tests/**/*.test.ts"],
+  },
+});
+


### PR DESCRIPTION
## Summary
- bootstrap a TypeScript + Zod + Vitest static site generator slice from the issue PRD
- add a strict validation entrypoint with schema checks, cross-page rules, exact theme token enforcement, and CSS token scanning
- implement the first three content components from the example page (`hero`, `feature-grid`, `cta-band`) plus demo content and HTML/CSS emission

## Validation
- npm run check

Closes #1