### PR TITLE
[codex] Add optional images to feature grid items

### DIFF
--- a/schemas/site-content.schema.json
+++ b/schemas/site-content.schema.json
@@ -215,6 +215,31 @@
                                     "body": {
                                       "type": "string",
                                       "minLength": 1
+                                    },
+                                    "image": {
+                                      "type": "object",
+                                      "properties": {
+                                        "src": {
+                                          "type": "string",
+                                          "minLength": 1,
+                                          "maxLength": 2048
+                                        },
+                                        "alt": {
+                                          "type": "string",
+                                          "minLength": 1,
+                                          "maxLength": 200
+                                        },
+                                        "caption": {
+                                          "type": "string",
+                                          "minLength": 1,
+                                          "maxLength": 280
+                                        }
+                                      },
+                                      "required": [
+                                        "src",
+                                        "alt"
+                                      ],
+                                      "additionalProperties": false
                                     }
                                   },
                                   "required": [
@@ -351,24 +376,18 @@
                           {
                             "type": "object",
                             "properties": {
+                              "src": {
+                                "$ref": "#/definitions/SiteContent/properties/site/properties/layout/properties/components/items/anyOf/0/anyOf/2/properties/items/items/properties/image/properties/src"
+                              },
+                              "alt": {
+                                "$ref": "#/definitions/SiteContent/properties/site/properties/layout/properties/components/items/anyOf/0/anyOf/2/properties/items/items/properties/image/properties/alt"
+                              },
+                              "caption": {
+                                "$ref": "#/definitions/SiteContent/properties/site/properties/layout/properties/components/items/anyOf/0/anyOf/2/properties/items/items/properties/image/properties/caption"
+                              },
                               "type": {
                                 "type": "string",
                                 "const": "media"
-                              },
-                              "src": {
-                                "type": "string",
-                                "minLength": 1,
-                                "maxLength": 2048
-                              },
-                              "alt": {
-                                "type": "string",
-                                "minLength": 1,
-                                "maxLength": 200
-                              },
-                              "caption": {
-                                "type": "string",
-                                "minLength": 1,
-                                "maxLength": 280
                               },
                               "size": {
                                 "type": "string",
@@ -380,9 +399,9 @@
                               }
                             },
                             "required": [
-                              "type",
                               "src",
-                              "alt"
+                              "alt",
+                              "type"
                             ],
                             "additionalProperties": false
                           },

--- a/src/components/feature-grid/feature-grid.css
+++ b/src/components/feature-grid/feature-grid.css
@@ -28,14 +28,46 @@
 
 .c-feature-grid__item {
   padding: var(--space-5);
+  display: grid;
+  gap: var(--space-4);
   border: var(--border-width-1) solid var(--color-border);
   border-radius: var(--radius-lg);
   background: var(--surface-background);
   box-shadow: var(--shadow-sm);
 }
 
+.c-feature-grid__item--has-image {
+  grid-template-columns: minmax(4.5rem, 5.5rem) minmax(0, 1fr);
+  align-items: start;
+}
+
+.c-feature-grid__item-media {
+  margin: 0;
+  display: grid;
+  gap: var(--space-2);
+}
+
+.c-feature-grid__item-image {
+  display: block;
+  width: 100%;
+  height: auto;
+  border-radius: var(--radius-md);
+}
+
+.c-feature-grid__item-caption {
+  margin: 0;
+  color: var(--color-text-muted);
+  font-size: var(--font-size-0);
+  line-height: var(--line-height-body);
+}
+
+.c-feature-grid__item-copy {
+  display: grid;
+  gap: var(--space-2);
+}
+
 .c-feature-grid__item-title {
-  margin: 0 0 var(--space-2);
+  margin: 0;
   font-family: var(--font-family-heading);
   font-size: var(--font-size-3);
 }

--- a/src/components/feature-grid/feature-grid.render.ts
+++ b/src/components/feature-grid/feature-grid.render.ts
@@ -7,6 +7,11 @@ export const featureGridClassNames = [
   "c-feature-grid__title",
   "c-feature-grid__items",
   "c-feature-grid__item",
+  "c-feature-grid__item--has-image",
+  "c-feature-grid__item-media",
+  "c-feature-grid__item-image",
+  "c-feature-grid__item-caption",
+  "c-feature-grid__item-copy",
   "c-feature-grid__item-title",
   "c-feature-grid__item-body",
 ] as const;
@@ -14,12 +19,36 @@ export const featureGridClassNames = [
 export const renderFeatureGrid = (data: FeatureGridData): string => {
   const itemsHtml = data.items
     .map(
-      (item) => [
-        '      <li class="c-feature-grid__item">',
-        `        <h3 class="c-feature-grid__item-title">${escapeHtml(item.title)}</h3>`,
-        `        <p class="c-feature-grid__item-body">${escapeHtml(item.body)}</p>`,
-        "      </li>",
-      ].join("\n"),
+      (item) => {
+        const itemClasses = ["c-feature-grid__item"];
+
+        if (item.image) {
+          itemClasses.push("c-feature-grid__item--has-image");
+        }
+
+        return [
+          `      <li class="${itemClasses.join(" ")}">`,
+          item.image
+            ? [
+                '        <figure class="c-feature-grid__item-media">',
+                `          <img class="c-feature-grid__item-image" src="${escapeHtml(item.image.src)}" alt="${escapeHtml(item.image.alt)}" />`,
+                item.image.caption
+                  ? `          <figcaption class="c-feature-grid__item-caption">${escapeHtml(item.image.caption)}</figcaption>`
+                  : "",
+                "        </figure>",
+              ]
+                .filter(Boolean)
+                .join("\n")
+            : "",
+          '        <div class="c-feature-grid__item-copy">',
+          `          <h3 class="c-feature-grid__item-title">${escapeHtml(item.title)}</h3>`,
+          `          <p class="c-feature-grid__item-body">${escapeHtml(item.body)}</p>`,
+          "        </div>",
+          "      </li>",
+        ]
+          .filter(Boolean)
+          .join("\n");
+      },
     )
     .join("\n");
 
@@ -34,4 +63,3 @@ export const renderFeatureGrid = (data: FeatureGridData): string => {
     "</section>",
   ].join("\n");
 };
-

--- a/src/components/feature-grid/feature-grid.schema.ts
+++ b/src/components/feature-grid/feature-grid.schema.ts
@@ -1,9 +1,12 @@
 import { z } from "zod";
 
+import { ImageReferenceSchema } from "../../schemas/shared.js";
+
 export const FeatureGridItemSchema = z
   .object({
     title: z.string().min(1),
     body: z.string().min(1),
+    image: ImageReferenceSchema.optional(),
   })
   .strict();
 
@@ -16,4 +19,3 @@ export const FeatureGridSchema = z
   .strict();
 
 export type FeatureGridData = z.infer<typeof FeatureGridSchema>;
-

--- a/src/components/feature-grid/feature-grid.test.ts
+++ b/src/components/feature-grid/feature-grid.test.ts
@@ -12,6 +12,11 @@ describe("FeatureGridSchema", () => {
         {
           title: "Strict validation",
           body: "Unknown keys fail.",
+          image: {
+            src: "https://example.com/validation.jpg",
+            alt: "Validation checklist on a desk",
+            caption: "Optional image support keeps content flexible.",
+          },
         },
       ],
     });
@@ -20,6 +25,9 @@ describe("FeatureGridSchema", () => {
 
     expect(html).toContain('<section class="c-feature-grid">');
     expect(html).toContain('<ul class="c-feature-grid__items">');
+    expect(html).toContain('c-feature-grid__item--has-image');
+    expect(html).toContain('<figure class="c-feature-grid__item-media">');
+    expect(html).toContain('src="https://example.com/validation.jpg"');
     expect(html).toContain("Strict validation");
   });
 
@@ -49,5 +57,35 @@ describe("FeatureGridSchema", () => {
       ),
     ).toBe(true);
   });
