### PR TITLE
Backport shared component updates from sitebyemail

### DIFF
--- a/content/examples/themes/app-announcement.json
+++ b/content/examples/themes/app-announcement.json
@@ -67,6 +67,26 @@
           "align": "start"
         },
         {
+          "type": "link-list",
+          "title": "Theme navigation sample",
+          "lead": "This compact control confirms link-based route pickers render cleanly in the active theme.",
+          "links": [
+            {
+              "label": "App Announcement",
+              "href": "/themes/app-announcement",
+              "current": true
+            },
+            {
+              "label": "Corporate",
+              "href": "/themes/corporate"
+            },
+            {
+              "label": "Studio Industrial",
+              "href": "/themes/studio-industrial"
+            }
+          ]
+        },
+        {
           "type": "feature-list",
           "title": "What this preview is for",
           "items": [
@@ -152,6 +172,14 @@
           "height": 900,
           "caption": "Media is included with a caption so image framing and supporting text can be checked together.",
           "size": "wide"
+        },
+        {
+          "type": "contact-form",
+          "title": "Sample contact form",
+          "intro": "Theme previews also include a form so field spacing and button treatment stay covered.",
+          "action": "/contact",
+          "submitLabel": "Send sample request",
+          "deliveryNote": "This is a preview-only form block used for theme validation."
         },
         {
           "type": "prose",

--- a/content/examples/themes/brutalism.json
+++ b/content/examples/themes/brutalism.json
@@ -67,6 +67,26 @@
           "align": "start"
         },
         {
+          "type": "link-list",
+          "title": "Theme navigation sample",
+          "lead": "This compact control confirms link-based route pickers render cleanly in the active theme.",
+          "links": [
+            {
+              "label": "Brutalism",
+              "href": "/themes/brutalism",
+              "current": true
+            },
+            {
+              "label": "Corporate",
+              "href": "/themes/corporate"
+            },
+            {
+              "label": "Dark SaaS",
+              "href": "/themes/dark-saas"
+            }
+          ]
+        },
+        {
           "type": "feature-list",
           "title": "What this preview is for",
           "items": [
@@ -150,6 +170,14 @@
           "alt": "Sample workspace image used for the brutalism theme preview",
           "caption": "Media is included with a caption so image framing and supporting text can be checked together.",
           "size": "wide"
+        },
+        {
+          "type": "contact-form",
+          "title": "Sample contact form",
+          "intro": "Theme previews also include a form so field spacing and button treatment stay covered.",
+          "action": "/contact",
+          "submitLabel": "Send sample request",
+          "deliveryNote": "This is a preview-only form block used for theme validation."
         },
         {
           "type": "prose",

--- a/content/examples/themes/corporate.json
+++ b/content/examples/themes/corporate.json
@@ -67,6 +67,26 @@
           "align": "start"
         },
         {
+          "type": "link-list",
+          "title": "Theme navigation sample",
+          "lead": "This compact control confirms link-based route pickers render cleanly in the active theme.",
+          "links": [
+            {
+              "label": "Corporate",
+              "href": "/themes/corporate",
+              "current": true
+            },
+            {
+              "label": "Brutalism",
+              "href": "/themes/brutalism"
+            },
+            {
+              "label": "Dark SaaS",
+              "href": "/themes/dark-saas"
+            }
+          ]
+        },
+        {
           "type": "feature-list",
           "title": "What this preview is for",
           "items": [
@@ -150,6 +170,14 @@
           "alt": "Sample workspace image used for the corporate theme preview",
           "caption": "Media is included with a caption so image framing and supporting text can be checked together.",
           "size": "wide"
+        },
+        {
+          "type": "contact-form",
+          "title": "Sample contact form",
+          "intro": "Theme previews also include a form so field spacing and button treatment stay covered.",
+          "action": "/contact",
+          "submitLabel": "Send sample request",
+          "deliveryNote": "This is a preview-only form block used for theme validation."
         },
         {
           "type": "prose",

--- a/content/examples/themes/dark-saas.json
+++ b/content/examples/themes/dark-saas.json
@@ -67,6 +67,26 @@
           "align": "start"
         },
         {
+          "type": "link-list",
+          "title": "Theme navigation sample",
+          "lead": "This compact control confirms link-based route pickers render cleanly in the active theme.",
+          "links": [
+            {
+              "label": "Dark SaaS",
+              "href": "/themes/dark-saas",
+              "current": true
+            },
+            {
+              "label": "Corporate",
+              "href": "/themes/corporate"
+            },
+            {
+              "label": "App Announcement",
+              "href": "/themes/app-announcement"
+            }
+          ]
+        },
+        {
           "type": "feature-list",
           "title": "What this preview is for",
           "items": [
@@ -150,6 +170,14 @@
           "alt": "Sample workspace image used for the dark-saas theme preview",
           "caption": "Media is included with a caption so image framing and supporting text can be checked together.",
           "size": "wide"
+        },
+        {
+          "type": "contact-form",
+          "title": "Sample contact form",
+          "intro": "Theme previews also include a form so field spacing and button treatment stay covered.",
+          "action": "/contact",
+          "submitLabel": "Send sample request",
+          "deliveryNote": "This is a preview-only form block used for theme validation."
         },
         {
           "type": "prose",

--- a/content/examples/themes/studio-industrial.json
+++ b/content/examples/themes/studio-industrial.json
@@ -67,6 +67,26 @@
           "align": "start"
         },
         {
+          "type": "link-list",
+          "title": "Theme navigation sample",
+          "lead": "This compact control confirms link-based route pickers render cleanly in the active theme.",
+          "links": [
+            {
+              "label": "Studio Industrial",
+              "href": "/themes/studio-industrial",
+              "current": true
+            },
+            {
+              "label": "Corporate",
+              "href": "/themes/corporate"
+            },
+            {
+              "label": "App Announcement",
+              "href": "/themes/app-announcement"
+            }
+          ]
+        },
+        {
           "type": "feature-list",
           "title": "What this preview is for",
           "items": [
@@ -150,6 +170,14 @@
           "alt": "Sample workspace image used for the studio-industrial theme preview",
           "caption": "Media is included with a caption so image framing and supporting text can be checked together.",
           "size": "wide"
+        },
+        {
+          "type": "contact-form",
+          "title": "Sample contact form",
+          "intro": "Theme previews also include a form so field spacing and button treatment stay covered.",
+          "action": "/contact",
+          "submitLabel": "Send sample request",
+          "deliveryNote": "This is a preview-only form block used for theme validation."
         },
         {
           "type": "prose",

--- a/schemas/site-content.schema.json
+++ b/schemas/site-content.schema.json
@@ -250,6 +250,12 @@
                                         "alt"
                                       ],
                                       "additionalProperties": false
+                                    },
+                                    "cta": {
+                                      "$ref": "#/definitions/SiteContent/properties/site/properties/layout/properties/components/items/anyOf/0/anyOf/0/properties/primaryCta"
+                                    },
+                                    "selected": {
+                                      "type": "boolean"
                                     }
                                   },
                                   "required": [
@@ -350,6 +356,52 @@
                             "properties": {
                               "type": {
                                 "type": "string",
+                                "const": "contact-form"
+                              },
+                              "title": {
+                                "type": "string",
+                                "minLength": 1,
+                                "maxLength": 120
+                              },
+                              "intro": {
+                                "type": "string",
+                                "minLength": 1,
+                                "maxLength": 280
+                              },
+                              "action": {
+                                "type": "string",
+                                "minLength": 1,
+                                "maxLength": 2048
+                              },
+                              "submitLabel": {
+                                "type": "string",
+                                "minLength": 1,
+                                "maxLength": 40
+                              },
+                              "subject": {
+                                "type": "string",
+                                "minLength": 1,
+                                "maxLength": 120
+                              },
+                              "deliveryNote": {
+                                "type": "string",
+                                "minLength": 1,
+                                "maxLength": 200
+                              }
+                            },
+                            "required": [
+                              "type",
+                              "title",
+                              "action",
+                              "submitLabel"
+                            ],
+                            "additionalProperties": false
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "type": {
+                                "type": "string",
                                 "const": "google-maps"
                               },
                               "embedUrl": {
@@ -380,6 +432,55 @@
                               "type",
                               "embedUrl",
                               "title"
+                            ],
+                            "additionalProperties": false
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "type": {
+                                "type": "string",
+                                "const": "link-list"
+                              },
+                              "title": {
+                                "type": "string",
+                                "minLength": 1,
+                                "maxLength": 120
+                              },
+                              "lead": {
+                                "type": "string",
+                                "minLength": 1,
+                                "maxLength": 280
+                              },
+                              "links": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "properties": {
+                                    "label": {
+                                      "$ref": "#/definitions/SiteContent/properties/site/properties/layout/properties/components/items/anyOf/0/anyOf/0/properties/primaryCta/properties/label"
+                                    },
+                                    "href": {
+                                      "$ref": "#/definitions/SiteContent/properties/site/properties/layout/properties/components/items/anyOf/0/anyOf/0/properties/primaryCta/properties/href"
+                                    },
+                                    "current": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "label",
+                                    "href"
+                                  ],
+                                  "additionalProperties": false
+                                },
+                                "minItems": 1,
+                                "maxItems": 8
+                              }
+                            },
+                            "required": [
+                              "type",
+                              "title",
+                              "links"
                             ],
                             "additionalProperties": false
                           },

