### PR TITLE
[codex] Only include used component CSS

### DIFF
--- a/src/build/framework.ts
+++ b/src/build/framework.ts
@@ -262,13 +262,17 @@ const emitSiteCss = (site: SiteData): string => {
   return `:root {\n  --site-page-background-image: url("${escapeCssString(site.pageBackgroundImageUrl)}");\n}\n`;
 };
 
-const renderSiteCss = async (site: SiteData): Promise<string> => {
+const renderSiteCss = async (siteContent: SiteContentData): Promise<string> => {
+  const { site } = siteContent;
   const resolvedTheme = resolveThemeDefinition(themes[site.theme], site.themeOverrides);
+  const usedComponentTypes = collectUsedComponentTypes(siteContent);
   const componentCssChunks = await Promise.all(
-    componentDefinitions.map(async (componentDefinition) => {
-      const css = await readFile(componentDefinition.cssPath, "utf8");
-      return `/* ${componentDefinition.type} */\n${css}`;
-    }),
+    componentDefinitions
+      .filter((componentDefinition) => usedComponentTypes.has(componentDefinition.type))
+      .map(async (componentDefinition) => {
+        const css = await readFile(componentDefinition.cssPath, "utf8");
+        return `/* ${componentDefinition.type} */\n${css}`;
+      }),
   );
 
   const baseCss = await readFile(baseCssPath, "utf8");
@@ -332,7 +336,7 @@ export const buildSite = async (
   await rm(outDir, { recursive: true, force: true });
   await mkdir(path.join(outDir, "assets"), { recursive: true });
 
-  const css = await renderSiteCss(siteContent.site);
+  const css = await renderSiteCss(siteContent);
   const js = renderSiteJs(siteContent);
   await writeFile(path.join(outDir, "assets", "site.css"), css, "utf8");
 

--- a/tests/site-layout.test.ts
+++ b/tests/site-layout.test.ts
@@ -91,6 +91,76 @@ describe("site layout", () => {
     }
   });
 
+  it("only emits CSS for component types used by the built site", async () => {
+    const outDir = await mkdtemp(path.join(os.tmpdir(), "cruftless-layout-css-"));
+    const site = SiteContentSchema.parse({
+      site: {
+        name: "LaunchKit",
+        baseUrl: "https://launchkit.example",
+        theme: "app-announcement",
+        layout: {
+          components: [
+            {
+              type: "prose",
+              title: "Shared header",
+              paragraphs: ["This introduction appears on every page."],
+            },
+            {
+              type: "page-content",
+            },
+          ],
+        },
+      },
+      pages: [
+        {
+          slug: "/",
+          title: "Home",
+          components: [
+            {
+              type: "hero",
+              headline: "Launch faster",
+              primaryCta: {
+                label: "Get started",
+                href: "/start",
+              },
+            },
+          ],
+        },
+        {
+          slug: "/pricing",
+          title: "Pricing",
+          components: [
+            {
+              type: "faq",
+              title: "Pricing FAQ",
+              items: [
+                {
+                  question: "Is there a free plan?",
+                  answer: "Yes, teams can start without a contract.",
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+
+    try {
+      await buildSite(site, outDir);
+
+      const css = await readFile(path.join(outDir, "assets", "site.css"), "utf8");
+
+      expect(css).toContain(".c-prose");
+      expect(css).toContain(".c-hero");
+      expect(css).toContain(".c-faq");
+      expect(css).not.toContain(".c-feature-grid");
+      expect(css).not.toContain(".c-google-maps");
+      expect(css).not.toContain(".c-navbar");
+    } finally {
+      await rm(outDir, { recursive: true, force: true });
+    }
+  });
+
   it("renders a shared navigation bar and emits its measured-collapse runtime", async () => {
     const outDir = await mkdtemp(path.join(os.tmpdir(), "cruftless-navbar-layout-"));
     const site = SiteContentSchema.parse({


### PR DESCRIPTION
## Summary
- filter component CSS chunks to the component types actually used by the site layout or any page
- keep base, theme, and site-level CSS output unchanged
- add a build test that proves used component CSS stays in the bundle and unused component CSS is omitted

## Why
- `renderSiteCss` was appending every component stylesheet even when the site never rendered that component
- the build already computed used component types for JS, so CSS can reuse the same simple filter without adding a more complicated selector-pruning pass

## Validation
- `npm run validate:strict`

Closes #41