### PR TITLE
Add feature-list and faq components

### DIFF
--- a/content/site.json
+++ b/content/site.json
@@ -27,6 +27,24 @@
           "align": "start"
         },
         {
+          "type": "feature-list",
+          "title": "Keep the content contract tight",
+          "items": [
+            {
+              "title": "Model every block explicitly",
+              "body": "Content picks a known component instead of inventing markup."
+            },
+            {
+              "title": "Reject extra fields",
+              "body": "Unexpected keys fail before they can drift into production."
+            },
+            {
+              "title": "Review small diffs",
+              "body": "Stable HTML keeps generated output easy to inspect."
+            }
+          ]
+        },
+        {
           "type": "feature-grid",
           "title": "Why this approach works",
           "items": [
@@ -70,6 +88,20 @@
           "align": "center"
         },
         {
+          "type": "faq",
+          "title": "Questions teams ask before switching",
+          "items": [
+            {
+              "question": "Can this framework accept arbitrary HTML from JSON?",
+              "answer": "No. Components own the markup so validation stays strict and predictable."
+            },
+            {
+              "question": "Do themes change the structure of a page?",
+              "answer": "No. Themes only change tokens like color, spacing, and typography."
+            }
+          ]
+        },
+        {
           "type": "cta-band",
           "headline": "Need a stricter content pipeline?",
           "primaryCta": {
@@ -81,4 +113,3 @@
     }
   ]
 }
-

--- a/src/components/faq/faq.css
+++ b/src/components/faq/faq.css
@@ -1,0 +1,39 @@
+.c-faq {
+  padding-block: var(--space-7);
+}
+
+.c-faq__inner {
+  width: min(calc(100% - (2 * var(--space-5))), var(--content-max));
+  margin-inline: auto;
+  display: grid;
+  gap: var(--space-5);
+}
+
+.c-faq__title {
+  margin: 0;
+  font-family: var(--font-family-heading);
+  font-size: var(--font-size-4);
+  line-height: var(--line-height-heading);
+}
+
+.c-faq__items {
+  display: grid;
+  gap: var(--space-3);
+}
+
+.c-faq__item {
+  padding: var(--space-4) var(--space-5);
+  border: var(--border-width-1) solid var(--color-border);
+  border-radius: var(--radius-lg);
+  background: var(--color-surface);
+}
+
+.c-faq__question {
+  font-weight: var(--font-weight-semibold);
+  cursor: pointer;
+}
+
+.c-faq__answer {
+  margin: var(--space-3) 0 0;
+  color: var(--color-text-muted);
+}

--- a/src/components/faq/faq.render.ts
+++ b/src/components/faq/faq.render.ts
@@ -1,0 +1,36 @@
+import type { FaqData } from "./faq.schema.js";
+import { escapeHtml } from "../../renderer/escape-html.js";
+
+export const faqClassNames = [
+  "c-faq",
+  "c-faq__inner",
+  "c-faq__title",
+  "c-faq__items",
+  "c-faq__item",
+  "c-faq__question",
+  "c-faq__answer",
+] as const;
+
+export const renderFaq = (data: FaqData): string => {
+  const itemsHtml = data.items
+    .map(
+      (item) => [
+        '      <details class="c-faq__item">',
+        `        <summary class="c-faq__question">${escapeHtml(item.question)}</summary>`,
+        `        <p class="c-faq__answer">${escapeHtml(item.answer)}</p>`,
+        "      </details>",
+      ].join("\n"),
+    )
+    .join("\n");
+
+  return [
+    '<section class="c-faq">',
+    '  <div class="c-faq__inner">',
+    `    <h2 class="c-faq__title">${escapeHtml(data.title)}</h2>`,
+    '    <div class="c-faq__items">',
+    itemsHtml,
+    "    </div>",
+    "  </div>",
+    "</section>",
+  ].join("\n");
+};

--- a/src/components/faq/faq.schema.ts
+++ b/src/components/faq/faq.schema.ts
@@ -1,0 +1,18 @@
+import { z } from "zod";
+
+export const FaqItemSchema = z
+  .object({
+    question: z.string().min(1).max(140),
+    answer: z.string().min(1).max(320),
+  })
+  .strict();
+
+export const FaqSchema = z
+  .object({
+    type: z.literal("faq"),
+    title: z.string().min(1).max(120),
+    items: z.array(FaqItemSchema).min(1).max(8),
+  })
+  .strict();
+
+export type FaqData = z.infer<typeof FaqSchema>;