--- a/src/components/contact-form/contact-form.css
+++ b/src/components/contact-form/contact-form.css
@@ -1,0 +1,109 @@
+.c-contact-form {
+  padding-block: var(--space-7);
+}
+
+.c-contact-form__inner {
+  width: min(calc(100% - (2 * var(--space-5))), var(--content-max));
+  margin-inline: auto;
+  padding: var(--space-6);
+  display: grid;
+  gap: var(--space-4);
+  border: var(--border-width-2) solid var(--color-border);
+  border-radius: var(--radius-xl);
+  background: var(--surface-background);
+  box-shadow: var(--shadow-sm);
+}
+
+.c-contact-form__title,
+.c-contact-form__intro,
+.c-contact-form__note {
+  margin: 0;
+}
+
+.c-contact-form__title {
+  font-size: var(--font-size-4);
+  font-weight: var(--font-weight-bold);
+  letter-spacing: var(--heading-letter-spacing);
+  line-height: var(--line-height-heading);
+}
+
+.c-contact-form__intro,
+.c-contact-form__note {
+  color: var(--color-text-muted);
+}
+
+.c-contact-form__form,
+.c-contact-form__grid {
+  display: grid;
+  gap: var(--space-4);
+}
+
+.c-contact-form__grid {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.c-contact-form__field {
+  display: grid;
+  gap: var(--space-2);
+}
+
+.c-contact-form__field--full {
+  grid-column: 1 / -1;
+}
+
+.c-contact-form__label {
+  font-size: var(--font-size-0);
+  font-weight: var(--font-weight-semibold);
+  letter-spacing: 0.01rem;
+}
+
+.c-contact-form__input,
+.c-contact-form__textarea {
+  width: 100%;
+  padding: var(--space-3);
+  border: var(--border-width-2) solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-surface);
+  color: var(--color-text);
+  font-family: var(--font-family-body);
+  font-size: var(--font-size-1);
+  line-height: var(--line-height-body);
+}
+
+.c-contact-form__textarea {
+  min-height: 10rem;
+}
+
+.c-contact-form__input:focus,
+.c-contact-form__textarea:focus {
+  outline: 3px solid var(--color-focus-ring);
+  outline-offset: 2px;
+  border-color: var(--color-primary);
+}
+
+.c-contact-form__actions {
+  display: grid;
+  gap: var(--space-3);
+}
+
+.c-contact-form__submit {
+  place-self: start;
+}
+
+.c-contact-form__honeypot {
+  position: absolute;
+  left: -10000px;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+}
+
+@media (width <= 48rem) {
+  .c-contact-form__grid {
+    grid-template-columns: 1fr;
+  }
+
+  .c-contact-form__field--full {
+    grid-column: auto;
+  }
+}

