### PR TITLE
[codex] Fix primary button hover text

### DIFF
--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -85,6 +85,7 @@ button:focus-visible {
 .c-button--primary:hover {
   border-color: var(--color-link-hover);
   background: var(--color-link-hover);
+  color: var(--color-primary-contrast);
 }
 
 .c-button--secondary:hover {

--- a/tests/component-css-widths.test.ts
+++ b/tests/component-css-widths.test.ts
@@ -47,6 +47,13 @@ describe("component width tokens", () => {
     expect(css).toContain("color: var(--button-secondary-text);");
   });
 
+  it("keeps primary button text readable on hover", async () => {
+    const css = await readBaseCss();
+
+    expect(css).toContain(".c-button--primary:hover {");
+    expect(css).toContain("color: var(--color-primary-contrast);");
+  });
+
   it("keeps google maps width modes split between content and container tokens", async () => {
     const css = await readComponentCss("google-maps");
 


### PR DESCRIPTION
## Summary
- keep primary button text on the contrast color during hover so the label stays readable
- add a focused CSS regression test for the primary hover state

## Why
The global `a:hover` rule was changing button text to `--color-link-hover`, which matches the primary button hover background. That made the label effectively disappear on hover.

## Validation
- `npm test -- --run tests/component-css-widths.test.ts`
- `npm run validate:strict`

Closes #39
