### PR TITLE
Add watch mode and incremental output writes

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,19 @@ npm run build
 ```
 
 This reads `content/site.json` and writes the generated site to `dist/`.
+If the generated output is already current, the build leaves those files untouched.
+
+To keep rebuilding while you edit a content file, use watch mode:
+
+```bash
+npm run build:watch
+```
+
+Or watch a specific content file and output directory:
+
+```bash
+npm run build -- content/examples/78th-street-studios.json dist/78th-street-studios --watch
+```
 
 ### 4. Build or validate a specific content file
 

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "scripts": {
     "build": "tsx src/build/build.ts",
+    "build:watch": "tsx src/build/build.ts --watch",
     "build:examples": "tsx src/build/build-examples.ts",
     "build:example:baird": "tsx src/build/build.ts content/examples/baird-automotive.json dist/baird-automotive",
     "build:example:78th": "tsx src/build/build.ts content/examples/78th-street-studios.json dist/78th-street-studios",

--- a/src/build/build-examples.ts
+++ b/src/build/build-examples.ts
@@ -1,4 +1,3 @@
-import { rm } from "node:fs/promises";
 import path from "node:path";
 
 import { themeNames } from "../themes/index.js";
@@ -9,8 +8,6 @@ const examplesOutDir = path.resolve(process.cwd(), "dist/examples");
 const examplesIndexContentPath = path.join(examplesContentDir, "index.json");
 
 try {
-  await rm(examplesOutDir, { recursive: true, force: true });
-
   let builtPages = 0;
   const examplesIndex = await buildSiteFromFile(examplesIndexContentPath, examplesOutDir);
   builtPages += examplesIndex.pages.length;

--- a/src/build/build.ts
+++ b/src/build/build.ts
@@ -1,21 +1,98 @@
+import { watchFile, unwatchFile } from "node:fs";
 import path from "node:path";
 
 import {
+  buildSite,
   ValidationFailure,
-  buildSiteFromFile,
   defaultContentPath,
   defaultOutDir,
+  loadValidatedSite,
 } from "./framework.js";
 
-const [, , contentArg, outArg] = process.argv;
+const args = process.argv.slice(2);
+const watchMode = args.includes("--watch") || args.includes("-w");
+const positionalArgs = args.filter((arg) => arg !== "--watch" && arg !== "-w");
+
+if (positionalArgs.length > 2) {
+  throw new Error("Usage: tsx src/build/build.ts [content-path] [out-dir] [--watch]");
+}
+
+const [contentArg, outArg] = positionalArgs;
 const contentPath = contentArg ? path.resolve(process.cwd(), contentArg) : defaultContentPath;
 const outDir = outArg ? path.resolve(process.cwd(), outArg) : defaultOutDir;
 
+const formatBuildSummary = (pageCount: number, outDirectory: string, changedFiles: number): string => {
+  const relativeOutDir = path.relative(process.cwd(), outDirectory) || ".";
+  const fileLabel = changedFiles === 1 ? "1 file changed" : `${changedFiles} files changed`;
+  return `Built ${pageCount} page(s) into ${relativeOutDir} (${fileLabel})`;
+};
+
+const runBuild = async (): Promise<boolean> => {
+  try {
+    const siteContent = await loadValidatedSite(contentPath);
+    const buildResult = await buildSite(siteContent, outDir);
+    const changedFiles =
+      buildResult.filesCreated + buildResult.filesUpdated + buildResult.filesRemoved;
+
+    console.log(formatBuildSummary(siteContent.pages.length, outDir, changedFiles));
+    return true;
+  } catch (error) {
+    if (error instanceof ValidationFailure) {
+      console.error(error.message);
+      return false;
+    }
+
+    throw error;
+  }
+};
+
 try {
-  const siteContent = await buildSiteFromFile(contentPath, outDir);
-  console.log(
-    `Built ${siteContent.pages.length} page(s) into ${path.relative(process.cwd(), outDir)}`,
-  );
+  const initialBuildSucceeded = await runBuild();
+
+  if (!watchMode) {
+    process.exitCode = initialBuildSucceeded ? 0 : 1;
+  } else {
+    let buildInProgress = false;
+    let queuedBuild = false;
+
+    const triggerBuild = () => {
+      if (buildInProgress) {
+        queuedBuild = true;
+        return;
+      }
+
+      buildInProgress = true;
+      void (async () => {
+        console.log(`Change detected in ${path.relative(process.cwd(), contentPath)}. Rebuilding...`);
+        const buildSucceeded = await runBuild();
+        process.exitCode = buildSucceeded ? 0 : 1;
+        buildInProgress = false;
+
+        if (queuedBuild) {
+          queuedBuild = false;
+          triggerBuild();
+        }
+      })();
+    };
+
+    watchFile(contentPath, { interval: 250 }, (current, previous) => {
+      if (current.mtimeMs === previous.mtimeMs && current.size === previous.size) {
+        return;
+      }
+
+      triggerBuild();
+    });
+
+    const stopWatching = () => {
+      unwatchFile(contentPath);
+      process.exit();
+    };
+
+    process.on("SIGINT", stopWatching);
+    process.on("SIGTERM", stopWatching);
+
+    console.log(`Watching ${path.relative(process.cwd(), contentPath)} for changes...`);
+  }
 } catch (error) {
   if (error instanceof ValidationFailure) {
     console.error(error.message);
@@ -24,4 +101,3 @@ try {
     throw error;
   }
 }
-

--- a/src/build/framework.ts
+++ b/src/build/framework.ts
@@ -1,5 +1,5 @@
 import { existsSync } from "node:fs";
-import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdir, readdir, readFile, rmdir, unlink, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import type { ZodIssue } from "zod";
@@ -329,19 +329,129 @@ const renderSiteJs = (siteContent: SiteContentData): string => {
     .join("\n\n");
 };
 
+export interface BuildResult {
+  pageCount: number;
+  filesCreated: number;
+  filesUpdated: number;
+  filesUnchanged: number;
+  filesRemoved: number;
+}
+
+const collectFilesRecursively = async (directoryPath: string): Promise<string[]> => {
+  const entries = await readdir(directoryPath, { withFileTypes: true });
+  const nestedPaths = await Promise.all(
+    entries.map(async (entry) => {
+      const entryPath = path.join(directoryPath, entry.name);
+
+      if (entry.isDirectory()) {
+        return collectFilesRecursively(entryPath);
+      }
+
+      return entry.isFile() ? [entryPath] : [];
+    }),
+  );
+
+  return nestedPaths.flat();
+};
+
+const writeFileIfChanged = async (
+  filePath: string,
+  contents: string,
+): Promise<"created" | "updated" | "unchanged"> => {
+  try {
+    const existingContents = await readFile(filePath, "utf8");
+
+    if (existingContents === contents) {
+      return "unchanged";
+    }
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+      throw error;
+    }
+
+    await writeFile(filePath, contents, "utf8");
+    return "created";
+  }
+
+  await writeFile(filePath, contents, "utf8");
+  return "updated";
+};
+
+const removeEmptyDirectories = async (directoryPath: string, rootDir: string): Promise<void> => {
+  const entries = await readdir(directoryPath, { withFileTypes: true });
+
+  await Promise.all(
+    entries
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => removeEmptyDirectories(path.join(directoryPath, entry.name), rootDir)),
+  );
+
+  if (directoryPath === rootDir) {
+    return;
+  }
+
+  const remainingEntries = await readdir(directoryPath);
+  if (remainingEntries.length === 0) {
+    await rmdir(directoryPath);
+  }
+};
+
+const removeStaleGeneratedFiles = async (
+  outDir: string,
+  expectedFiles: ReadonlySet<string>,
+): Promise<number> => {
+  try {
+    const existingFiles = await collectFilesRecursively(outDir);
+    const staleFiles = existingFiles.filter((filePath) => !expectedFiles.has(filePath));
+
+    await Promise.all(staleFiles.map((filePath) => unlink(filePath)));
+    await removeEmptyDirectories(outDir, outDir);
+
+    return staleFiles.length;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return 0;
+    }
+
+    throw error;
+  }
+};
+
 export const buildSite = async (
   siteContent: SiteContentData,
   outDir: string = defaultOutDir,
-): Promise<void> => {
-  await rm(outDir, { recursive: true, force: true });
+): Promise<BuildResult> => {
   await mkdir(path.join(outDir, "assets"), { recursive: true });
 
   const css = await renderSiteCss(siteContent);
   const js = renderSiteJs(siteContent);
-  await writeFile(path.join(outDir, "assets", "site.css"), css, "utf8");
+  const expectedFiles = new Set<string>();
+  let filesCreated = 0;
+  let filesUpdated = 0;
+  let filesUnchanged = 0;
+
+  const recordWriteResult = (writeResult: "created" | "updated" | "unchanged") => {
+    if (writeResult === "created") {
+      filesCreated += 1;
+      return;
+    }
+
+    if (writeResult === "updated") {
+      filesUpdated += 1;
+      return;
+    }
+
+    filesUnchanged += 1;
+  };
+
+  const cssOutputPath = path.join(outDir, "assets", "site.css");
+  expectedFiles.add(cssOutputPath);
+  recordWriteResult(await writeFileIfChanged(cssOutputPath, css));
 
   if (js) {
-    await writeFile(path.join(outDir, "assets", "site.js"), js, "utf8");
+    const jsOutputPath = path.join(outDir, "assets", "site.js");
+    expectedFiles.add(jsOutputPath);
+    recordWriteResult(await writeFileIfChanged(jsOutputPath, js));
   }
 
   for (const [pageIndex, page] of siteContent.pages.entries()) {
@@ -357,8 +467,19 @@ export const buildSite = async (
     });
     const outputPath = pageSlugToOutputPath(page.slug, outDir);
     await mkdir(path.dirname(outputPath), { recursive: true });
-    await writeFile(outputPath, documentHtml, "utf8");
+    expectedFiles.add(outputPath);
+    recordWriteResult(await writeFileIfChanged(outputPath, documentHtml));
   }
+
+  const filesRemoved = await removeStaleGeneratedFiles(outDir, expectedFiles);
+
+  return {
+    pageCount: siteContent.pages.length,
+    filesCreated,
+    filesUpdated,
+    filesUnchanged,
+    filesRemoved,
+  };
 };
 
 export const buildSiteFromFile = async (

--- a/tests/build-output.test.ts
+++ b/tests/build-output.test.ts
@@ -1,0 +1,144 @@
+import { access, mkdtemp, readFile, rm, stat } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { buildSite } from "../src/build/framework.js";
+import { SiteContentSchema } from "../src/schemas/site.schema.js";
+
+const waitForMtimeTick = async (): Promise<void> =>
+  new Promise((resolve) => {
+    setTimeout(resolve, 30);
+  });
+
+const createScriptedSite = () =>
+  SiteContentSchema.parse({
+    site: {
+      name: "LaunchKit",
+      baseUrl: "https://launchkit.example",
+      theme: "friendly-modern",
+      layout: {
+        components: [
+          {
+            type: "navigation-bar",
+            brandText: "LaunchKit",
+            links: [
+              {
+                label: "Home",
+                href: "/",
+              },
+            ],
+          },
+          {
+            type: "page-content",
+          },
+        ],
+      },
+    },
+    pages: [
+      {
+        slug: "/",
+        title: "Home",
+        components: [
+          {
+            type: "hero",
+            headline: "Launch faster",
+            primaryCta: {
+              label: "Get started",
+              href: "/start",
+            },
+          },
+        ],
+      },
+      {
+        slug: "/about",
+        title: "About",
+        components: [
+          {
+            type: "prose",
+            title: "About LaunchKit",
+            paragraphs: ["Theme-driven static pages without custom templates."],
+          },
+        ],
+      },
+    ],
+  });
+
+const createStaticSite = () =>
+  SiteContentSchema.parse({
+    site: {
+      name: "LaunchKit",
+      baseUrl: "https://launchkit.example",
+      theme: "friendly-modern",
+    },
+    pages: [
+      {
+        slug: "/",
+        title: "Home",
+        components: [
+          {
+            type: "hero",
+            headline: "Launch faster",
+            primaryCta: {
+              label: "Get started",
+              href: "/start",
+            },
+          },
+        ],
+      },
+    ],
+  });
+
+describe("buildSite output writes", () => {
+  it("does not rewrite unchanged files on repeated builds", async () => {
+    const outDir = await mkdtemp(path.join(os.tmpdir(), "cruftless-build-output-"));
+
+    try {
+      await buildSite(createStaticSite(), outDir);
+
+      const cssPath = path.join(outDir, "assets", "site.css");
+      const htmlPath = path.join(outDir, "index.html");
+      const initialCssStat = await stat(cssPath);
+      const initialHtmlStat = await stat(htmlPath);
+
+      await waitForMtimeTick();
+
+      const secondBuild = await buildSite(createStaticSite(), outDir);
+      const laterCssStat = await stat(cssPath);
+      const laterHtmlStat = await stat(htmlPath);
+
+      expect(secondBuild.filesCreated).toBe(0);
+      expect(secondBuild.filesUpdated).toBe(0);
+      expect(secondBuild.filesRemoved).toBe(0);
+      expect(secondBuild.filesUnchanged).toBe(2);
+      expect(laterCssStat.mtimeMs).toBe(initialCssStat.mtimeMs);
+      expect(laterHtmlStat.mtimeMs).toBe(initialHtmlStat.mtimeMs);
+    } finally {
+      await rm(outDir, { recursive: true, force: true });
+    }
+  });
+
+  it("removes stale generated files when the rendered output no longer needs them", async () => {
+    const outDir = await mkdtemp(path.join(os.tmpdir(), "cruftless-build-cleanup-"));
+
+    try {
+      await buildSite(createScriptedSite(), outDir);
+
+      expect(await readFile(path.join(outDir, "assets", "site.js"), "utf8")).toContain(
+        "resolveNavigationBarMode",
+      );
+      expect(await readFile(path.join(outDir, "about", "index.html"), "utf8")).toContain(
+        "About LaunchKit",
+      );
+
+      const secondBuild = await buildSite(createStaticSite(), outDir);
+
+      expect(secondBuild.filesRemoved).toBe(2);
+      await expect(access(path.join(outDir, "assets", "site.js"))).rejects.toThrow();
+      await expect(access(path.join(outDir, "about", "index.html"))).rejects.toThrow();
+    } finally {
+      await rm(outDir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add `--watch` support for `npm run build` and a `build:watch` shortcut so content edits trigger rebuilds
- make site builds rewrite generated files only when rendered output changes, while still removing stale generated files
- stop `build:examples` from deleting its whole output tree up front, and add coverage for no-op rebuilds and stale file cleanup

## Validation
- npm run validate:strict
- manual watch smoke test against a temporary content file: formatting-only change rebuilt with `0 files changed`, then a real content change rebuilt with `1 file changed`

Closes #51