--- a/src/components/contact-form/contact-form.render.ts
+++ b/src/components/contact-form/contact-form.render.ts
@@ -1,0 +1,73 @@
+import type { ContactFormData } from "./contact-form.schema.js";
+import { escapeHtml } from "../../renderer/escape-html.js";
+
+export const contactFormClassNames = [
+  "c-contact-form",
+  "c-contact-form__inner",
+  "c-contact-form__title",
+  "c-contact-form__intro",
+  "c-contact-form__form",
+  "c-contact-form__grid",
+  "c-contact-form__field",
+  "c-contact-form__field--full",
+  "c-contact-form__label",
+  "c-contact-form__input",
+  "c-contact-form__textarea",
+  "c-contact-form__actions",
+  "c-contact-form__note",
+  "c-contact-form__honeypot",
+  "c-contact-form__submit",
+  "c-contact-form__legend",
+] as const;
+
+export const renderContactForm = (data: ContactFormData): string => {
+  const subjectHtml = data.subject
+    ? `    <input type="hidden" name="subject" value="${escapeHtml(data.subject)}">`
+    : "";
+
+  return [
+    '<section class="c-contact-form">',
+    '  <div class="c-contact-form__inner">',
+    `    <h2 class="c-contact-form__title">${escapeHtml(data.title)}</h2>`,
+    data.intro ? `    <p class="c-contact-form__intro">${escapeHtml(data.intro)}</p>` : "",
+    `    <form class="c-contact-form__form" action="${escapeHtml(data.action)}" method="post">`,
+    subjectHtml,
+    '      <div class="c-contact-form__honeypot" aria-hidden="true">',
+    '        <label class="c-contact-form__label" for="contact-website">Website</label>',
+    '        <input class="c-contact-form__input" id="contact-website" name="website" type="text" tabindex="-1" autocomplete="off">',
+    "      </div>",
+    '      <div class="c-contact-form__grid">',
+    '        <div class="c-contact-form__field">',
+    '          <label class="c-contact-form__label" for="contact-name">Name</label>',
+    '          <input class="c-contact-form__input" id="contact-name" name="name" type="text" autocomplete="name" required>',
+    "        </div>",
+    '        <div class="c-contact-form__field">',
+    '          <label class="c-contact-form__label" for="contact-email">Email</label>',
+    '          <input class="c-contact-form__input" id="contact-email" name="email" type="email" autocomplete="email" required>',
+    "        </div>",
+    '        <div class="c-contact-form__field">',
+    '          <label class="c-contact-form__label" for="contact-business">Business name</label>',
+    '          <input class="c-contact-form__input" id="contact-business" name="businessName" type="text" autocomplete="organization">',
+    "        </div>",
+    '        <div class="c-contact-form__field">',
+    '          <label class="c-contact-form__label" for="contact-phone">Phone</label>',
+    '          <input class="c-contact-form__input" id="contact-phone" name="phone" type="tel" autocomplete="tel">',
+    "        </div>",
+    '        <div class="c-contact-form__field c-contact-form__field--full">',
+    '          <label class="c-contact-form__label" for="contact-message">What do you need help with?</label>',
+    '          <textarea class="c-contact-form__textarea" id="contact-message" name="message" rows="7" required></textarea>',
+    "        </div>",
+    "      </div>",
+    '      <div class="c-contact-form__actions">',
+    `        <button class="c-button c-button--primary c-contact-form__submit" type="submit">${escapeHtml(data.submitLabel)}</button>`,
+    data.deliveryNote
+      ? `        <p class="c-contact-form__note">${escapeHtml(data.deliveryNote)}</p>`
+      : "",
+    "      </div>",
+    "    </form>",
+    "  </div>",
+    "</section>",
+  ]
+    .filter(Boolean)
+    .join("\n");
+};

