### PR TITLE
Add dist link validation for built sites

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@ The strict validation entrypoint is meant to catch real regressions, not just sy
 - example-site validation
 - default-site build
 - example-site builds
+- same-site relative reference checks in the built `dist/` output
 
 If you change the schema, component registry, theme tokens, renderer behavior, or example content, run `npm run validate:strict`.
 

--- a/content/examples/78th-street-studios.json
+++ b/content/examples/78th-street-studios.json
@@ -16,11 +16,11 @@
           "links": [
             {
               "label": "Home",
-              "href": "/"
+              "href": "/78th-street-studios/"
             },
             {
               "label": "About",
-              "href": "/about"
+              "href": "/78th-street-studios/about"
             },
             {
               "label": "Plan a Visit",
@@ -80,7 +80,7 @@
           "subheadline": "A 170,000-square-foot Cleveland landmark filled with galleries, artist studios, performance spaces, recording rooms, and year-round events.",
           "primaryCta": {
             "label": "Explore the Story",
-            "href": "/about"
+            "href": "/78th-street-studios/about"
           },
           "secondaryCta": {
             "label": "Plan a Visit",
@@ -149,7 +149,7 @@
           },
           "secondaryCta": {
             "label": "Back Home",
-            "href": "/"
+            "href": "/78th-street-studios/"
           },
           "align": "start"
         },

--- a/content/examples/baird-automotive.json
+++ b/content/examples/baird-automotive.json
@@ -15,23 +15,23 @@
           "links": [
             {
               "label": "Home",
-              "href": "/"
+              "href": "/baird-automotive/"
             },
             {
               "label": "Our Story",
-              "href": "/our-story"
+              "href": "/baird-automotive/our-story"
             },
             {
               "label": "Services",
-              "href": "/services"
+              "href": "/baird-automotive/services"
             },
             {
               "label": "Community",
-              "href": "/in-the-community"
+              "href": "/baird-automotive/in-the-community"
             },
             {
               "label": "Contact",
-              "href": "/contact"
+              "href": "/baird-automotive/contact"
             }
           ]
         },
@@ -48,7 +48,7 @@
           },
           "secondaryCta": {
             "label": "Review Services",
-            "href": "/services"
+            "href": "/baird-automotive/services"
           }
         },
         {
@@ -77,11 +77,11 @@
           "subheadline": "Baird Automotive presents itself as a professional, honest repair shop serving Northern Virginia drivers with diagnostics, maintenance, and long-term customer care.",
           "primaryCta": {
             "label": "Review Services",
-            "href": "/services"
+            "href": "/baird-automotive/services"
           },
           "secondaryCta": {
             "label": "Contact the Shop",
-            "href": "/contact"
+            "href": "/baird-automotive/contact"
           },
           "align": "start"
         },
@@ -187,7 +187,7 @@
           },
           "secondaryCta": {
             "label": "Read Our Story",
-            "href": "/our-story"
+            "href": "/baird-automotive/our-story"
           }
         }
       ]
@@ -206,11 +206,11 @@
           "subheadline": "The story page traces Baird Automotive from its 1992 opening through repeat recognition in regional publications and a team with more than 100 years of combined experience.",
           "primaryCta": {
             "label": "See Services",
-            "href": "/services"
+            "href": "/baird-automotive/services"
           },
           "secondaryCta": {
             "label": "Back Home",
-            "href": "/"
+            "href": "/baird-automotive/"
           },
           "align": "start"
         },
@@ -292,11 +292,11 @@
           "body": "The live site keeps steering visitors back toward practical next steps: services, appointments, and direct contact.",
           "primaryCta": {
             "label": "Review Services",
-            "href": "/services"
+            "href": "/baird-automotive/services"
           },
           "secondaryCta": {
             "label": "Contact Baird",
-            "href": "/contact"
+            "href": "/baird-automotive/contact"
           }
         }
       ]
@@ -315,11 +315,11 @@
           "subheadline": "Baird Automotive says its technicians handle scheduled maintenance, repair work, performance problems, check engine lights, and electrical diagnostics for a broad mix of vehicles.",
           "primaryCta": {
             "label": "Contact the Shop",
-            "href": "/contact"
+            "href": "/baird-automotive/contact"
           },
           "secondaryCta": {
             "label": "Back Home",
-            "href": "/"
+            "href": "/baird-automotive/"
           },
           "align": "start"
         },
@@ -435,7 +435,7 @@
           },
           "secondaryCta": {
             "label": "Visit Contact Page",
-            "href": "/contact"
+            "href": "/baird-automotive/contact"
           }
         }
       ]
@@ -454,11 +454,11 @@
           "subheadline": "The community page focuses on local schools, kids' programs, Arlington events, and endurance-sport sponsorships tied to Joey Baird and the shop.",
           "primaryCta": {
             "label": "Contact the Shop",
-            "href": "/contact"
+            "href": "/baird-automotive/contact"
           },
           "secondaryCta": {
             "label": "Back Home",
-            "href": "/"
+            "href": "/baird-automotive/"
           },
           "align": "start"
         },

