### PR TITLE
[codex] Improve app-announcement example quality

### DIFF
--- a/content/examples/themes/app-announcement.json
+++ b/content/examples/themes/app-announcement.json
@@ -146,8 +146,10 @@
         },
         {
           "type": "media",
-          "src": "https://images.example.com/previews/app-announcement-workspace.jpg",
+          "src": "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 1600 900'%3E%3Crect width='1600' height='900' fill='%23f5efe4'/%3E%3Crect x='120' y='120' width='1360' height='660' rx='28' fill='%23ffffff' stroke='%231f2937' stroke-width='24'/%3E%3Crect x='200' y='220' width='420' height='360' rx='24' fill='%23dbeafe'/%3E%3Crect x='680' y='220' width='620' height='48' rx='24' fill='%231f2937'/%3E%3Crect x='680' y='308' width='520' height='32' rx='16' fill='%236b7280'/%3E%3Crect x='680' y='390' width='560' height='32' rx='16' fill='%239ca3af'/%3E%3Crect x='680' y='490' width='220' height='96' rx='24' fill='%23f59e0b'/%3E%3C/svg%3E",
           "alt": "Sample workspace image used for the app-announcement theme preview",
+          "width": 1600,
+          "height": 900,
           "caption": "Media is included with a caption so image framing and supporting text can be checked together.",
           "size": "wide"
         },

--- a/schemas/site-content.schema.json
+++ b/schemas/site-content.schema.json
@@ -233,6 +233,16 @@
                                           "type": "string",
                                           "minLength": 1,
                                           "maxLength": 280