--- a/src/components/contact-form/contact-form.schema.ts
+++ b/src/components/contact-form/contact-form.schema.ts
@@ -1,0 +1,15 @@
+import { z } from "zod";
+
+export const ContactFormSchema = z
+  .object({
+    type: z.literal("contact-form"),
+    title: z.string().min(1).max(120),
+    intro: z.string().min(1).max(280).optional(),
+    action: z.string().min(1).max(2048),
+    submitLabel: z.string().min(1).max(40),
+    subject: z.string().min(1).max(120).optional(),
+    deliveryNote: z.string().min(1).max(200).optional(),
+  })
+  .strict();
+
+export type ContactFormData = z.infer<typeof ContactFormSchema>;

--- a/src/components/contact-form/contact-form.test.ts
+++ b/src/components/contact-form/contact-form.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+
+import { renderContactForm } from "./contact-form.render.js";
+import { ContactFormSchema } from "./contact-form.schema.js";
+
+describe("ContactFormSchema", () => {
+  it("accepts valid content and renders a working form shell", () => {
+    const parsed = ContactFormSchema.parse({
+      type: "contact-form",
+      title: "Tell me about your business",
+      intro: "Share a few details and I will reply by email.",
+      action: "/api/contact",
+      submitLabel: "Send inquiry",
+      subject: "New brochure site inquiry",
+      deliveryNote: "Messages are routed through Cloudflare and answered by email.",
+    });
+
+    const html = renderContactForm(parsed);
+
+    expect(html).toContain('<section class="c-contact-form">');
+    expect(html).toContain('action="/api/contact"');
+    expect(html).toContain('name="message"');
+    expect(html).toContain("Send inquiry");
+    expect(html).toContain('type="hidden" name="subject" value="New brochure site inquiry"');
+  });
+
+  it("rejects unknown fields and missing action", () => {
+    const extraField = ContactFormSchema.safeParse({
+      type: "contact-form",
+      title: "Tell me about your business",
+      action: "/api/contact",
+      submitLabel: "Send inquiry",
+      theme: "loud",
+    });
+
+    expect(extraField.success).toBe(false);
+    if (extraField.success) {
+      return;
+    }
+
+    expect(extraField.error.issues[0]?.code).toBe("unrecognized_keys");
+
+    const missingAction = ContactFormSchema.safeParse({
+      type: "contact-form",
+      title: "Tell me about your business",
+      submitLabel: "Send inquiry",
+    });
+
+    expect(missingAction.success).toBe(false);
+    if (missingAction.success) {
+      return;
+    }
+
+    expect(
+      missingAction.error.issues.some(
+        (issue) => String(issue.path.join(".")) === "action",
+      ),
+    ).toBe(true);
+  });
+});