--- a/content/examples/themes/brutalism.json
+++ b/content/examples/themes/brutalism.json
@@ -9,9 +9,9 @@
           "type": "navigation-bar",
           "brandText": "Brutalism",
           "links": [
-            { "label": "Preview", "href": "/" },
-            { "label": "Theme List", "href": "/themes" },
-            { "label": "Validate", "href": "/commands/validate-examples" }
+            { "label": "Preview", "href": "/examples/brutalism/" },
+            { "label": "Theme List", "href": "/examples/" },
+            { "label": "Pricing", "href": "/pricing" }
           ]
         },
         {
@@ -42,7 +42,7 @@
           "headline": "Brutalism theme preview",
           "subheadline": "Blunt hierarchy, thick borders, and loud contrast on one review page.",
           "primaryCta": { "label": "Jump to examples", "href": "#examples" },
-          "secondaryCta": { "label": "See theme list", "href": "/themes" },
+          "secondaryCta": { "label": "See all previews", "href": "/examples/" },
           "align": "start"
         },
         {
@@ -50,9 +50,9 @@
           "title": "Theme navigation sample",
           "lead": "This compact control confirms route pickers stay readable in the active theme.",
           "links": [
-            { "label": "Brutalism", "href": "/themes/brutalism", "current": true },
-            { "label": "High-Vis Service", "href": "/themes/high-vis-service" },
-            { "label": "Workshop", "href": "/themes/workshop" }
+            { "label": "Brutalism", "href": "/examples/brutalism/", "current": true },
+            { "label": "High-Vis Service", "href": "/examples/high-vis-service/" },
+            { "label": "Workshop", "href": "/examples/workshop/" }
           ]
         },
         {
@@ -87,8 +87,8 @@
           "type": "cta-band",
           "headline": "Build every theme example at once",
           "body": "Run the bulk examples build to regenerate the full preview set into dist/examples.",
-          "primaryCta": { "label": "Run build:examples", "href": "/commands/build-examples" },
-          "secondaryCta": { "label": "Run validate:examples", "href": "/commands/validate-examples" }
+          "primaryCta": { "label": "Browse all previews", "href": "/examples/" },
+          "secondaryCta": { "label": "See pricing", "href": "/pricing" }
         },
         {
           "type": "google-maps",

--- a/content/examples/themes/corporate.json
+++ b/content/examples/themes/corporate.json
@@ -9,9 +9,9 @@
           "type": "navigation-bar",
           "brandText": "Corporate",
           "links": [
-            { "label": "Preview", "href": "/" },
-            { "label": "Theme List", "href": "/themes" },
-            { "label": "Validate", "href": "/commands/validate-examples" }
+            { "label": "Preview", "href": "/examples/corporate/" },
+            { "label": "Theme List", "href": "/examples/" },
+            { "label": "Pricing", "href": "/pricing" }
           ]
         },
         {
@@ -42,7 +42,7 @@
           "headline": "Corporate theme preview",
           "subheadline": "Trust-first hierarchy, restrained surfaces, and clear calls to action on one review page.",
           "primaryCta": { "label": "Jump to examples", "href": "#examples" },
-          "secondaryCta": { "label": "See theme list", "href": "/themes" },
+          "secondaryCta": { "label": "See all previews", "href": "/examples/" },
           "align": "start"
         },
         {
@@ -50,9 +50,9 @@
           "title": "Theme navigation sample",
           "lead": "This compact control confirms route pickers stay readable in the active theme.",
           "links": [
-            { "label": "Corporate", "href": "/themes/corporate", "current": true },
-            { "label": "Workshop", "href": "/themes/workshop" },
-            { "label": "Friendly Modern", "href": "/themes/friendly-modern" }
+            { "label": "Corporate", "href": "/examples/corporate/", "current": true },
+            { "label": "Workshop", "href": "/examples/workshop/" },
+            { "label": "Friendly Modern", "href": "/examples/friendly-modern/" }
           ]
         },
         {
@@ -87,8 +87,8 @@
           "type": "cta-band",
           "headline": "Build every theme example at once",
           "body": "Run the bulk examples build to regenerate the full preview set into dist/examples.",
-          "primaryCta": { "label": "Run build:examples", "href": "/commands/build-examples" },
-          "secondaryCta": { "label": "Run validate:examples", "href": "/commands/validate-examples" }
+          "primaryCta": { "label": "Browse all previews", "href": "/examples/" },
+          "secondaryCta": { "label": "See pricing", "href": "/pricing" }
         },
         {
           "type": "google-maps",

--- a/content/examples/themes/friendly-modern.json
+++ b/content/examples/themes/friendly-modern.json
@@ -9,9 +9,9 @@
           "type": "navigation-bar",
           "brandText": "Friendly Modern",
           "links": [
-            { "label": "Preview", "href": "/" },
-            { "label": "Theme List", "href": "/themes" },
-            { "label": "Validate", "href": "/commands/validate-examples" }
+            { "label": "Preview", "href": "/examples/friendly-modern/" },
+            { "label": "Theme List", "href": "/examples/" },
+            { "label": "Pricing", "href": "/pricing" }
           ]
         },
         {
@@ -42,7 +42,7 @@
           "headline": "Friendly Modern theme preview",
           "subheadline": "Approachable service styling, rounded surfaces, and bright calls to action on one review page.",
           "primaryCta": { "label": "Jump to examples", "href": "#examples" },
-          "secondaryCta": { "label": "See theme list", "href": "/themes" },
+          "secondaryCta": { "label": "See all previews", "href": "/examples/" },
           "align": "start"
         },
         {
@@ -50,9 +50,9 @@
           "title": "Theme navigation sample",
           "lead": "This compact control confirms route pickers stay readable in the active theme.",
           "links": [
-            { "label": "Friendly Modern", "href": "/themes/friendly-modern", "current": true },
-            { "label": "Corporate", "href": "/themes/corporate" },
-            { "label": "Wellness Calm", "href": "/themes/wellness-calm" }
+            { "label": "Friendly Modern", "href": "/examples/friendly-modern/", "current": true },
+            { "label": "Corporate", "href": "/examples/corporate/" },
+            { "label": "Wellness Calm", "href": "/examples/wellness-calm/" }
           ]
         },
         {
@@ -87,8 +87,8 @@
           "type": "cta-band",
           "headline": "Build every theme example at once",
           "body": "Run the bulk examples build to regenerate the full preview set into dist/examples.",
-          "primaryCta": { "label": "Run build:examples", "href": "/commands/build-examples" },
-          "secondaryCta": { "label": "Run validate:examples", "href": "/commands/validate-examples" }
+          "primaryCta": { "label": "Browse all previews", "href": "/examples/" },
+          "secondaryCta": { "label": "See pricing", "href": "/pricing" }
         },
         {
           "type": "google-maps",

--- a/content/examples/themes/heritage-local.json
+++ b/content/examples/themes/heritage-local.json
@@ -9,9 +9,9 @@
           "type": "navigation-bar",
           "brandText": "Heritage Local",
           "links": [
-            { "label": "Preview", "href": "/" },
-            { "label": "Theme List", "href": "/themes" },
-            { "label": "Validate", "href": "/commands/validate-examples" }
+            { "label": "Preview", "href": "/examples/heritage-local/" },
+            { "label": "Theme List", "href": "/examples/" },
+            { "label": "Pricing", "href": "/pricing" }
           ]
         },
         {
@@ -42,7 +42,7 @@
           "headline": "Heritage Local theme preview",
           "subheadline": "Classic typography, framed sections, and long-running-business tone on one review page.",
           "primaryCta": { "label": "Jump to examples", "href": "#examples" },
-          "secondaryCta": { "label": "See theme list", "href": "/themes" },
+          "secondaryCta": { "label": "See all previews", "href": "/examples/" },
           "align": "start"
         },
         {
@@ -50,9 +50,9 @@
           "title": "Theme navigation sample",
           "lead": "This compact control confirms route pickers stay readable in the active theme.",
           "links": [
-            { "label": "Heritage Local", "href": "/themes/heritage-local", "current": true },
-            { "label": "Corporate", "href": "/themes/corporate" },
-            { "label": "Workshop", "href": "/themes/workshop" }
+            { "label": "Heritage Local", "href": "/examples/heritage-local/", "current": true },
+            { "label": "Corporate", "href": "/examples/corporate/" },
+            { "label": "Workshop", "href": "/examples/workshop/" }
           ]
         },
         {
@@ -87,8 +87,8 @@
           "type": "cta-band",
           "headline": "Build every theme example at once",
           "body": "Run the bulk examples build to regenerate the full preview set into dist/examples.",
-          "primaryCta": { "label": "Run build:examples", "href": "/commands/build-examples" },
-          "secondaryCta": { "label": "Run validate:examples", "href": "/commands/validate-examples" }
+          "primaryCta": { "label": "Browse all previews", "href": "/examples/" },
+          "secondaryCta": { "label": "See pricing", "href": "/pricing" }
         },
         {
           "type": "google-maps",

--- a/content/examples/themes/high-vis-service.json
+++ b/content/examples/themes/high-vis-service.json
@@ -9,9 +9,9 @@
           "type": "navigation-bar",
           "brandText": "High-Vis Service",
           "links": [
-            { "label": "Preview", "href": "/" },
-            { "label": "Theme List", "href": "/themes" },
-            { "label": "Validate", "href": "/commands/validate-examples" }
+            { "label": "Preview", "href": "/examples/high-vis-service/" },
+            { "label": "Theme List", "href": "/examples/" },
+            { "label": "Pricing", "href": "/pricing" }
           ]
         },
         {
@@ -42,7 +42,7 @@
           "headline": "High-Vis Service theme preview",
           "subheadline": "Urgent contrast, dispatch-style hierarchy, and strong CTA surfaces on one review page.",
           "primaryCta": { "label": "Jump to examples", "href": "#examples" },
-          "secondaryCta": { "label": "See theme list", "href": "/themes" },
+          "secondaryCta": { "label": "See all previews", "href": "/examples/" },
           "align": "start"
         },
         {
@@ -50,9 +50,9 @@
           "title": "Theme navigation sample",
           "lead": "This compact control confirms route pickers stay readable in the active theme.",
           "links": [
-            { "label": "High-Vis Service", "href": "/themes/high-vis-service", "current": true },
-            { "label": "Corporate", "href": "/themes/corporate" },
-            { "label": "Brutalism", "href": "/themes/brutalism" }
+            { "label": "High-Vis Service", "href": "/examples/high-vis-service/", "current": true },
+            { "label": "Corporate", "href": "/examples/corporate/" },
+            { "label": "Brutalism", "href": "/examples/brutalism/" }
           ]
         },
         {
@@ -87,8 +87,8 @@
           "type": "cta-band",
           "headline": "Build every theme example at once",
           "body": "Run the bulk examples build to regenerate the full preview set into dist/examples.",
-          "primaryCta": { "label": "Run build:examples", "href": "/commands/build-examples" },
-          "secondaryCta": { "label": "Run validate:examples", "href": "/commands/validate-examples" }
+          "primaryCta": { "label": "Browse all previews", "href": "/examples/" },
+          "secondaryCta": { "label": "See pricing", "href": "/pricing" }
         },
         {
           "type": "google-maps",

--- a/content/examples/themes/index.json
+++ b/content/examples/themes/index.json
@@ -1,0 +1,60 @@
+{
+  "site": {
+    "name": "Theme Previews",
+    "baseUrl": "https://example.com/examples/",
+    "theme": "friendly-modern",
+    "layout": {
+      "components": [
+        {
+          "type": "navigation-bar",
+          "brandText": "Theme Previews",
+          "links": [
+            { "label": "Home", "href": "/" },
+            { "label": "Pricing", "href": "/pricing" },
+            { "label": "Preview Index", "href": "/examples/" }
+          ]
+        },
+        { "type": "page-content" }
+      ]
+    }
+  },
+  "pages": [
+    {
+      "slug": "/",
+      "title": "Theme Previews",
+      "metadata": {
+        "description": "Directory for the shared theme preview fixtures."
+      },
+      "components": [
+        {
+          "type": "hero",
+          "headline": "Compare the shared theme previews",
+          "subheadline": "Each preview uses the same component coverage with a different theme, so visual regressions stand out quickly.",
+          "primaryCta": { "label": "Browse corporate", "href": "/examples/corporate/" },
+          "secondaryCta": { "label": "Back to pricing", "href": "/pricing" },
+          "align": "start"
+        },
+        {
+          "type": "feature-grid",
+          "title": "Available previews",
+          "items": [
+            { "title": "Corporate", "body": "Structured defaults with restrained surfaces.", "cta": { "label": "Open preview", "href": "/examples/corporate/" } },
+            { "title": "Brutalism", "body": "Sharper contrast with a more opinionated voice.", "cta": { "label": "Open preview", "href": "/examples/brutalism/" } },
+            { "title": "Workshop", "body": "A tactile direction suited to studios and trades.", "cta": { "label": "Open preview", "href": "/examples/workshop/" } },
+            { "title": "Refined Professional", "body": "A more polished, service-oriented presentation.", "cta": { "label": "Open preview", "href": "/examples/refined-professional/" } }
+          ]
+        },
+        {
+          "type": "feature-grid",
+          "title": "More preview directions",
+          "items": [
+            { "title": "Friendly Modern", "body": "Softer colors and more conversational framing.", "cta": { "label": "Open preview", "href": "/examples/friendly-modern/" } },
+            { "title": "Heritage Local", "body": "A grounded look for legacy and place-based brands.", "cta": { "label": "Open preview", "href": "/examples/heritage-local/" } },
+            { "title": "Wellness Calm", "body": "A gentler palette for health and hospitality use cases.", "cta": { "label": "Open preview", "href": "/examples/wellness-calm/" } },
+            { "title": "High-Vis Service", "body": "A louder, urgency-forward service presentation.", "cta": { "label": "Open preview", "href": "/examples/high-vis-service/" } }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/content/examples/themes/refined-professional.json
+++ b/content/examples/themes/refined-professional.json
@@ -9,9 +9,9 @@
           "type": "navigation-bar",
           "brandText": "Refined Professional",
           "links": [
-            { "label": "Preview", "href": "/" },
-            { "label": "Theme List", "href": "/themes" },
-            { "label": "Validate", "href": "/commands/validate-examples" }
+            { "label": "Preview", "href": "/examples/refined-professional/" },
+            { "label": "Theme List", "href": "/examples/" },
+            { "label": "Pricing", "href": "/pricing" }
           ]
         },
         {
@@ -42,7 +42,7 @@
           "headline": "Refined Professional theme preview",
           "subheadline": "Quiet contrast, serif-led hierarchy, and premium dark surfaces on one review page.",
           "primaryCta": { "label": "Jump to examples", "href": "#examples" },
-          "secondaryCta": { "label": "See theme list", "href": "/themes" },
+          "secondaryCta": { "label": "See all previews", "href": "/examples/" },
           "align": "start"
         },
         {
@@ -50,9 +50,9 @@
           "title": "Theme navigation sample",
           "lead": "This compact control confirms route pickers stay readable in the active theme.",
           "links": [
-            { "label": "Refined Professional", "href": "/themes/refined-professional", "current": true },
-            { "label": "Corporate", "href": "/themes/corporate" },
-            { "label": "Heritage Local", "href": "/themes/heritage-local" }
+            { "label": "Refined Professional", "href": "/examples/refined-professional/", "current": true },
+            { "label": "Corporate", "href": "/examples/corporate/" },
+            { "label": "Heritage Local", "href": "/examples/heritage-local/" }
           ]
         },
         {
@@ -87,8 +87,8 @@
           "type": "cta-band",
           "headline": "Build every theme example at once",
           "body": "Run the bulk examples build to regenerate the full preview set into dist/examples.",
-          "primaryCta": { "label": "Run build:examples", "href": "/commands/build-examples" },
-          "secondaryCta": { "label": "Run validate:examples", "href": "/commands/validate-examples" }
+          "primaryCta": { "label": "Browse all previews", "href": "/examples/" },
+          "secondaryCta": { "label": "See pricing", "href": "/pricing" }
         },
         {
           "type": "google-maps",

--- a/content/examples/themes/wellness-calm.json
+++ b/content/examples/themes/wellness-calm.json
@@ -9,9 +9,9 @@
           "type": "navigation-bar",
           "brandText": "Wellness Calm",
           "links": [
-            { "label": "Preview", "href": "/" },
-            { "label": "Theme List", "href": "/themes" },
-            { "label": "Validate", "href": "/commands/validate-examples" }
+            { "label": "Preview", "href": "/examples/wellness-calm/" },
+            { "label": "Theme List", "href": "/examples/" },
+            { "label": "Pricing", "href": "/pricing" }
           ]
         },
         {
@@ -42,7 +42,7 @@
           "headline": "Wellness Calm theme preview",
           "subheadline": "Soft gradients, airy spacing, and low-friction components on one review page.",
           "primaryCta": { "label": "Jump to examples", "href": "#examples" },
-          "secondaryCta": { "label": "See theme list", "href": "/themes" },
+          "secondaryCta": { "label": "See all previews", "href": "/examples/" },
           "align": "start"
         },
         {
@@ -50,9 +50,9 @@
           "title": "Theme navigation sample",
           "lead": "This compact control confirms route pickers stay readable in the active theme.",
           "links": [
-            { "label": "Wellness Calm", "href": "/themes/wellness-calm", "current": true },
-            { "label": "Friendly Modern", "href": "/themes/friendly-modern" },
-            { "label": "Workshop", "href": "/themes/workshop" }
+            { "label": "Wellness Calm", "href": "/examples/wellness-calm/", "current": true },
+            { "label": "Friendly Modern", "href": "/examples/friendly-modern/" },
+            { "label": "Workshop", "href": "/examples/workshop/" }
           ]
         },
         {
@@ -87,8 +87,8 @@
           "type": "cta-band",
           "headline": "Build every theme example at once",
           "body": "Run the bulk examples build to regenerate the full preview set into dist/examples.",
-          "primaryCta": { "label": "Run build:examples", "href": "/commands/build-examples" },
-          "secondaryCta": { "label": "Run validate:examples", "href": "/commands/validate-examples" }
+          "primaryCta": { "label": "Browse all previews", "href": "/examples/" },
+          "secondaryCta": { "label": "See pricing", "href": "/pricing" }
         },
         {
           "type": "google-maps",

--- a/content/examples/themes/workshop.json
+++ b/content/examples/themes/workshop.json
@@ -9,9 +9,9 @@
           "type": "navigation-bar",
           "brandText": "Workshop",
           "links": [
-            { "label": "Preview", "href": "/" },
-            { "label": "Theme List", "href": "/themes" },
-            { "label": "Validate", "href": "/commands/validate-examples" }
+            { "label": "Preview", "href": "/examples/workshop/" },
+            { "label": "Theme List", "href": "/examples/" },
+            { "label": "Pricing", "href": "/pricing" }
           ]
         },
         {
@@ -42,7 +42,7 @@
           "headline": "Workshop theme preview",
           "subheadline": "Tactile surfaces, serif-led headings, and craft-forward accents on one review page.",
           "primaryCta": { "label": "Jump to examples", "href": "#examples" },
-          "secondaryCta": { "label": "See theme list", "href": "/themes" },
+          "secondaryCta": { "label": "See all previews", "href": "/examples/" },
           "align": "start"
         },
         {
@@ -50,9 +50,9 @@
           "title": "Theme navigation sample",
           "lead": "This compact control confirms route pickers stay readable in the active theme.",
           "links": [
-            { "label": "Workshop", "href": "/themes/workshop", "current": true },
-            { "label": "Corporate", "href": "/themes/corporate" },
-            { "label": "Heritage Local", "href": "/themes/heritage-local" }
+            { "label": "Workshop", "href": "/examples/workshop/", "current": true },
+            { "label": "Corporate", "href": "/examples/corporate/" },
+            { "label": "Heritage Local", "href": "/examples/heritage-local/" }
           ]
         },
         {
@@ -87,8 +87,8 @@
           "type": "cta-band",
           "headline": "Build every theme example at once",
           "body": "Run the bulk examples build to regenerate the full preview set into dist/examples.",
-          "primaryCta": { "label": "Run build:examples", "href": "/commands/build-examples" },
-          "secondaryCta": { "label": "Run validate:examples", "href": "/commands/validate-examples" }
+          "primaryCta": { "label": "Browse all previews", "href": "/examples/" },
+          "secondaryCta": { "label": "See pricing", "href": "/pricing" }
         },
         {
           "type": "google-maps",

--- a/content/site.json
+++ b/content/site.json
@@ -62,11 +62,11 @@
           "subheadline": "Strict JSON, fixed components, and theme-driven presentation.",
           "primaryCta": {
             "label": "Start now",
-            "href": "/start"
+            "href": "/pricing"
           },
           "secondaryCta": {
             "label": "See demo",
-            "href": "/demo"
+            "href": "/pricing"
           },
           "align": "start"
         },
@@ -112,7 +112,7 @@
           "body": "Run validation before every build and keep the markup intentionally boring.",
           "primaryCta": {
             "label": "Read docs",
-            "href": "/docs"
+            "href": "/pricing"
           }
         }
       ]
@@ -127,7 +127,7 @@
           "subheadline": "A narrow framework is easier to validate, review, and keep consistent.",
           "primaryCta": {
             "label": "Start free",
-            "href": "/signup"
+            "href": "/"
           },
           "align": "center"
         },
@@ -150,7 +150,7 @@
           "headline": "Need a stricter content pipeline?",
           "primaryCta": {
             "label": "Contact sales",
-            "href": "/contact"
+            "href": "/pricing"
           }
         }
       ]

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "lint:ts": "tsc --noEmit",
     "test": "vitest run",
     "test:browser": "tsx tests/navigation-bar.browser.ts",
-    "validate:strict": "npm run schema:check && npm run lint:ts && npm run lint:css && npm run test && npm run test:browser && npm run validate && npm run validate:example:78th && npm run validate:example:baird && npm run validate:examples && npm run build && npm run build:example:78th && npm run build:example:baird && npm run build:examples",
+    "validate:dist-links": "node scripts/validate-dist-links.mjs",
+    "validate:strict": "npm run schema:check && npm run lint:ts && npm run lint:css && npm run test && npm run test:browser && npm run validate && npm run validate:example:78th && npm run validate:example:baird && npm run validate:examples && npm run build && npm run build:example:78th && npm run build:example:baird && npm run build:examples && npm run validate:dist-links",
     "check": "npm run validate:strict"
   },
   "dependencies": {

--- a/scripts/validate-dist-links.mjs
+++ b/scripts/validate-dist-links.mjs
@@ -1,0 +1,269 @@
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+export const supportedScanExtensions = new Set([
+  ".css",
+  ".htm",
+  ".html",
+  ".js",
+  ".mjs",
+  ".cjs",
+]);
+
+const htmlReferencePattern = /\b(?:href|src|srcset)\s*=\s*(["'])(.*?)\1/gi;
+const cssUrlPattern = /url\(\s*(["']?)(.*?)\1\s*\)/gi;
+const cssImportPattern =
+  /@import\s+(?:url\(\s*(["']?)(.*?)\1\s*\)|(["'])(.*?)\3)/gi;
+const jsDynamicImportPattern = /\bimport\s*\(\s*(["'])(.*?)\1\s*\)/g;
+const jsStaticImportPattern = /\bimport\s+(?:[^"'()]+\s+from\s+)?(["'])(.*?)\1/g;
+
+const isDirectExecution =
+  process.argv[1] !== undefined && import.meta.url === pathToFileURL(process.argv[1]).href;
+
+const normalizeReference = (reference) => {
+  const trimmed = reference.trim();
+
+  if (!trimmed) {
+    return "";
+  }
+
+  const withoutQueryOrHash = trimmed.split(/[?#]/, 1)[0]?.trim() ?? "";
+
+  if (!withoutQueryOrHash) {
+    return "";
+  }
+
+  try {
+    return decodeURIComponent(withoutQueryOrHash);
+  } catch {
+    return withoutQueryOrHash;
+  }
+};
+
+export const isSameSiteRelativeReference = (reference) => {
+  const normalized = normalizeReference(reference);
+
+  if (!normalized || normalized.startsWith("#")) {
+    return false;
+  }
+
+  if (normalized.startsWith("//")) {
+    return false;
+  }
+
+  if (/^[a-zA-Z][a-zA-Z\d+.-]*:/.test(normalized)) {
+    return false;
+  }
+
+  return true;
+};
+
+const extractHtmlReferences = (contents) => {
+  const references = [];
+
+  for (const match of contents.matchAll(new RegExp(htmlReferencePattern.source, htmlReferencePattern.flags))) {
+    const [, , rawValue] = match;
+
+    if (match[0].toLowerCase().includes("srcset")) {
+      references.push(
+        ...rawValue
+          .split(",")
+          .map((entry) => entry.trim().split(/\s+/, 1)[0] ?? "")
+          .filter(Boolean),
+      );
+      continue;
+    }
+
+    references.push(rawValue);
+  }
+
+  return references;
+};
+
+const extractCssReferences = (contents) => {
+  const references = [];
+
+  for (const match of contents.matchAll(new RegExp(cssUrlPattern.source, cssUrlPattern.flags))) {
+    const [, , rawValue] = match;
+    references.push(rawValue);
+  }
+
+  for (const match of contents.matchAll(new RegExp(cssImportPattern.source, cssImportPattern.flags))) {
+    const rawValue = match[2] ?? match[4] ?? "";
+    references.push(rawValue);
+  }
+
+  return references;
+};
+
+const extractJavaScriptReferences = (contents) => [
+  ...Array.from(
+    contents.matchAll(new RegExp(jsDynamicImportPattern.source, jsDynamicImportPattern.flags)),
+    (match) => match[2],
+  ),
+  ...Array.from(
+    contents.matchAll(new RegExp(jsStaticImportPattern.source, jsStaticImportPattern.flags)),
+    (match) => match[2],
+  ),
+];
+
+export const extractReferencesFromFile = (filePath, contents) => {
+  const extension = path.extname(filePath).toLowerCase();
+
+  if (extension === ".html" || extension === ".htm") {
+    return extractHtmlReferences(contents);
+  }
+
+  if (extension === ".css") {
+    return extractCssReferences(contents);
+  }
+
+  if (extension === ".js" || extension === ".mjs" || extension === ".cjs") {
+    return extractJavaScriptReferences(contents);
+  }
+
+  return [];
+};
+
+const collectScanFiles = (directory) => {
+  const entries = readdirSync(directory)
+    .map((name) => path.join(directory, name))
+    .sort((left, right) => left.localeCompare(right));
+
+  return entries.flatMap((entry) => {
+    const stats = statSync(entry);
+
+    if (stats.isDirectory()) {
+      return collectScanFiles(entry);
+    }
+
+    return supportedScanExtensions.has(path.extname(entry).toLowerCase()) ? [entry] : [];
+  });
+};
+
+const isInsideRoot = (rootDir, targetPath) => {
+  const relativePath = path.relative(rootDir, targetPath);
+  return relativePath === "" || (!relativePath.startsWith("..") && !path.isAbsolute(relativePath));
+};
+
+const resolveReferenceCandidates = (sourceFilePath, reference, distDir) => {
+  const normalized = normalizeReference(reference);
+  const sourceDir = path.dirname(sourceFilePath);
+  const baseDir = normalized.startsWith("/") ? distDir : sourceDir;
+  const resolvedTarget = path.resolve(baseDir, normalized.replace(/^\/+/, ""));
+
+  if (!isInsideRoot(distDir, resolvedTarget)) {
+    return {
+      normalized,
+      candidates: [],
+      reason: "resolves outside dist",
+    };
+  }
+
+  if (normalized === "/") {
+    return {
+      normalized,
+      candidates: [path.join(distDir, "index.html")],
+      reason: null,
+    };
+  }
+
+  if (normalized.endsWith("/")) {
+    return {
+      normalized,
+      candidates: [path.join(resolvedTarget, "index.html")],
+      reason: null,
+    };
+  }
+
+  if (path.extname(normalized)) {
+    return {
+      normalized,
+      candidates: [resolvedTarget],
+      reason: null,
+    };
+  }
+
+  return {
+    normalized,
+    candidates: [
+      resolvedTarget,
+      `${resolvedTarget}.html`,
+      path.join(resolvedTarget, "index.html"),
+    ],
+    reason: null,
+  };
+};
+
+export const findBrokenDistReferences = (distDir) => {
+  const resolvedDistDir = path.resolve(distDir);
+
+  if (!existsSync(resolvedDistDir)) {
+    throw new Error(
+      `Missing ${path.relative(process.cwd(), resolvedDistDir) || "dist"}. Run the site build before validating dist references.`,
+    );
+  }
+
+  const scanFiles = collectScanFiles(resolvedDistDir);
+  const problems = [];
+  const problemKeys = new Set();
+
+  for (const filePath of scanFiles) {
+    const contents = readFileSync(filePath, "utf8");
+    const references = extractReferencesFromFile(filePath, contents);
+
+    for (const reference of references) {
+      if (!isSameSiteRelativeReference(reference)) {
+        continue;
+      }
+
+      const resolution = resolveReferenceCandidates(filePath, reference, resolvedDistDir);
+      const targetExists = resolution.candidates.some((candidatePath) => existsSync(candidatePath));
+
+      if (!targetExists) {
+        const problem = {
+          sourcePath: filePath,
+          reference: resolution.normalized,
+          candidates: resolution.candidates,
+          reason: resolution.reason ?? "missing target",
+        };
+        const problemKey = `${problem.sourcePath}::${problem.reference}::${problem.reason}`;
+
+        if (!problemKeys.has(problemKey)) {
+          problems.push(problem);
+          problemKeys.add(problemKey);
+        }
+      }
+    }
+  }
+
+  return problems;
+};
+
+if (isDirectExecution) {
+  const distDir = process.argv[2] ? path.resolve(process.cwd(), process.argv[2]) : path.resolve(process.cwd(), "dist");
+  const problems = findBrokenDistReferences(distDir);
+
+  if (problems.length === 0) {
+    console.log(
+      `Validated same-site relative references in ${path.relative(process.cwd(), distDir) || "dist"}.`,
+    );
+    process.exit(0);
+  }
+
+  console.error("Broken dist references found:");
+
+  for (const problem of problems) {
+    const sourcePath = path.relative(process.cwd(), problem.sourcePath);
+    const candidateList = problem.candidates
+      .map((candidatePath) => path.relative(process.cwd(), candidatePath))
+      .join(", ");
+
+    console.error(
+      `- ${sourcePath}: ${problem.reference} (${problem.reason}; checked ${candidateList || "no valid in-dist target"})`,
+    );
+  }
+
+  process.exit(1);
+}

--- a/src/build/build-examples.ts
+++ b/src/build/build-examples.ts
@@ -6,11 +6,15 @@ import { ValidationFailure, buildSiteFromFile } from "./framework.js";
 
 const examplesContentDir = path.resolve(process.cwd(), "content/examples/themes");
 const examplesOutDir = path.resolve(process.cwd(), "dist/examples");
+const examplesIndexContentPath = path.join(examplesContentDir, "index.json");
 
 try {
   await rm(examplesOutDir, { recursive: true, force: true });
 
   let builtPages = 0;
+  const examplesIndex = await buildSiteFromFile(examplesIndexContentPath, examplesOutDir);
+  builtPages += examplesIndex.pages.length;
+
   for (const themeName of themeNames) {
     const contentPath = path.join(examplesContentDir, `${themeName}.json`);
     const outDir = path.join(examplesOutDir, themeName);
@@ -19,7 +23,7 @@ try {
   }
 
   console.log(
-    `Built ${themeNames.length} theme example site(s) with ${builtPages} page(s) into ${path.relative(process.cwd(), examplesOutDir)}`,
+    `Built the theme preview index plus ${themeNames.length} theme example site(s) with ${builtPages} page(s) into ${path.relative(process.cwd(), examplesOutDir)}`,
   );
 } catch (error) {
   if (error instanceof ValidationFailure) {

--- a/src/build/validate-examples.ts
+++ b/src/build/validate-examples.ts
@@ -4,9 +4,13 @@ import { themeNames } from "../themes/index.js";
 import { ValidationFailure, loadValidatedSite } from "./framework.js";
 
 const examplesContentDir = path.resolve(process.cwd(), "content/examples/themes");
+const examplesIndexContentPath = path.join(examplesContentDir, "index.json");
 
 try {
   let totalPages = 0;
+  const examplesIndex = await loadValidatedSite(examplesIndexContentPath);
+  totalPages += examplesIndex.pages.length;
+
   for (const themeName of themeNames) {
     const contentPath = path.join(examplesContentDir, `${themeName}.json`);
     const siteContent = await loadValidatedSite(contentPath);
@@ -14,7 +18,7 @@ try {
   }
 
   console.log(
-    `Validated ${themeNames.length} theme example site(s) with ${totalPages} page(s) from ${path.relative(process.cwd(), examplesContentDir)}`,
+    `Validated the theme preview index plus ${themeNames.length} theme example site(s) with ${totalPages} page(s) from ${path.relative(process.cwd(), examplesContentDir)}`,
   );
 } catch (error) {
   if (error instanceof ValidationFailure) {

--- a/tests/validate-dist-links.test.ts
+++ b/tests/validate-dist-links.test.ts
@@ -1,0 +1,139 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+// @ts-ignore Vitest imports the ESM helper directly for behavior tests.
+import * as validateDistLinks from "../scripts/validate-dist-links.mjs";
+
+const { extractReferencesFromFile, findBrokenDistReferences, isSameSiteRelativeReference } =
+  validateDistLinks;
+
+const tempDirectories: string[] = [];
+
+const createTempDist = () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "cruftless-dist-links-"));
+  tempDirectories.push(directory);
+  return directory;
+};
+
+const writeFixture = (rootDir: string, relativePath: string, contents: string) => {
+  const filePath = path.join(rootDir, relativePath);
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, contents, "utf8");
+};
+
+describe("dist link validation", () => {
+  afterEach(() => {
+    while (tempDirectories.length > 0) {
+      const directory = tempDirectories.pop();
+
+      if (directory) {
+        fs.rmSync(directory, { recursive: true, force: true });
+      }
+    }
+  });
+
+  it("treats same-site root-relative and relative references as in-scope", () => {
+    expect(isSameSiteRelativeReference("/pricing")).toBe(true);
+    expect(isSameSiteRelativeReference("../assets/site.css?v=1")).toBe(true);
+    expect(isSameSiteRelativeReference("./hero.jpg#intro")).toBe(true);
+    expect(isSameSiteRelativeReference("assets/site.css")).toBe(true);
+    expect(isSameSiteRelativeReference("https://example.com/pricing")).toBe(false);
+    expect(isSameSiteRelativeReference("mailto:hello@example.com")).toBe(false);
+    expect(isSameSiteRelativeReference("#faq")).toBe(false);
+  });
+
+  it("extracts supported reference types from built files", () => {
+    const htmlReferences = extractReferencesFromFile(
+      "index.html",
+      '<link rel="stylesheet" href="assets/site.css"><img srcset="hero.jpg 1x, /images/hero@2x.jpg 2x"><script src="../assets/site.js"></script>',
+    );
+    const cssReferences = extractReferencesFromFile(
+      "assets/site.css",
+      '@import "../fonts/site.css"; .hero { background-image: url("../images/hero.png"); }',
+    );
+    const jsReferences = extractReferencesFromFile(
+      "assets/site.js",
+      'const module = import("../chunks/nav.js"); import "./boot.js";',
+    );
+
+    expect(htmlReferences).toEqual([
+      "assets/site.css",
+      "hero.jpg",
+      "/images/hero@2x.jpg",
+      "../assets/site.js",
+    ]);
+    expect(cssReferences).toEqual([
+      "../images/hero.png",
+      "../fonts/site.css",
+    ]);
+    expect(jsReferences).toEqual([
+      "../chunks/nav.js",
+      "./boot.js",
+    ]);
+  });
+
+  it("accepts extensionless page routes and asset references that resolve inside dist", () => {
+    const distDir = createTempDist();
+
+    writeFixture(
+      distDir,
+      "index.html",
+      [
+        '<link rel="stylesheet" href="assets/site.css">',
+        '<a href="/pricing">Pricing</a>',
+        '<img srcset="images/hero.jpg 1x, /images/hero@2x.jpg 2x">',
+        '<a href="https://example.com">External</a>',
+      ].join("\n"),
+    );
+    writeFixture(distDir, "pricing/index.html", "<p>Pricing</p>");
+    writeFixture(
+      distDir,
+      "assets/site.css",
+      '.hero { background-image: url("../images/hero.png"); }',
+    );
+    writeFixture(distDir, "images/hero.jpg", "hero");
+    writeFixture(distDir, "images/hero@2x.jpg", "hero-2x");
+    writeFixture(distDir, "images/hero.png", "hero-bg");
+
+    expect(findBrokenDistReferences(distDir)).toEqual([]);
+  });
+
+  it("reports missing same-site targets with the source file and normalized reference", () => {
+    const distDir = createTempDist();
+
+    writeFixture(
+      distDir,
+      "index.html",
+      [
+        '<a href="/missing-page">Missing page</a>',
+        '<script src="assets/missing.js"></script>',
+      ].join("\n"),
+    );
+    writeFixture(
+      distDir,
+      "assets/site.css",
+      '.hero { background-image: url("../images/missing.png"); }',
+    );
+
+    expect(findBrokenDistReferences(distDir)).toEqual([
+      expect.objectContaining({
+        sourcePath: path.join(distDir, "assets", "site.css"),
+        reference: "../images/missing.png",
+        reason: "missing target",
+      }),
+      expect.objectContaining({
+        sourcePath: path.join(distDir, "index.html"),
+        reference: "/missing-page",
+        reason: "missing target",
+      }),
+      expect.objectContaining({
+        sourcePath: path.join(distDir, "index.html"),
+        reference: "assets/missing.js",
+        reason: "missing target",
+      }),
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- add a deterministic dist reference scan to strict validation
- fix broken public routes in the shared sample site, bundled example sites, and theme previews
- add a shared /examples/ preview index so theme preview navigation has a real same-site hub

## Validation
- npm run validate:strict
