### PR TITLE
[codex] Move studio background image into site JSON

### DIFF
--- a/content/examples/78th-street-studios.json
+++ b/content/examples/78th-street-studios.json
@@ -2,7 +2,8 @@
   "site": {
     "name": "78th Street Studios",
     "baseUrl": "https://78thstreetstudios.com",
-    "theme": "studio-industrial"
+    "theme": "studio-industrial",
+    "pageBackgroundImageUrl": "https://78thstreetstudios.com/sites/78thstreetstudios.com/files/styles/adaptive/public/media/images/background/IMG_CFD448348658-1.jpeg?itok=FLmeLmsX"
   },
   "pages": [
     {

--- a/src/build/framework.ts
+++ b/src/build/framework.ts
@@ -10,6 +10,7 @@ import {
 } from "../components/index.js";
 import {
   SiteContentSchema,
+  type SiteData,
   type SiteContentData,
 } from "../schemas/site.schema.js";
 import { renderPageDocument } from "../renderer/render-page.js";
@@ -216,7 +217,20 @@ const pageSlugToOutputPath = (slug: string, outDir: string): string => {
   return path.join(outDir, slug.replace(/^\//, ""), "index.html");
 };
 
-const renderSiteCss = async (themeName: keyof typeof themes): Promise<string> => {
+const escapeCssString = (value: string): string =>
+  value
+    .replaceAll("\\", "\\\\")
+    .replaceAll("\"", "\\\"");
+
+const emitSiteCss = (site: SiteData): string => {
+  if (!site.pageBackgroundImageUrl) {
+    return "";
+  }
+
+  return `:root {\n  --site-page-background-image: url("${escapeCssString(site.pageBackgroundImageUrl)}");\n}\n`;
+};
+
+const renderSiteCss = async (site: SiteData): Promise<string> => {
   const componentCssChunks = await Promise.all(
     componentDefinitions.map(async (componentDefinition) => {
       const css = await readFile(componentDefinition.cssPath, "utf8");
@@ -227,12 +241,16 @@ const renderSiteCss = async (themeName: keyof typeof themes): Promise<string> =>
   const baseCss = await readFile(baseCssPath, "utf8");
 
   return [
+    "/* site */",
+    emitSiteCss(site).trim(),
     "/* theme */",
-    emitThemeCss(themes[themeName]),
+    emitThemeCss(themes[site.theme]),
     "/* base */",
     baseCss,
     ...componentCssChunks,
-  ].join("\n\n");
+  ]
+    .filter(Boolean)
+    .join("\n\n");
 };
 
 export const buildSite = async (
@@ -242,7 +260,7 @@ export const buildSite = async (
   await rm(outDir, { recursive: true, force: true });
   await mkdir(path.join(outDir, "assets"), { recursive: true });
 
-  const css = await renderSiteCss(siteContent.site.theme);
+  const css = await renderSiteCss(siteContent.site);
   await writeFile(path.join(outDir, "assets", "site.css"), css, "utf8");
 
   for (const page of siteContent.pages) {

--- a/src/schemas/site.schema.ts
+++ b/src/schemas/site.schema.ts
@@ -24,6 +24,7 @@ export const SiteSchema = z
     name: z.string().min(1).max(80),
     baseUrl: z.string().url(),
     theme: z.enum(themeNames),
+    pageBackgroundImageUrl: z.string().url().optional(),
   })
   .strict();
 
@@ -37,4 +38,3 @@ export const SiteContentSchema = z
 export type PageData = z.infer<typeof PageSchema>;
 export type SiteData = z.infer<typeof SiteSchema>;
 export type SiteContentData = z.infer<typeof SiteContentSchema>;
-

--- a/src/themes/studio-industrial.ts
+++ b/src/themes/studio-industrial.ts
@@ -16,7 +16,7 @@ export const studioIndustrialTheme = createThemeDefinition(
     "--color-link-hover": "#b13f21",
     "--color-focus-ring": "#d39b4c",
     "--page-background":
-      "linear-gradient(rgb(27 19 14 / 0.78), rgb(27 19 14 / 0.88)), url(\"https://78thstreetstudios.com/sites/78thstreetstudios.com/files/styles/adaptive/public/media/images/background/IMG_CFD448348658-1.jpeg?itok=FLmeLmsX\") center / cover fixed #1b130e",
+      "linear-gradient(rgb(27 19 14 / 0.78), rgb(27 19 14 / 0.88)), var(--site-page-background-image, none) center / cover fixed #1b130e",
     "--surface-background":
       "linear-gradient(180deg, rgb(243 237 227 / 0.97) 0%, rgb(229 219 203 / 0.95) 100%)",
     "--hero-background":

--- a/tests/78th-street-studios-example.test.ts
+++ b/tests/78th-street-studios-example.test.ts
@@ -35,6 +35,10 @@ describe("78th Street Studios example", () => {
       expect(aboutHtml).toContain("Old freight doors, long corridors, and raw industrial surfaces");
       expect(homeHtml).toContain('data-theme="studio-industrial"');
       expect(css).toContain('--font-family-heading: "Bookman Old Style", "Palatino Linotype", serif;');
+      expect(css).toContain("--site-page-background-image:");
+      expect(css).toContain(
+        'url("https://78thstreetstudios.com/sites/78thstreetstudios.com/files/styles/adaptive/public/media/images/background/IMG_CFD448348658-1.jpeg?itok=FLmeLmsX")',
+      );
     } finally {
       await rm(outDir, { recursive: true, force: true });
     }

--- a/tests/theme-build.test.ts
+++ b/tests/theme-build.test.ts
@@ -56,6 +56,7 @@ describe("buildSite theme CSS", () => {
 
       expect(css).toContain(themeMarkers[theme]);
       expect(html).toContain(`data-theme="${theme}"`);
+      expect(css).not.toContain("78thstreetstudios.com");
 
       for (const otherTheme of themeNames) {
         if (otherTheme === theme) {


### PR DESCRIPTION
## Summary
Moves the `studio-industrial` page background image out of the theme and into site JSON.

## Why
The theme had a 78th Street Studios-specific background URL hardcoded into `--page-background`, which made the theme itself site-specific.

## What changed
- Added optional `site.pageBackgroundImageUrl` to the site schema
- Emit a site-level CSS variable for that URL during build
- Updated `studio-industrial` to read the background image from the site CSS variable instead of a hardcoded asset
- Updated the 78th Street Studios example JSON to provide the background image there
- Tightened tests so the theme build stays free of the 78th-specific URL unless content provides it

## Validation
- `npm run validate:strict`
- `npm run validate:example:78th`
- `npm run build:example:78th`

Closes #17