--- a/src/components/feature-grid/feature-grid.css
+++ b/src/components/feature-grid/feature-grid.css
@@ -36,6 +36,10 @@
   box-shadow: var(--shadow-sm);
 }
 
+.c-feature-grid__item--selected {
+  border-color: var(--color-primary);
+}
+
 .c-feature-grid__item--has-image {
   grid-template-columns: minmax(4.5rem, 5.5rem) minmax(0, 1fr);
   align-items: start;
@@ -75,4 +79,18 @@
 .c-feature-grid__item-body {
   margin: 0;
   color: var(--color-text-muted);
+}
+
+.c-feature-grid__item-status {
+  margin: 0;
+  color: var(--color-primary);
+  font-family: var(--font-family-heading);
+  font-size: var(--font-size-0);
+  font-weight: var(--font-weight-semibold);
+  letter-spacing: var(--button-letter-spacing);
+}
+
+.c-feature-grid__item-cta {
+  width: fit-content;
+  place-self: start;
 }

--- a/src/components/feature-grid/feature-grid.render.ts
+++ b/src/components/feature-grid/feature-grid.render.ts
@@ -8,12 +8,15 @@ export const featureGridClassNames = [
   "c-feature-grid__items",
   "c-feature-grid__item",
   "c-feature-grid__item--has-image",
+  "c-feature-grid__item--selected",
   "c-feature-grid__item-media",
   "c-feature-grid__item-image",
   "c-feature-grid__item-caption",
   "c-feature-grid__item-copy",
   "c-feature-grid__item-title",
   "c-feature-grid__item-body",
+  "c-feature-grid__item-status",
+  "c-feature-grid__item-cta",
 ] as const;
 
 export const renderFeatureGrid = (data: FeatureGridData): string => {
@@ -24,6 +27,10 @@ export const renderFeatureGrid = (data: FeatureGridData): string => {
 
         if (item.image) {
           itemClasses.push("c-feature-grid__item--has-image");
+        }
+
+        if (item.selected) {
+          itemClasses.push("c-feature-grid__item--selected");
         }
 
         const imageDimensions =
@@ -48,6 +55,12 @@ export const renderFeatureGrid = (data: FeatureGridData): string => {
           '        <div class="c-feature-grid__item-copy">',
           `          <h3 class="c-feature-grid__item-title">${escapeHtml(item.title)}</h3>`,
           `          <p class="c-feature-grid__item-body">${escapeHtml(item.body)}</p>`,
+          item.selected
+            ? '          <p class="c-feature-grid__item-status" aria-current="page">Current selection</p>'
+            : "",
+          item.cta
+            ? `          <a class="c-feature-grid__item-cta c-button c-button--secondary" href="${escapeHtml(item.cta.href)}">${escapeHtml(item.cta.label)}</a>`
+            : "",
           "        </div>",
           "      </li>",
         ]

--- a/src/components/feature-grid/feature-grid.schema.ts
+++ b/src/components/feature-grid/feature-grid.schema.ts
@@ -1,12 +1,14 @@
 import { z } from "zod";
 
-import { ImageReferenceSchema } from "../../schemas/shared.js";
+import { ImageReferenceSchema, LinkSchema } from "../../schemas/shared.js";
 
 export const FeatureGridItemSchema = z
   .object({
     title: z.string().min(1),
     body: z.string().min(1),
     image: ImageReferenceSchema.optional(),
+    cta: LinkSchema.optional(),
+    selected: z.boolean().optional(),
   })
   .strict();
 

--- a/src/components/feature-grid/feature-grid.test.ts
+++ b/src/components/feature-grid/feature-grid.test.ts
@@ -19,6 +19,11 @@ describe("FeatureGridSchema", () => {
             height: 800,
             caption: "Optional image support keeps content flexible.",
           },
+          selected: true,
+          cta: {
+            label: "See examples",
+            href: "/examples",
+          },
         },
       ],
     });