--- a/src/components/faq/faq.test.ts
+++ b/src/components/faq/faq.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+
+import { renderFaq } from "./faq.render.js";
+import { FaqSchema } from "./faq.schema.js";
+
+describe("FaqSchema", () => {
+  it("accepts valid content and renders disclosure markup", () => {
+    const parsed = FaqSchema.parse({
+      type: "faq",
+      title: "Common questions",
+      items: [
+        {
+          question: "Can content authors add arbitrary classes?",
+          answer: "No. Class names only come from framework code.",
+        },
+      ],
+    });
+
+    const html = renderFaq(parsed);
+
+    expect(html).toContain('<section class="c-faq">');
+    expect(html).toContain('<details class="c-faq__item">');
+    expect(html).toContain("Class names only come from framework code.");
+  });
+
+  it("rejects empty items and unknown nested fields", () => {
+    const emptyItems = FaqSchema.safeParse({
+      type: "faq",
+      title: "Common questions",
+      items: [],
+    });
+
+    expect(emptyItems.success).toBe(false);
+    if (emptyItems.success) {
+      return;
+    }
+
+    expect(
+      emptyItems.error.issues.some((issue) => String(issue.path.join(".")) === "items"),
+    ).toBe(true);
+
+    const extraField = FaqSchema.safeParse({
+      type: "faq",
+      title: "Common questions",
+      items: [
+        {
+          question: "Can content authors add arbitrary classes?",
+          answer: "No. Class names only come from framework code.",
+          openByDefault: true,
+        },
+      ],
+    });
+
+    expect(extraField.success).toBe(false);
+    if (extraField.success) {
+      return;
+    }
+
+    expect(
+      extraField.error.issues.some(
+        (issue) =>
+          issue.code === "unrecognized_keys" &&
+          String(issue.path.join(".")) === "items.0",
+      ),
+    ).toBe(true);
+  });
+});

--- a/src/components/feature-list/feature-list.css
+++ b/src/components/feature-list/feature-list.css
@@ -1,0 +1,43 @@
+.c-feature-list {
+  padding-block: var(--space-7);
+}
+
+.c-feature-list__inner {
+  width: min(calc(100% - (2 * var(--space-5))), var(--content-max));
+  margin-inline: auto;
+  display: grid;
+  gap: var(--space-5);
+}
+
+.c-feature-list__title {
+  margin: 0;
+  font-family: var(--font-family-heading);
+  font-size: var(--font-size-4);
+  line-height: var(--line-height-heading);
+}
+
+.c-feature-list__items {
+  display: grid;
+  gap: var(--space-4);
+  margin: 0;
+  padding: 0 0 0 var(--space-5);
+}
+
+.c-feature-list__item {
+  display: grid;
+  gap: var(--space-2);
+  padding: var(--space-4);
+  border: var(--border-width-1) solid var(--color-border);
+  border-radius: var(--radius-lg);
+  background: var(--color-surface);
+}
+
+.c-feature-list__item-title {
+  margin: 0;
+  font-size: var(--font-size-2);
+}
+
+.c-feature-list__item-body {
+  margin: 0;
+  color: var(--color-text-muted);
+}

--- a/src/components/feature-list/feature-list.render.ts
+++ b/src/components/feature-list/feature-list.render.ts
@@ -1,0 +1,36 @@
+import type { FeatureListData } from "./feature-list.schema.js";
+import { escapeHtml } from "../../renderer/escape-html.js";
+
+export const featureListClassNames = [
+  "c-feature-list",
+  "c-feature-list__inner",
+  "c-feature-list__title",
+  "c-feature-list__items",
+  "c-feature-list__item",
+  "c-feature-list__item-title",
+  "c-feature-list__item-body",
+] as const;
+
+export const renderFeatureList = (data: FeatureListData): string => {
+  const itemsHtml = data.items
+    .map(
+      (item) => [
+        '      <li class="c-feature-list__item">',
+        `        <h3 class="c-feature-list__item-title">${escapeHtml(item.title)}</h3>`,
+        `        <p class="c-feature-list__item-body">${escapeHtml(item.body)}</p>`,
+        "      </li>",
+      ].join("\n"),
+    )
+    .join("\n");
+
+  return [
+    '<section class="c-feature-list">',
+    '  <div class="c-feature-list__inner">',
+    `    <h2 class="c-feature-list__title">${escapeHtml(data.title)}</h2>`,
+    '    <ol class="c-feature-list__items">',
+    itemsHtml,
+    "    </ol>",
+    "  </div>",
+    "</section>",
+  ].join("\n");
+};

