### PR TITLE
[codex] Add media and prose components

### DIFF
--- a/content/site.json
+++ b/content/site.json
@@ -110,6 +110,55 @@
           }
         }
       ]
+    },
+    {
+      "slug": "/about",
+      "title": "About",
+      "metadata": {
+        "description": "Long-form narrative and supporting media for the team behind LaunchKit."
+      },
+      "components": [
+        {
+          "type": "hero",
+          "headline": "A stricter generator should still leave room for character",
+          "subheadline": "Structured blocks are useful, but some pages need a real image and enough copy to tell the story cleanly.",
+          "primaryCta": {
+            "label": "See pricing",
+            "href": "/pricing"
+          },
+          "secondaryCta": {
+            "label": "Back home",
+            "href": "/"
+          },
+          "align": "start"
+        },
+        {
+          "type": "media",
+          "src": "https://images.unsplash.com/photo-1497366754035-f200968a6e72?auto=format&fit=crop&w=1200&q=80",
+          "alt": "Sunlit studio workspace with notebooks, a laptop, and a camera on the table",
+          "caption": "A visual section gives the page an anchor before the longer story begins.",
+          "size": "wide"
+        },
+        {
+          "type": "prose",
+          "title": "Why this needed a different section",
+          "lead": "About pages usually read as a sequence, not a set of interchangeable cards.",
+          "paragraphs": [
+            "LaunchKit started as a reaction to site generators that let content shape the markup until nothing was predictable enough to review. The structure here stays narrow on purpose, but the original version still flattened every story into the same compact block.",
+            "That tradeoff worked for feature callouts and FAQs, yet it stripped the personality out of pages that were supposed to feel human. A long-form prose section restores the pacing of a real narrative so a team can explain where the product came from, what it values, and why it exists without breaking the schema contract.",
+            "The media block does the same thing visually. Instead of forcing every page to rely on text-only layout, it gives a visually driven site a stable figure component with alt text, captions, and predictable sizing."
+          ]
+        },
+        {
+          "type": "cta-band",
+          "headline": "Use structured content without flattening the story",
+          "body": "The generator can stay strict while still supporting narrative pages that feel intentional.",
+          "primaryCta": {
+            "label": "Start now",
+            "href": "/start"
+          }
+        }
+      ]
     }
   ]
 }

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -19,6 +19,10 @@ import {
 } from "./feature-grid/feature-grid.render.js";
 import { HeroSchema, HeroSchemaBase } from "./hero/hero.schema.js";
 import { heroClassNames, renderHero } from "./hero/hero.render.js";