@@ -31,7 +36,11 @@ describe("FeatureGridSchema", () => {
     expect(html).toContain('<figure class="c-feature-grid__item-media">');
     expect(html).toContain('src="https://example.com/validation.jpg"');
     expect(html).toContain('width="1200" height="800"');
+    expect(html).toContain("Current selection");
     expect(html).toContain("Strict validation");
+    expect(html).toContain('class="c-feature-grid__item-cta c-button c-button--secondary"');
+    expect(html).toContain('href="/examples"');
+    expect(html).toContain("See examples");
   });
 
   it("rejects nested unknown fields", () => {
@@ -88,6 +97,37 @@ describe("FeatureGridSchema", () => {
         (issue) =>
           issue.code === "unrecognized_keys" &&
           String(issue.path.join(".")) === "items.0.image",
+      ),
+    ).toBe(true);
+  });
+
+  it("rejects unknown fields inside an item CTA", () => {
+    const result = FeatureGridSchema.safeParse({
+      type: "feature-grid",
+      title: "Why it works",
+      items: [
+        {
+          title: "Strict validation",
+          body: "Unknown keys fail.",
+          cta: {
+            label: "See examples",
+            href: "/examples",
+            tone: "quiet",
+          },
+        },
+      ],
+    });
+
+    expect(result.success).toBe(false);
+    if (result.success) {
+      return;
+    }
+
+    expect(
+      result.error.issues.some(
+        (issue) =>
+          issue.code === "unrecognized_keys" &&
+          String(issue.path.join(".")) === "items.0.cta",
       ),
     ).toBe(true);
   });

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,6 +1,13 @@
 import { fileURLToPath } from "node:url";
 import { z } from "zod";
 
+import {
+  ContactFormSchema,
+} from "./contact-form/contact-form.schema.js";
+import {
+  contactFormClassNames,
+  renderContactForm,
+} from "./contact-form/contact-form.render.js";
 import { CtaBandSchema } from "./cta-band/cta-band.schema.js";
 import { ctaBandClassNames, renderCtaBand } from "./cta-band/cta-band.render.js";
 import { FaqSchema } from "./faq/faq.schema.js";