--- a/src/components/feature-list/feature-list.schema.ts
+++ b/src/components/feature-list/feature-list.schema.ts
@@ -1,0 +1,18 @@
+import { z } from "zod";
+
+export const FeatureListItemSchema = z
+  .object({
+    title: z.string().min(1).max(80),
+    body: z.string().min(1).max(240),
+  })
+  .strict();
+
+export const FeatureListSchema = z
+  .object({
+    type: z.literal("feature-list"),
+    title: z.string().min(1).max(120),
+    items: z.array(FeatureListItemSchema).min(1).max(6),
+  })
+  .strict();
+
+export type FeatureListData = z.infer<typeof FeatureListSchema>;

--- a/src/components/feature-list/feature-list.test.ts
+++ b/src/components/feature-list/feature-list.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+
+import { renderFeatureList } from "./feature-list.render.js";
+import { FeatureListSchema } from "./feature-list.schema.js";
+
+describe("FeatureListSchema", () => {
+  it("accepts valid content and renders ordered list markup", () => {
+    const parsed = FeatureListSchema.parse({
+      type: "feature-list",
+      title: "How teams keep output reviewable",
+      items: [
+        {
+          title: "Lock the schema",
+          body: "Make invalid content fail early.",
+        },
+      ],
+    });
+
+    const html = renderFeatureList(parsed);
+
+    expect(html).toContain('<section class="c-feature-list">');
+    expect(html).toContain('<ol class="c-feature-list__items">');
+    expect(html).toContain("Lock the schema");
+  });
+
+  it("rejects nested unknown fields", () => {
+    const result = FeatureListSchema.safeParse({
+      type: "feature-list",
+      title: "How teams keep output reviewable",
+      items: [
+        {
+          title: "Lock the schema",
+          body: "Make invalid content fail early.",
+          eyebrow: "Bad field",
+        },
+      ],
+    });
+
+    expect(result.success).toBe(false);
+    if (result.success) {
+      return;
+    }
+
+    expect(
+      result.error.issues.some(
+        (issue) =>
+          issue.code === "unrecognized_keys" &&
+          String(issue.path.join(".")) === "items.0",
+      ),
+    ).toBe(true);
+  });
+});

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -3,6 +3,13 @@ import { z } from "zod";
 
 import { CtaBandSchema } from "./cta-band/cta-band.schema.js";
 import { ctaBandClassNames, renderCtaBand } from "./cta-band/cta-band.render.js";
+import { FaqSchema } from "./faq/faq.schema.js";
+import { faqClassNames, renderFaq } from "./faq/faq.render.js";
+import { FeatureListSchema } from "./feature-list/feature-list.schema.js";
+import {
+  featureListClassNames,
+  renderFeatureList,
+} from "./feature-list/feature-list.render.js";
 import {
   FeatureGridSchema,
 } from "./feature-grid/feature-grid.schema.js";
@@ -15,7 +22,9 @@ import { heroClassNames, renderHero } from "./hero/hero.render.js";
 
 export const ComponentSchemaBase = z.discriminatedUnion("type", [
   HeroSchemaBase,
+  FeatureListSchema,
   FeatureGridSchema,
+  FaqSchema,
   CtaBandSchema,
 ]);
 
@@ -58,10 +67,22 @@ export const componentDefinitions: readonly ComponentDefinition[] = [
     classNames: heroClassNames,
   },
   {
+    type: "feature-list",
+    render: (data) => renderFeatureList(FeatureListSchema.parse(data)),
+    cssPath: fileURLToPath(new URL("./feature-list/feature-list.css", import.meta.url)),
+    classNames: featureListClassNames,
+  },
+  {
     type: "feature-grid",
     render: (data) => renderFeatureGrid(FeatureGridSchema.parse(data)),
     cssPath: fileURLToPath(new URL("./feature-grid/feature-grid.css", import.meta.url)),
     classNames: featureGridClassNames,
+  },
+  {
+    type: "faq",
+    render: (data) => renderFaq(FaqSchema.parse(data)),
+    cssPath: fileURLToPath(new URL("./faq/faq.css", import.meta.url)),
+    classNames: faqClassNames,
   },
   {
     type: "cta-band",
@@ -79,8 +100,12 @@ export const renderComponent = (data: ComponentData): string => {
   switch (data.type) {
     case "hero":
       return renderHero(data);
+    case "feature-list":
+      return renderFeatureList(data);
     case "feature-grid":
       return renderFeatureGrid(data);
+    case "faq":
+      return renderFaq(data);
     case "cta-band":
       return renderCtaBand(data);
     default: {


### PR DESCRIPTION
Closes #3

## What changed
- added PRD-aligned `feature-list` and `faq` components in the existing schema/render/CSS/test pattern
- registered both components in the framework so strict JSON validation and rendering support them
- updated the demo site content to exercise both new components in built output

## Validation
- npm run validate:strict