### PR TITLE
[codex] Add redesign prompt pack

### DIFF
--- a/docs/redesign-one-shot-prompt.md
+++ b/docs/redesign-one-shot-prompt.md
@@ -26,8 +26,6 @@ Required workflow:
 
 1. Source inventory
 - Crawl or inspect the full public site navigation and obvious linked public pages.
-- If an auto researcher is available, you may use it as a discovery aid to widen page and asset coverage, especially when the source site has weak navigation, footer-only pages, or brittle markup.
-- Treat auto researcher output as a lead list to verify, not as proof that coverage is complete.
 - Cross-check header navigation, footer navigation, contact/about links, and obvious in-content public links so low-traffic pages are not skipped just because they are not featured on the homepage.
 - Produce a page inventory with:
   - URL
@@ -59,7 +57,7 @@ Required workflow:
 - Assume a skeptical reviewer is trying to prove the redesign dropped important content.
 - Compare the source inventory against the output page by page.
 - Cite the output page or section that carries each retained source page and each retained image.
-- Do not treat an auto researcher summary as sufficient evidence on its own; the final audit must still map retained content into the generated output.
+- Do not treat a high-level crawl summary as sufficient evidence on its own; the final audit must still map retained content into the generated output.
 - List anything that was condensed, normalized, or omitted.
 - For each omission, explain whether it was duplicated boilerplate, unsupported CMS chrome, broken source markup, or a true limitation in the current generator.
 - If an image, page, or site detail from the source is not clearly represented, the work is not ready.

--- a/reports/redesign-prompt-iterations.md
+++ b/reports/redesign-prompt-iterations.md
@@ -158,10 +158,10 @@ High quality. This is the first version that is strong enough to use as the defa
 
 Use the prompt in `docs/redesign-one-shot-prompt.md` as the default one-shot redesign prompt for this repo.
 
-Auto researcher makes sense here as an optional source-discovery pre-pass, not as a replacement for the redesign prompt itself.
+Auto researcher makes more sense here as an optional prompt-hardening aid during iteration, not as an instruction embedded in the shipped redesign prompt.
 
-- It can help surface footer-only pages, weakly linked pages, and assets that a quick manual crawl might miss.
-- It is most useful before generation, when the goal is to widen the candidate inventory and reduce source-coverage gaps.
-- It is not enough on its own because the final output still needs a page-by-page mapping, an image ledger, a gap ledger, and a steelman audit tied directly to the generated site.
+- Use it while refining the prompt to ask what retention, source-coverage, or traceability failures a weaker version of the prompt would still allow.
+- That kind of critique is what helped push this prompt toward explicit source coverage notes, page-to-output mapping, image mapping, and the stricter readiness gate.
+- Keep the shipped prompt tool-agnostic. The runtime prompt should require the evidence directly, regardless of what helper tools were used while drafting it.
 
 It went well overall. The extra passes were worth doing because the remaining weaknesses were not about tone, they were about evidence: source coverage and mapping traceability. The smallest repeatable process fix that made the next iteration better was simple: once the prompt looked "good enough," force one more pass that asks what proof is still missing before accepting the result.

--- a/tests/redesign-prompt-docs.test.ts
+++ b/tests/redesign-prompt-docs.test.ts
@@ -13,18 +13,17 @@ describe("site redesign prompt docs", () => {
     expect(promptDoc).toContain("Preserve every meaningful public page");
     expect(promptDoc).toContain("Preserve all reasonable copy");
     expect(promptDoc).toContain("Preserve important images");
-    expect(promptDoc).toContain("If an auto researcher is available");
-    expect(promptDoc).toContain("Treat auto researcher output as a lead list to verify");
     expect(promptDoc).toContain("Cross-check header navigation, footer navigation");
     expect(promptDoc).toContain("image retention ledger");
     expect(promptDoc).toContain("source coverage note");
     expect(promptDoc).toContain("Steelman review before declaring readiness");
-    expect(promptDoc).toContain("Do not treat an auto researcher summary as sufficient evidence on its own");
+    expect(promptDoc).toContain("Do not treat a high-level crawl summary as sufficient evidence on its own");
     expect(promptDoc).toContain("Cite the output page or section");
     expect(promptDoc).toContain('Only say "ready for customer review"');
     expect(promptDoc).toContain("the work is not ready");
     expect(promptDoc).toContain("gap ledger");
     expect(promptDoc).toContain("exact dates");
+    expect(promptDoc).not.toContain("auto researcher");
   });
 
   it("records iterative testing against the repo's real example migrations", async () => {
@@ -41,7 +40,7 @@ describe("site redesign prompt docs", () => {
     expect(report).toContain("source coverage");
     expect(report).toContain("traceability");
     expect(report).toContain("steelman audit");
-    expect(report).toContain("Auto researcher makes sense here as an optional source-discovery pre-pass");
-    expect(report).toContain("not as a replacement for the redesign prompt itself");
+    expect(report).toContain("Auto researcher makes more sense here as an optional prompt-hardening aid during iteration");
+    expect(report).toContain("Keep the shipped prompt tool-agnostic");
   });
 });


### PR DESCRIPTION
## Summary
- add a reusable one-shot prompt for migrating an existing public site into this repo's JSON site-generator format
- add an iteration report showing how the prompt was tightened against the Baird Automotive and 78th Street Studios example migrations
- add a focused test that keeps the prompt anchored to page retention, copy retention, image retention, and the steelman readiness gate

## Why
Issue #27 asked for a prompt that can one-shot a redesign from an existing site while retaining the important copy, images, pages, and site details. It also asked for iteration notes showing how the prompt was tested and improved until quality was high.

## Validation
- `npx vitest run tests/redesign-prompt-docs.test.ts`
- `npm run validate:strict`

## Notes
- The strict validation run passed cleanly.
- The iteration report explains what changed in each prompt pass and why the final version is the first one that clears the quality bar.

Refs #27