@@ -24,6 +31,8 @@ import {
 } from "./google-maps/google-maps.render.js";
 import { HeroSchema, HeroSchemaBase } from "./hero/hero.schema.js";
 import { heroClassNames, renderHero } from "./hero/hero.render.js";
+import { LinkListSchema } from "./link-list/link-list.schema.js";
+import { linkListClassNames, renderLinkList } from "./link-list/link-list.render.js";
 import { MediaSchema } from "./media/media.schema.js";
 import { mediaClassNames, renderMedia } from "./media/media.render.js";
 import {
@@ -48,7 +57,9 @@ export const ComponentSchemaBase = z.discriminatedUnion("type", [
   FeatureGridSchema,
   FaqSchema,
   CtaBandSchema,
+  ContactFormSchema,
   GoogleMapsSchema,
+  LinkListSchema,
   MediaSchema,
   NavigationBarSchemaBase,
   ProseSchema,
@@ -118,10 +129,22 @@ export const componentDefinitions: readonly ComponentDefinition[] = [
     classNames: ctaBandClassNames,
   },
   {
+    type: "contact-form",
+    render: (data) => renderContactForm(ContactFormSchema.parse(data)),
+    cssPath: fileURLToPath(new URL("./contact-form/contact-form.css", import.meta.url)),
+    classNames: contactFormClassNames,
+  },
+  {
     type: "google-maps",
     render: (data) => renderGoogleMaps(GoogleMapsSchema.parse(data)),
     cssPath: fileURLToPath(new URL("./google-maps/google-maps.css", import.meta.url)),
     classNames: googleMapsClassNames,
+  },
+  {
+    type: "link-list",
+    render: (data) => renderLinkList(LinkListSchema.parse(data)),
+    cssPath: fileURLToPath(new URL("./link-list/link-list.css", import.meta.url)),
+    classNames: linkListClassNames,
   },
   {
     type: "media",
@@ -160,8 +183,12 @@ export const renderComponent = (data: ComponentData): string => {
       return renderFaq(data);
     case "cta-band":
       return renderCtaBand(data);
+    case "contact-form":
+      return renderContactForm(data);
     case "google-maps":
       return renderGoogleMaps(data);
+    case "link-list":
+      return renderLinkList(data);
     case "media":
       return renderMedia(data);
     case "navigation-bar":

--- a/src/components/link-list/link-list.css
+++ b/src/components/link-list/link-list.css
@@ -1,0 +1,47 @@
+.c-link-list {
+  padding-block: var(--space-7);
+}
+
+.c-link-list__inner {
+  width: min(calc(100% - (2 * var(--space-5))), var(--content-max));
+  margin-inline: auto;
+  display: grid;
+  gap: var(--space-4);
+}
+
+.c-link-list__title,
+.c-link-list__lead {
+  margin: 0;
+}
+
+.c-link-list__title {
+  font-size: var(--font-size-4);
+  line-height: var(--line-height-heading);
+}
+
+.c-link-list__lead {
+  color: var(--color-text-muted);
+  font-size: var(--font-size-2);
+  line-height: var(--line-height-loose);
+}
+
+.c-link-list__links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-3);
+  padding: 0;
+  margin: 0;
+  list-style: none;
+}
+
+.c-link-list__item {
+  margin: 0;
+}
+
+.c-link-list__link {
+  min-width: 11rem;
+}
+
+.c-link-list__link--current {
+  cursor: default;
+}

--- a/src/components/link-list/link-list.render.ts
+++ b/src/components/link-list/link-list.render.ts
@@ -1,0 +1,41 @@
+import { escapeHtml } from "../../renderer/escape-html.js";
+import type { LinkListData } from "./link-list.schema.js";
+
+export const linkListClassNames = [
+  "c-link-list",
+  "c-link-list__inner",
+  "c-link-list__title",
+  "c-link-list__lead",
+  "c-link-list__links",
+  "c-link-list__item",
+  "c-link-list__link",
+  "c-link-list__link--current",
+] as const;
+
+export const renderLinkList = (data: LinkListData): string => {
+  const linksHtml = data.links
+    .map((link) =>
+      [
+        '      <li class="c-link-list__item">',
+        link.current
+          ? `        <span class="c-button c-button--primary c-link-list__link c-link-list__link--current" aria-current="page">${escapeHtml(link.label)}</span>`
+          : `        <a class="c-button c-button--secondary c-link-list__link" href="${escapeHtml(link.href)}">${escapeHtml(link.label)}</a>`,
+        "      </li>",
+      ].join("\n"),
+    )
+    .join("\n");
+
+  return [
+    '<section class="c-link-list">',
+    '  <div class="c-link-list__inner">',
+    `    <h2 class="c-link-list__title">${escapeHtml(data.title)}</h2>`,
+    data.lead ? `    <p class="c-link-list__lead">${escapeHtml(data.lead)}</p>` : "",
+    '    <ul class="c-link-list__links">',
+    linksHtml,
+    "    </ul>",
+    "  </div>",
+    "</section>",
+  ]
+    .filter(Boolean)
+    .join("\n");
+};

--- a/src/components/link-list/link-list.schema.ts
+++ b/src/components/link-list/link-list.schema.ts
@@ -1,0 +1,18 @@
+import { z } from "zod";
+
+import { LinkSchema } from "../../schemas/shared.js";
+
+export const LinkListItemSchema = LinkSchema.extend({
+  current: z.boolean().optional(),
+});
+
+export const LinkListSchema = z
+  .object({
+    type: z.literal("link-list"),
+    title: z.string().min(1).max(120),
+    lead: z.string().min(1).max(280).optional(),
+    links: z.array(LinkListItemSchema).min(1).max(8),
+  })
+  .strict();
+
+export type LinkListData = z.infer<typeof LinkListSchema>;

--- a/src/components/link-list/link-list.test.ts
+++ b/src/components/link-list/link-list.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+
+import { renderLinkList } from "./link-list.render.js";
+import { LinkListSchema } from "./link-list.schema.js";
+
+describe("LinkListSchema", () => {
+  it("accepts valid content and renders current and linked options", () => {
+    const parsed = LinkListSchema.parse({
+      type: "link-list",
+      title: "View this example in another style",
+      lead: "Each option opens a prebuilt sibling page.",
+      links: [
+        {
+          label: "Corporate",
+          href: "/examples/automotive/corporate/",
+          current: true,
+        },
+        {
+          label: "Brutalism",
+          href: "/examples/automotive/brutalism/",
+        },
+      ],
+    });
+
+    const html = renderLinkList(parsed);
+
+    expect(html).toContain('<section class="c-link-list">');
+    expect(html).toContain('aria-current="page"');
+    expect(html).toContain('href="/examples/automotive/brutalism/"');
+    expect(html).toContain("prebuilt sibling page");
+  });
+
+  it("rejects unknown fields inside a link item", () => {
+    const result = LinkListSchema.safeParse({
+      type: "link-list",
+      title: "View this example in another style",
+      links: [
+        {
+          label: "Corporate",
+          href: "/examples/automotive/corporate/",
+          active: true,
+        },
+      ],
+    });
+
+    expect(result.success).toBe(false);
+    if (result.success) {
+      return;
+    }
+
+    expect(
+      result.error.issues.some(
+        (issue) =>
+          issue.code === "unrecognized_keys" &&
+          String(issue.path.join(".")) === "links.0",
+      ),
+    ).toBe(true);
+  });
+});

--- a/tests/component-css-widths.test.ts
+++ b/tests/component-css-widths.test.ts
@@ -12,6 +12,7 @@ const readBaseCss = async () => readFile(path.join(repoRoot, "src", "styles", "b
 describe("component width tokens", () => {
   it("uses content-max for standard component wrappers", async () => {
     const standardComponents = [
+      "contact-form",
       "cta-band",
       "faq",
       "feature-grid",


### PR DESCRIPTION
## Summary
- backport the generic `contact-form` and `link-list` components from `sitebyemail.com`
- backport the shared `feature-grid` CTA and selected-state support
- update theme example fixtures and the generated schema so every shared component stays covered upstream

## Validation
- npm run validate:strict