+                                        },
+                                        "width": {
+                                          "type": "integer",
+                                          "exclusiveMinimum": 0,
+                                          "maximum": 10000
+                                        },
+                                        "height": {
+                                          "type": "integer",
+                                          "exclusiveMinimum": 0,
+                                          "maximum": 10000
                                         }
                                       },
                                       "required": [
@@ -384,6 +394,12 @@
                               },
                               "caption": {
                                 "$ref": "#/definitions/SiteContent/properties/site/properties/layout/properties/components/items/anyOf/0/anyOf/2/properties/items/items/properties/image/properties/caption"
+                              },
+                              "width": {
+                                "$ref": "#/definitions/SiteContent/properties/site/properties/layout/properties/components/items/anyOf/0/anyOf/2/properties/items/items/properties/image/properties/width"
+                              },
+                              "height": {
+                                "$ref": "#/definitions/SiteContent/properties/site/properties/layout/properties/components/items/anyOf/0/anyOf/2/properties/items/items/properties/image/properties/height"
                               },
                               "type": {
                                 "type": "string",

--- a/src/components/feature-grid/feature-grid.render.ts
+++ b/src/components/feature-grid/feature-grid.render.ts
@@ -26,12 +26,17 @@ export const renderFeatureGrid = (data: FeatureGridData): string => {
           itemClasses.push("c-feature-grid__item--has-image");
         }
 
+        const imageDimensions =
+          item.image?.width !== undefined && item.image.height !== undefined
+            ? ` width="${item.image.width}" height="${item.image.height}"`
+            : "";
+
         return [
           `      <li class="${itemClasses.join(" ")}">`,
           item.image
             ? [
                 '        <figure class="c-feature-grid__item-media">',
-                `          <img class="c-feature-grid__item-image" src="${escapeHtml(item.image.src)}" alt="${escapeHtml(item.image.alt)}" />`,
+                `          <img class="c-feature-grid__item-image" src="${escapeHtml(item.image.src)}" alt="${escapeHtml(item.image.alt)}"${imageDimensions} />`,
                 item.image.caption
                   ? `          <figcaption class="c-feature-grid__item-caption">${escapeHtml(item.image.caption)}</figcaption>`
                   : "",

--- a/src/components/feature-grid/feature-grid.test.ts
+++ b/src/components/feature-grid/feature-grid.test.ts
@@ -15,6 +15,8 @@ describe("FeatureGridSchema", () => {
           image: {
             src: "https://example.com/validation.jpg",
             alt: "Validation checklist on a desk",
+            width: 1200,
+            height: 800,
             caption: "Optional image support keeps content flexible.",
           },
         },
@@ -28,6 +30,7 @@ describe("FeatureGridSchema", () => {
     expect(html).toContain('c-feature-grid__item--has-image');
     expect(html).toContain('<figure class="c-feature-grid__item-media">');
     expect(html).toContain('src="https://example.com/validation.jpg"');
+    expect(html).toContain('width="1200" height="800"');
     expect(html).toContain("Strict validation");
   });
 

--- a/src/components/media/media.render.ts
+++ b/src/components/media/media.render.ts
@@ -10,9 +10,14 @@ export const mediaClassNames = [
 ] as const;
 
 export const renderMedia = (data: MediaData): string => {
+  const dimensions =
+    data.width !== undefined && data.height !== undefined
+      ? ` width="${data.width}" height="${data.height}"`
+      : "";
+
   return [
     `<figure class="c-media c-media--size-${escapeHtml(data.size)}">`,
-    `  <img class="c-media__image" src="${escapeHtml(data.src)}" alt="${escapeHtml(data.alt)}" />`,
+    `  <img class="c-media__image" src="${escapeHtml(data.src)}" alt="${escapeHtml(data.alt)}"${dimensions} />`,
     data.caption ? `  <figcaption class="c-media__caption">${escapeHtml(data.caption)}</figcaption>` : "",
     "</figure>",
   ]

--- a/src/components/media/media.test.ts
+++ b/src/components/media/media.test.ts
@@ -9,6 +9,8 @@ describe("MediaSchema", () => {
       type: "media",
       src: "https://example.com/studio.jpg",
       alt: "Founder standing in the studio",
+      width: 1600,
+      height: 900,
       caption: "A real image gives landing pages more character than a card grid alone.",
       size: "content",
     });
@@ -18,6 +20,7 @@ describe("MediaSchema", () => {
     expect(html).toContain('<figure class="c-media c-media--size-content">');
     expect(html).toContain('<img class="c-media__image"');
     expect(html).toContain('alt="Founder standing in the studio"');
+    expect(html).toContain('width="1600" height="900"');
     expect(html).toContain("<figcaption");
   });
 

--- a/src/components/navigation-bar/navigation-bar.render.ts
+++ b/src/components/navigation-bar/navigation-bar.render.ts
@@ -26,6 +26,11 @@ const renderLinkList = (links: NavigationBarData["links"]): string =>
     )
     .join("");
 
+const renderMeasureLinkList = (links: NavigationBarData["links"]): string =>
+  links
+    .map((link) => `<li><span class="c-navbar__link">${escapeHtml(link.label)}</span></li>`)
+    .join("");
+
 const createPanelId = (data: NavigationBarData): string => {
   const seed = JSON.stringify({
     brandText: data.brandText,
@@ -53,6 +58,7 @@ export const renderNavigationBar = (data: NavigationBarData): string => {
     .join("");
   const brandHtml = brandParts ? `<a class="c-navbar__brand" href="/">${brandParts}</a>` : "";
   const linksHtml = renderLinkList(data.links);
+  const measureLinksHtml = renderMeasureLinkList(data.links);
 
   return [
     '<header class="c-navbar" data-js="navigation-bar" data-navigation-bar-mode="inline" data-navigation-bar-open="false">',
@@ -64,7 +70,7 @@ export const renderNavigationBar = (data: NavigationBarData): string => {
     '        <span class="c-navbar__menu-label">Menu</span>',
     '        <span class="c-navbar__menu-icon" aria-hidden="true"><span></span><span></span><span></span></span>',
     "      </button>",
-    `      <nav class="c-navbar__measure" aria-hidden="true"><ul class="c-navbar__list">${linksHtml}</ul></nav>`,
+    `      <nav class="c-navbar__measure" aria-hidden="true"><ul class="c-navbar__list">${measureLinksHtml}</ul></nav>`,
     "    </div>",
     "  </div>",
     `  <nav class="c-navbar__panel" id="${escapeHtml(panelId)}" aria-label="Menu" hidden><ul class="c-navbar__list">${linksHtml}</ul></nav>`,

--- a/src/components/navigation-bar/navigation-bar.test.ts
+++ b/src/components/navigation-bar/navigation-bar.test.ts
@@ -33,6 +33,10 @@ describe("NavigationBarSchema", () => {
     expect(html.indexOf("c-navbar__brand-image")).toBeLessThan(
       html.indexOf("c-navbar__brand-text"),
     );
+    const measureMarkup =
+      html.match(/<nav class="c-navbar__measure" aria-hidden="true">([\s\S]*?)<\/nav>/)?.[1] ?? "";
+    expect(measureMarkup).toContain('<span class="c-navbar__link">Pricing &amp; Plans</span>');
+    expect(measureMarkup).not.toContain("<a ");
     expect(html).not.toContain("<Kit>");
   });
 

--- a/src/schemas/shared.ts
+++ b/src/schemas/shared.ts
@@ -14,6 +14,8 @@ export const ImageReferenceSchema = z
     src: z.string().min(1).max(2048),
     alt: z.string().min(1).max(200),
     caption: z.string().min(1).max(280).optional(),
+    width: z.number().int().positive().max(10000).optional(),
+    height: z.number().int().positive().max(10000).optional(),
   })
   .strict();
 

--- a/tests/app-announcement-theme-example.test.ts
+++ b/tests/app-announcement-theme-example.test.ts
@@ -1,0 +1,46 @@
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { buildSiteFromFile, loadValidatedSite } from "../src/build/framework.js";
+
+const exampleContentPath = path.resolve(
+  process.cwd(),
+  "content/examples/themes/app-announcement.json",
+);
+
+describe("app-announcement theme example", () => {
+  it("renders deterministic media markup and keeps the measuring nav non-interactive", async () => {
+    const siteContent = await loadValidatedSite(exampleContentPath);
+    const media = siteContent.pages[0]?.components.find((component) => component.type === "media");
+
+    expect(siteContent.site.theme).toBe("app-announcement");
+    expect(media).toMatchObject({
+      type: "media",
+      width: 1600,
+      height: 900,
+    });
+
+    const outDir = await mkdtemp(path.join(os.tmpdir(), "app-announcement-theme-"));
+
+    try {
+      await buildSiteFromFile(exampleContentPath, outDir);
+
+      const homeHtml = await readFile(path.join(outDir, "index.html"), "utf8");
+      const measureMarkup =
+        homeHtml.match(/<nav class="c-navbar__measure" aria-hidden="true">([\s\S]*?)<\/nav>/)?.[1] ??
+        "";
+
+      expect(homeHtml).toContain('class="c-media__image"');
+      expect(homeHtml).toContain('src="data:image/svg+xml,');
+      expect(homeHtml).toContain('width="1600" height="900"');
+      expect(homeHtml).not.toContain("images.example.com");
+      expect(measureMarkup).toContain('<span class="c-navbar__link">');
+      expect(measureMarkup).not.toContain("<a ");
+    } finally {
+      await rm(outDir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- fix the app-announcement theme example so it no longer ships a broken placeholder image request
- emit explicit image dimensions for shared media and feature-grid images when the content provides them
- keep the hidden navbar measurement markup non-interactive so it does not trip the aria-hidden Lighthouse audit

## Why
The Lighthouse report for issue #40 pointed at a broken example image, missing image dimensions on the media component, and focusable links inside the hidden navbar measurement nav. Those were generator-side quality issues, so the example page kept reproducing them on every build.

## Impact
The app-announcement example now loads without the console error from `images.example.com`, ships explicit `width` and `height` attributes for the preview image, and avoids the accessibility violation in the hidden measuring nav. Shared media rendering also supports explicit dimensions for other sites that provide them.

## Validation
- `npm run validate:strict`

Fixes #40
