### PR TITLE
Add Google Maps component

### DIFF
--- a/content/examples/78th-street-studios.json
+++ b/content/examples/78th-street-studios.json
@@ -100,6 +100,13 @@
           "size": "wide"
         },
         {
+          "type": "google-maps",
+          "embedUrl": "https://www.google.com/maps?q=78th+Street+Studios+Cleveland+OH&output=embed&z=15",
+          "title": "78th Street Studios map",
+          "caption": "Use the embedded map to get directions to the building in Cleveland.",
+          "size": "wide"
+        },
+        {
           "type": "prose",
           "title": "Why the building matters",
           "lead": "78th Street Studios combines art destination, working studio building, and event venue in one sprawling piece of Cleveland industrial history.",

--- a/schemas/site-content.schema.json
+++ b/schemas/site-content.schema.json
@@ -25,6 +25,10 @@
                 "app-announcement",
                 "studio-industrial"
               ]
+            },
+            "pageBackgroundImageUrl": {
+              "type": "string",
+              "format": "uri"
             }
           },
           "required": [
@@ -294,6 +298,44 @@
                         "type",
                         "headline",
                         "primaryCta"
+                      ],
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "type": "string",
+                          "const": "google-maps"
+                        },
+                        "embedUrl": {
+                          "type": "string",
+                          "format": "uri",
+                          "maxLength": 2048
+                        },
+                        "title": {
+                          "type": "string",
+                          "minLength": 1,
+                          "maxLength": 120
+                        },
+                        "caption": {
+                          "type": "string",
+                          "minLength": 1,
+                          "maxLength": 280
+                        },
+                        "size": {
+                          "type": "string",
+                          "enum": [
+                            "content",
+                            "wide"
+                          ],
+                          "default": "wide"
+                        }
+                      },
+                      "required": [
+                        "type",
+                        "embedUrl",
+                        "title"
                       ],
                       "additionalProperties": false
                     },

--- a/src/components/google-maps/google-maps.css
+++ b/src/components/google-maps/google-maps.css
@@ -1,0 +1,39 @@
+.c-google-maps {
+  margin: 0;
+  padding-block: var(--space-7);
+  display: grid;
+  gap: var(--space-3);
+}
+
+.c-google-maps--size-content {
+  width: min(calc(100% - (2 * var(--space-5))), var(--content-max));
+  margin-inline: auto;
+}
+
+.c-google-maps--size-wide {
+  width: min(calc(100% - (2 * var(--space-5))), var(--container-max));
+  margin-inline: auto;
+}
+
+.c-google-maps__frame {
+  border-radius: var(--radius-xl);
+  border: var(--border-width-1) solid var(--color-border);
+  box-shadow: var(--shadow-md);
+  background: var(--color-surface-alt);
+}
+
+.c-google-maps__embed {
+  display: block;
+  width: 100%;
+  min-height: 20rem;
+  aspect-ratio: 16 / 9;
+  border: 0;
+  border-radius: var(--radius-xl);
+}
+
+.c-google-maps__caption {
+  margin: 0;
+  color: var(--color-text-muted);
+  font-size: var(--font-size-0);
+  line-height: var(--line-height-loose);
+}

--- a/src/components/google-maps/google-maps.render.ts
+++ b/src/components/google-maps/google-maps.render.ts
@@ -1,0 +1,26 @@
+import { escapeHtml } from "../../renderer/escape-html.js";
+import type { GoogleMapsData } from "./google-maps.schema.js";
+
+export const googleMapsClassNames = [
+  "c-google-maps",
+  "c-google-maps--size-content",
+  "c-google-maps--size-wide",
+  "c-google-maps__frame",
+  "c-google-maps__embed",
+  "c-google-maps__caption",
+] as const;
+
+export const renderGoogleMaps = (data: GoogleMapsData): string => {
+  return [
+    `<figure class="c-google-maps c-google-maps--size-${escapeHtml(data.size)}">`,
+    '  <div class="c-google-maps__frame">',
+    `    <iframe class="c-google-maps__embed" src="${escapeHtml(data.embedUrl)}" title="${escapeHtml(data.title)}" loading="lazy" allowfullscreen referrerpolicy="no-referrer-when-downgrade"></iframe>`,
+    "  </div>",
+    data.caption
+      ? `  <figcaption class="c-google-maps__caption">${escapeHtml(data.caption)}</figcaption>`
+      : "",
+    "</figure>",
+  ]
+    .filter(Boolean)
+    .join("\n");
+};

--- a/src/components/google-maps/google-maps.schema.ts
+++ b/src/components/google-maps/google-maps.schema.ts
@@ -1,0 +1,38 @@
+import { z } from "zod";
+
+const isGoogleMapsUrl = (value: string): boolean => {
+  try {
+    const url = new URL(value);
+
+    if (url.protocol !== "https:") {
+      return false;
+    }
+
+    const isGoogleMapsHost =
+      url.hostname === "google.com" ||
+      url.hostname === "www.google.com" ||
+      url.hostname === "maps.google.com";
+
+    return isGoogleMapsHost && url.pathname.startsWith("/maps");
+  } catch {
+    return false;
+  }
+};
+
+export const GoogleMapsSchema = z
+  .object({
+    type: z.literal("google-maps"),
+    embedUrl: z
+      .string()
+      .url()
+      .max(2048)
+      .refine(isGoogleMapsUrl, {
+        message: "embedUrl must be an https Google Maps URL under /maps",
+      }),
+    title: z.string().min(1).max(120),
+    caption: z.string().min(1).max(280).optional(),
+    size: z.enum(["content", "wide"]).default("wide"),
+  })
+  .strict();
+
+export type GoogleMapsData = z.infer<typeof GoogleMapsSchema>;