-});
 
+  it("rejects unknown fields inside an image reference", () => {
+    const result = FeatureGridSchema.safeParse({
+      type: "feature-grid",
+      title: "Why it works",
+      items: [
+        {
+          title: "Strict validation",
+          body: "Unknown keys fail.",
+          image: {
+            src: "https://example.com/validation.jpg",
+            alt: "Validation checklist on a desk",
+            layout: "right",
+          },
+        },
+      ],
+    });
+
+    expect(result.success).toBe(false);
+    if (result.success) {
+      return;
+    }
+
+    expect(
+      result.error.issues.some(
+        (issue) =>
+          issue.code === "unrecognized_keys" &&
+          String(issue.path.join(".")) === "items.0.image",
+      ),
+    ).toBe(true);
+  });
+});

--- a/src/components/media/media.schema.ts
+++ b/src/components/media/media.schema.ts
@@ -1,13 +1,10 @@
 import { z } from "zod";
 
-export const MediaSchema = z
-  .object({
-    type: z.literal("media"),
-    src: z.string().min(1).max(2048),
-    alt: z.string().min(1).max(200),
-    caption: z.string().min(1).max(280).optional(),
-    size: z.enum(["content", "wide"]).default("wide"),
-  })
-  .strict();
+import { ImageReferenceSchema } from "../../schemas/shared.js";
+
+export const MediaSchema = ImageReferenceSchema.extend({
+  type: z.literal("media"),
+  size: z.enum(["content", "wide"]).default("wide"),
+});
 
 export type MediaData = z.infer<typeof MediaSchema>;

--- a/src/schemas/shared.ts
+++ b/src/schemas/shared.ts
@@ -9,3 +9,12 @@ export const LinkSchema = z
 
 export type LinkData = z.infer<typeof LinkSchema>;
 
+export const ImageReferenceSchema = z
+  .object({
+    src: z.string().min(1).max(2048),
+    alt: z.string().min(1).max(200),
+    caption: z.string().min(1).max(280).optional(),
+  })
+  .strict();
+
+export type ImageReferenceData = z.infer<typeof ImageReferenceSchema>;


### PR DESCRIPTION
## Summary
- add a reusable nested image reference schema for component data
- allow feature grid items to render an optional image before the title and body by default
- keep the layout CSS-based so image placement can be overridden without changing markup

## Validation
- npm run check

Closes #37
