### PR TITLE
[codex] Use content-max consistently across standard components

### DIFF
--- a/src/components/cta-band/cta-band.css
+++ b/src/components/cta-band/cta-band.css
@@ -3,7 +3,7 @@
 }
 
 .c-cta-band__inner {
-  width: min(calc(100% - (2 * var(--space-5))), var(--container-max));
+  width: min(calc(100% - (2 * var(--space-5))), var(--content-max));
   margin-inline: auto;
   padding: var(--space-6);
   display: grid;

--- a/src/components/feature-grid/feature-grid.css
+++ b/src/components/feature-grid/feature-grid.css
@@ -3,7 +3,7 @@
 }
 
 .c-feature-grid__inner {
-  width: min(calc(100% - (2 * var(--space-5))), var(--container-max));
+  width: min(calc(100% - (2 * var(--space-5))), var(--content-max));
   margin-inline: auto;
   display: grid;
   gap: var(--space-5);

--- a/tests/component-css-widths.test.ts
+++ b/tests/component-css-widths.test.ts
@@ -1,0 +1,38 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const repoRoot = path.resolve(import.meta.dirname, "..");
+
+const readComponentCss = async (componentName: string) =>
+  readFile(path.join(repoRoot, "src", "components", componentName, `${componentName}.css`), "utf8");
+
+describe("component width tokens", () => {
+  it("uses content-max for standard component wrappers", async () => {
+    const standardComponents = [
+      "cta-band",
+      "faq",
+      "feature-grid",
+      "feature-list",
+      "hero",
+      "prose",
+    ];
+
+    const cssFiles = await Promise.all(standardComponents.map(readComponentCss));
+
+    for (const css of cssFiles) {
+      expect(css).toContain("var(--content-max)");
+      expect(css).not.toContain("var(--container-max)");
+    }
+  });
+
+  it("keeps media width modes split between content and container tokens", async () => {
+    const css = await readComponentCss("media");
+
+    expect(css).toContain(".c-media--size-content");
+    expect(css).toContain("var(--content-max)");
+    expect(css).toContain(".c-media--size-wide");
+    expect(css).toContain("var(--container-max)");
+  });
+});


### PR DESCRIPTION
## What changed
Standard component wrappers now use the `--content-max` token consistently. This updates the `cta-band` and `feature-grid` components to match the other standard components, while leaving the intentional wide media mode on `--container-max`.

I also added a regression test that reads the component CSS directly and verifies that standard wrappers stay on `--content-max` and that media keeps its split content and wide width modes.

## Why it changed
Issue #14 called out that component widths were inconsistent. The root cause was that two standard components still used the wider container token even though the rest of the component set had already converged on `--content-max`.

## Impact
Pages built with `cta-band` and `feature-grid` will now align with the same readable content width used by the rest of the standard components.

## Validation
- `npm run validate:strict`

Closes #14