--- a/src/components/google-maps/google-maps.test.ts
+++ b/src/components/google-maps/google-maps.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+
+import { renderGoogleMaps } from "./google-maps.render.js";
+import { GoogleMapsSchema } from "./google-maps.schema.js";
+
+describe("GoogleMapsSchema", () => {
+  it("accepts valid map data and renders escaped iframe markup", () => {
+    const parsed = GoogleMapsSchema.parse({
+      type: "google-maps",
+      embedUrl: "https://www.google.com/maps?q=78th+Street+Studios&output=embed&z=15",
+      title: 'Visit <Map> "Preview"',
+      caption: "Use the embedded map to plan your route.",
+      size: "content",
+    });
+
+    const html = renderGoogleMaps(parsed);
+
+    expect(html).toContain('<figure class="c-google-maps c-google-maps--size-content">');
+    expect(html).toContain('<iframe class="c-google-maps__embed"');
+    expect(html).toContain('title="Visit &lt;Map&gt; &quot;Preview&quot;"');
+    expect(html).toContain("Use the embedded map to plan your route.");
+    expect(html).not.toContain('title="Visit <Map> "Preview""');
+  });
+
+  it("rejects non-Google embed URLs and unknown fields", () => {
+    const invalidUrl = GoogleMapsSchema.safeParse({
+      type: "google-maps",
+      embedUrl: "https://example.com/maps?q=78th+Street+Studios&output=embed",
+      title: "Visit map",
+    });
+
+    expect(invalidUrl.success).toBe(false);
+    if (invalidUrl.success) {
+      return;
+    }
+
+    expect(invalidUrl.error.issues.some((issue) => issue.path.includes("embedUrl"))).toBe(true);
+
+    const extraField = GoogleMapsSchema.safeParse({
+      type: "google-maps",
+      embedUrl: "https://www.google.com/maps?q=78th+Street+Studios&output=embed",
+      title: "Visit map",
+      zoom: 15,
+    });
+
+    expect(extraField.success).toBe(false);
+    if (extraField.success) {
+      return;
+    }
+
+    expect(extraField.error.issues.some((issue) => issue.code === "unrecognized_keys")).toBe(true);
+  });
+});

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -17,6 +17,11 @@ import {
   featureGridClassNames,
   renderFeatureGrid,
 } from "./feature-grid/feature-grid.render.js";
+import { GoogleMapsSchema } from "./google-maps/google-maps.schema.js";
+import {
+  googleMapsClassNames,
+  renderGoogleMaps,
+} from "./google-maps/google-maps.render.js";
 import { HeroSchema, HeroSchemaBase } from "./hero/hero.schema.js";
 import { heroClassNames, renderHero } from "./hero/hero.render.js";
 import { MediaSchema } from "./media/media.schema.js";
@@ -30,6 +35,7 @@ export const ComponentSchemaBase = z.discriminatedUnion("type", [
   FeatureGridSchema,
   FaqSchema,
   CtaBandSchema,
+  GoogleMapsSchema,
   MediaSchema,
   ProseSchema,
 ]);
@@ -97,6 +103,12 @@ export const componentDefinitions: readonly ComponentDefinition[] = [
     classNames: ctaBandClassNames,
   },
   {
+    type: "google-maps",
+    render: (data) => renderGoogleMaps(GoogleMapsSchema.parse(data)),
+    cssPath: fileURLToPath(new URL("./google-maps/google-maps.css", import.meta.url)),
+    classNames: googleMapsClassNames,
+  },
+  {
     type: "media",
     render: (data) => renderMedia(MediaSchema.parse(data)),
     cssPath: fileURLToPath(new URL("./media/media.css", import.meta.url)),
@@ -126,6 +138,8 @@ export const renderComponent = (data: ComponentData): string => {
       return renderFaq(data);
     case "cta-band":
       return renderCtaBand(data);
+    case "google-maps":
+      return renderGoogleMaps(data);
     case "media":
       return renderMedia(data);
     case "prose":

--- a/tests/component-css-widths.test.ts
+++ b/tests/component-css-widths.test.ts
@@ -35,4 +35,13 @@ describe("component width tokens", () => {
     expect(css).toContain(".c-media--size-wide");
     expect(css).toContain("var(--container-max)");
   });
+
+  it("keeps google maps width modes split between content and container tokens", async () => {
+    const css = await readComponentCss("google-maps");
+
+    expect(css).toContain(".c-google-maps--size-content");
+    expect(css).toContain("var(--content-max)");
+    expect(css).toContain(".c-google-maps--size-wide");
+    expect(css).toContain("var(--container-max)");
+  });
 });


### PR DESCRIPTION
## Summary

- add a dedicated `google-maps` component that renders a Google Maps iframe with controlled content and wide width modes
- enforce a strict component contract so only HTTPS Google Maps `/maps` embed URLs and known fields are accepted
- wire the component into the shared schema and exercise it in the 78th Street Studios example fixture

## Validation

- `npm run validate:strict`
- `npm run validate:example:78th`
- `npm run build:example:78th`

Closes #22