+import { MediaSchema } from "./media/media.schema.js";
+import { mediaClassNames, renderMedia } from "./media/media.render.js";
+import { ProseSchema } from "./prose/prose.schema.js";
+import { proseClassNames, renderProse } from "./prose/prose.render.js";
 
 export const ComponentSchemaBase = z.discriminatedUnion("type", [
   HeroSchemaBase,
@@ -26,6 +30,8 @@ export const ComponentSchemaBase = z.discriminatedUnion("type", [
   FeatureGridSchema,
   FaqSchema,
   CtaBandSchema,
+  MediaSchema,
+  ProseSchema,
 ]);
 
 export const ComponentSchema = ComponentSchemaBase.superRefine((value, ctx) => {
@@ -90,6 +96,18 @@ export const componentDefinitions: readonly ComponentDefinition[] = [
     cssPath: fileURLToPath(new URL("./cta-band/cta-band.css", import.meta.url)),
     classNames: ctaBandClassNames,
   },
+  {
+    type: "media",
+    render: (data) => renderMedia(MediaSchema.parse(data)),
+    cssPath: fileURLToPath(new URL("./media/media.css", import.meta.url)),
+    classNames: mediaClassNames,
+  },
+  {
+    type: "prose",
+    render: (data) => renderProse(ProseSchema.parse(data)),
+    cssPath: fileURLToPath(new URL("./prose/prose.css", import.meta.url)),
+    classNames: proseClassNames,
+  },
 ];
 
 export const componentTypeNames = componentDefinitions.map(
@@ -108,6 +126,10 @@ export const renderComponent = (data: ComponentData): string => {
       return renderFaq(data);
     case "cta-band":
       return renderCtaBand(data);
+    case "media":
+      return renderMedia(data);
+    case "prose":
+      return renderProse(data);
     default: {
       throw new Error(`No renderer exists for component '${JSON.stringify(data)}'`);
     }

--- a/src/components/media/media.css
+++ b/src/components/media/media.css
@@ -1,0 +1,30 @@
+.c-media {
+  margin: 0;
+  padding-block: var(--space-7);
+}
+
+.c-media--size-content {
+  width: min(calc(100% - (2 * var(--space-5))), var(--content-max));
+  margin-inline: auto;
+}
+
+.c-media--size-wide {
+  width: min(calc(100% - (2 * var(--space-5))), var(--container-max));
+  margin-inline: auto;
+}
+
+.c-media__image {
+  display: block;
+  width: 100%;
+  border: var(--border-width-1) solid var(--color-border);
+  border-radius: var(--radius-xl);
+  background: var(--color-surface-alt);
+  box-shadow: var(--shadow-md);
+}
+
+.c-media__caption {
+  margin: var(--space-3) 0 0;
+  color: var(--color-text-muted);
+  font-size: var(--font-size-0);
+  line-height: var(--line-height-loose);
+}

--- a/src/components/media/media.render.ts
+++ b/src/components/media/media.render.ts
@@ -1,0 +1,21 @@
+import type { MediaData } from "./media.schema.js";
+import { escapeHtml } from "../../renderer/escape-html.js";
+
+export const mediaClassNames = [
+  "c-media",
+  "c-media--size-content",
+  "c-media--size-wide",
+  "c-media__image",
+  "c-media__caption",
+] as const;
+
+export const renderMedia = (data: MediaData): string => {
+  return [
+    `<figure class="c-media c-media--size-${escapeHtml(data.size)}">`,
+    `  <img class="c-media__image" src="${escapeHtml(data.src)}" alt="${escapeHtml(data.alt)}" />`,
+    data.caption ? `  <figcaption class="c-media__caption">${escapeHtml(data.caption)}</figcaption>` : "",
+    "</figure>",
+  ]
+    .filter(Boolean)
+    .join("\n");
+};

--- a/src/components/media/media.schema.ts
+++ b/src/components/media/media.schema.ts
@@ -1,0 +1,13 @@
+import { z } from "zod";
+
+export const MediaSchema = z
+  .object({
+    type: z.literal("media"),
+    src: z.string().min(1).max(2048),
+    alt: z.string().min(1).max(200),
+    caption: z.string().min(1).max(280).optional(),
+    size: z.enum(["content", "wide"]).default("wide"),
+  })
+  .strict();
+
+export type MediaData = z.infer<typeof MediaSchema>;

--- a/src/components/media/media.test.ts
+++ b/src/components/media/media.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+
+import { renderMedia } from "./media.render.js";
+import { MediaSchema } from "./media.schema.js";
+
+describe("MediaSchema", () => {
+  it("accepts valid content and renders figure markup", () => {
+    const parsed = MediaSchema.parse({
+      type: "media",
+      src: "https://example.com/studio.jpg",
+      alt: "Founder standing in the studio",
+      caption: "A real image gives landing pages more character than a card grid alone.",
+      size: "content",
+    });
+
+    const html = renderMedia(parsed);
+
+    expect(html).toContain('<figure class="c-media c-media--size-content">');
+    expect(html).toContain('<img class="c-media__image"');
+    expect(html).toContain('alt="Founder standing in the studio"');
+    expect(html).toContain("<figcaption");
+  });
+
+  it("rejects unknown fields", () => {
+    const result = MediaSchema.safeParse({
+      type: "media",
+      src: "https://example.com/studio.jpg",
+      alt: "Founder standing in the studio",
+      layout: "full-bleed",
+    });
+
+    expect(result.success).toBe(false);
+    if (result.success) {
+      return;
+    }
+
+    expect(result.error.issues.some((issue) => issue.code === "unrecognized_keys")).toBe(true);
+  });
+});

--- a/src/components/prose/prose.css
+++ b/src/components/prose/prose.css
@@ -1,0 +1,38 @@
+.c-prose {
+  padding-block: var(--space-7);
+}
+
+.c-prose__inner {
+  width: min(calc(100% - (2 * var(--space-5))), var(--content-max));
+  margin-inline: auto;
+  display: grid;
+  gap: var(--space-4);
+}
+
+.c-prose__title,
+.c-prose__lead,
+.c-prose__paragraph {
+  margin: 0;
+}
+
+.c-prose__title {
+  font-family: var(--font-family-heading);
+  font-size: var(--font-size-4);
+  line-height: var(--line-height-heading);
+}
+
+.c-prose__lead {
+  color: var(--color-text-muted);
+  font-size: var(--font-size-2);
+  line-height: var(--line-height-loose);
+}
+
+.c-prose__content {
+  display: grid;
+  gap: var(--space-4);
+}
+
+.c-prose__paragraph {
+  font-size: var(--font-size-2);
+  line-height: var(--line-height-loose);
+}

--- a/src/components/prose/prose.render.ts
+++ b/src/components/prose/prose.render.ts
@@ -1,0 +1,31 @@
+import type { ProseData } from "./prose.schema.js";
+import { escapeHtml } from "../../renderer/escape-html.js";
+
+export const proseClassNames = [
+  "c-prose",
+  "c-prose__inner",
+  "c-prose__title",
+  "c-prose__lead",
+  "c-prose__content",
+  "c-prose__paragraph",
+] as const;
+
+export const renderProse = (data: ProseData): string => {
+  const paragraphsHtml = data.paragraphs
+    .map((paragraph) => `      <p class="c-prose__paragraph">${escapeHtml(paragraph)}</p>`)
+    .join("\n");
+
+  return [
+    '<section class="c-prose">',
+    '  <div class="c-prose__inner">',
+    data.title ? `    <h2 class="c-prose__title">${escapeHtml(data.title)}</h2>` : "",
+    data.lead ? `    <p class="c-prose__lead">${escapeHtml(data.lead)}</p>` : "",
+    '    <div class="c-prose__content">',
+    paragraphsHtml,
+    "    </div>",
+    "  </div>",
+    "</section>",
+  ]
+    .filter(Boolean)
+    .join("\n");
+};

--- a/src/components/prose/prose.schema.ts
+++ b/src/components/prose/prose.schema.ts
@@ -1,0 +1,12 @@
+import { z } from "zod";
+
+export const ProseSchema = z
+  .object({
+    type: z.literal("prose"),
+    title: z.string().min(1).max(120).optional(),
+    lead: z.string().min(1).max(280).optional(),
+    paragraphs: z.array(z.string().min(1).max(1200)).min(1).max(12),
+  })
+  .strict();
+
+export type ProseData = z.infer<typeof ProseSchema>;

--- a/src/components/prose/prose.test.ts
+++ b/src/components/prose/prose.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+
+import { renderProse } from "./prose.render.js";
+import { ProseSchema } from "./prose.schema.js";
+
+describe("ProseSchema", () => {
+  it("accepts long-form content and renders paragraphs in order", () => {
+    const parsed = ProseSchema.parse({
+      type: "prose",
+      title: "Why the generator exists",
+      lead: "Narrative sections need more room than a card grid gives them.",
+      paragraphs: [
+        "The generator exists to keep structure rigid while still giving a page enough room to explain itself.",
+        "A long-form section lets a team keep the original flow of an about page instead of breaking it into disconnected tiles.",
+      ],
+    });
+
+    const html = renderProse(parsed);
+
+    expect(html).toContain('<section class="c-prose">');
+    expect(html).toContain('<div class="c-prose__content">');
+    expect(html).toContain("The generator exists to keep structure rigid");
+    expect(html.indexOf("The generator exists")).toBeLessThan(
+      html.indexOf("A long-form section lets a team"),
+    );
+  });
+
+  it("rejects an empty paragraph list", () => {
+    const result = ProseSchema.safeParse({
+      type: "prose",
+      paragraphs: [],
+    });
+
+    expect(result.success).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- add a `media` component with strict schema validation, stable figure markup, and bundled CSS
- add a `prose` component for long-form narrative sections with ordered paragraph rendering
- exercise both components in `content/site.json` by adding an `/about` page that uses the new blocks

## Why
Issue #10 called out two gaps in the framework: visually driven pages had no image/media block, and About-style pages had no long-form prose section. This change fills those two holes without widening the content contract beyond explicit component types.

## Validation
- `npm run validate:strict`
- inspected generated `dist/about/index.html` and `dist/assets/site.css` for the new component markup and styles

Closes #10.