### PR TITLE
[codex] Increase default content width to 80rem

### DIFF
--- a/src/themes/studio-industrial.ts
+++ b/src/themes/studio-industrial.ts
@@ -31,7 +31,6 @@ export const studioIndustrialTheme = createThemeDefinition(
     "--button-letter-spacing": "0.02em",
     "--button-secondary-text": "var(--color-text)",
     "--space-7": "2.75rem",
-    "--content-max": "46rem",
     "--button-height": "2.625rem",
     "--radius-md": "0.25rem",
     "--radius-lg": "0.5rem",

--- a/src/themes/theme-validation.test.ts
+++ b/src/themes/theme-validation.test.ts
@@ -113,6 +113,19 @@ describe("theme validation", () => {
     }
   });
 
+  it("keeps content width at 80rem while preserving separate container width control", () => {
+    expect(defaultThemeTokens["--content-max"]).toBe("80rem");
+
+    for (const [themeName, theme] of Object.entries(themes)) {
+      expect(theme.tokens["--content-max"], `${themeName} should inherit the shared content width`).toBe(
+        "80rem",
+      );
+    }
+
+    expect(defaultThemeTokens["--container-max"]).toBe("72rem");
+    expect(themes.corporate.tokens["--container-max"]).toBe("74rem");
+  });
+
   it("keeps every built-in theme distinct beyond color alone", () => {
     for (const [themeName, theme] of Object.entries(themes)) {
       const changedNonColorTokens = themeTokenNames.filter(

--- a/src/themes/tokens.ts
+++ b/src/themes/tokens.ts
@@ -53,7 +53,7 @@ const canonicalThemeTokens = {
   "--space-7": "3rem",
   "--space-8": "4rem",
   "--container-max": "72rem",
-  "--content-max": "48rem",
+  "--content-max": "80rem",
   "--nav-height": "4rem",
   "--button-height": "2.75rem",
   "--input-height": "2.75rem",


### PR DESCRIPTION
## What changed
- increased the shared `--content-max` token from `48rem` to `80rem`
- removed the `studio-industrial` override so built-in themes now share the same content width baseline
- added a test that locks in the new `80rem` content width and keeps `container-max` as a separate token for wide layouts

## Why
Issue #33 asked for the default content width to move to `80rem` and asked whether the container max should still be a variable.

`container-max` still makes sense as a separate variable because wide media and map layouts use it, and the `corporate` theme already overrides it independently of content width.

## Impact
Standard content sections now render at a wider readable width across the built-in themes, while wide embed and media layouts keep their separate container sizing behavior.

## Validation
- `npm run validate:strict`

Closes #33.
