### PR TITLE
[codex] Generate real theme preview screenshots

### DIFF
--- a/content/examples/themes/index.json
+++ b/content/examples/themes/index.json
@@ -38,20 +38,108 @@
           "type": "feature-grid",
           "title": "Available previews",
           "items": [
-            { "title": "Corporate", "body": "Structured defaults with restrained surfaces.", "cta": { "label": "Open preview", "href": "/examples/corporate/" } },
-            { "title": "Brutalism", "body": "Sharper contrast with a more opinionated voice.", "cta": { "label": "Open preview", "href": "/examples/brutalism/" } },
-            { "title": "Workshop", "body": "A tactile direction suited to studios and trades.", "cta": { "label": "Open preview", "href": "/examples/workshop/" } },
-            { "title": "Refined Professional", "body": "A more polished, service-oriented presentation.", "cta": { "label": "Open preview", "href": "/examples/refined-professional/" } }
+            {
+              "title": "Corporate",
+              "body": "Structured defaults with restrained surfaces.",
+              "imageLayout": "stacked",
+              "image": {
+                "src": "assets/previews/corporate.png",
+                "alt": "Real mobile screenshot preview of the corporate theme example page",
+                "width": 390,
+                "height": 700
+              },
+              "cta": { "label": "Open preview", "href": "/examples/corporate/" }
+            },
+            {
+              "title": "Brutalism",
+              "body": "Sharper contrast with a more opinionated voice.",
+              "imageLayout": "stacked",
+              "image": {
+                "src": "assets/previews/brutalism.png",
+                "alt": "Real mobile screenshot preview of the brutalism theme example page",
+                "width": 390,
+                "height": 700
+              },
+              "cta": { "label": "Open preview", "href": "/examples/brutalism/" }
+            },
+            {
+              "title": "Workshop",
+              "body": "A tactile direction suited to studios and trades.",
+              "imageLayout": "stacked",
+              "image": {
+                "src": "assets/previews/workshop.png",
+                "alt": "Real mobile screenshot preview of the workshop theme example page",
+                "width": 390,
+                "height": 700
+              },
+              "cta": { "label": "Open preview", "href": "/examples/workshop/" }
+            },
+            {
+              "title": "Refined Professional",
+              "body": "A more polished, service-oriented presentation.",
+              "imageLayout": "stacked",
+              "image": {
+                "src": "assets/previews/refined-professional.png",
+                "alt": "Real mobile screenshot preview of the refined professional theme example page",
+                "width": 390,
+                "height": 700
+              },
+              "cta": { "label": "Open preview", "href": "/examples/refined-professional/" }
+            }
           ]
         },
         {
           "type": "feature-grid",
           "title": "More preview directions",
           "items": [
-            { "title": "Friendly Modern", "body": "Softer colors and more conversational framing.", "cta": { "label": "Open preview", "href": "/examples/friendly-modern/" } },
-            { "title": "Heritage Local", "body": "A grounded look for legacy and place-based brands.", "cta": { "label": "Open preview", "href": "/examples/heritage-local/" } },
-            { "title": "Wellness Calm", "body": "A gentler palette for health and hospitality use cases.", "cta": { "label": "Open preview", "href": "/examples/wellness-calm/" } },
-            { "title": "High-Vis Service", "body": "A louder, urgency-forward service presentation.", "cta": { "label": "Open preview", "href": "/examples/high-vis-service/" } }
+            {
+              "title": "Friendly Modern",
+              "body": "Softer colors and more conversational framing.",
+              "imageLayout": "stacked",
+              "image": {
+                "src": "assets/previews/friendly-modern.png",
+                "alt": "Real mobile screenshot preview of the friendly modern theme example page",
+                "width": 390,
+                "height": 700
+              },
+              "cta": { "label": "Open preview", "href": "/examples/friendly-modern/" }
+            },
+            {
+              "title": "Heritage Local",
+              "body": "A grounded look for legacy and place-based brands.",
+              "imageLayout": "stacked",
+              "image": {
+                "src": "assets/previews/heritage-local.png",
+                "alt": "Real mobile screenshot preview of the heritage local theme example page",
+                "width": 390,
+                "height": 700
+              },
+              "cta": { "label": "Open preview", "href": "/examples/heritage-local/" }
+            },
+            {
+              "title": "Wellness Calm",
+              "body": "A gentler palette for health and hospitality use cases.",
+              "imageLayout": "stacked",
+              "image": {
+                "src": "assets/previews/wellness-calm.png",
+                "alt": "Real mobile screenshot preview of the wellness calm theme example page",
+                "width": 390,
+                "height": 700
+              },
+              "cta": { "label": "Open preview", "href": "/examples/wellness-calm/" }
+            },
+            {
+              "title": "High-Vis Service",
+              "body": "A louder, urgency-forward service presentation.",
+              "imageLayout": "stacked",
+              "image": {
+                "src": "assets/previews/high-vis-service.png",
+                "alt": "Real mobile screenshot preview of the high-vis service theme example page",
+                "width": 390,
+                "height": 700
+              },
+              "cta": { "label": "Open preview", "href": "/examples/high-vis-service/" }
+            }
           ]
         }
       ]

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "lint:css": "stylelint \"src/**/*.css\"",
     "lint:ts": "tsc --noEmit",
     "test": "vitest run",
-    "test:browser": "tsx tests/navigation-bar.browser.ts",
+    "test:browser": "tsx tests/navigation-bar.browser.ts && tsx tests/example-previews.browser.ts",
     "validate:dist-links": "node scripts/validate-dist-links.mjs",
     "validate:strict": "npm run schema:check && npm run lint:ts && npm run lint:css && npm run test && npm run test:browser && npm run validate && npm run validate:example:78th && npm run validate:example:baird && npm run validate:examples && npm run build && npm run build:example:78th && npm run build:example:baird && npm run build:examples && npm run validate:dist-links",
     "check": "npm run validate:strict"

--- a/schemas/site-content.schema.json
+++ b/schemas/site-content.schema.json
@@ -254,6 +254,13 @@
                                       ],
                                       "additionalProperties": false
                                     },
+                                    "imageLayout": {
+                                      "type": "string",
+                                      "enum": [
+                                        "inline",
+                                        "stacked"
+                                      ]
+                                    },
                                     "cta": {
                                       "$ref": "#/definitions/SiteContent/properties/site/properties/layout/properties/components/items/anyOf/0/anyOf/0/properties/primaryCta"
                                     },

--- a/src/build/build-examples.ts
+++ b/src/build/build-examples.ts
@@ -1,26 +1,17 @@
 import path from "node:path";
 
 import { themeNames } from "../themes/index.js";
-import { ValidationFailure, buildSiteFromFile } from "./framework.js";
-
-const examplesContentDir = path.resolve(process.cwd(), "content/examples/themes");
-const examplesOutDir = path.resolve(process.cwd(), "dist/examples");
-const examplesIndexContentPath = path.join(examplesContentDir, "index.json");
+import {
+  ValidationFailure,
+  buildThemeExamples,
+  examplesOutDir,
+} from "./theme-example-previews.js";
 
 try {
-  let builtPages = 0;
-  const examplesIndex = await buildSiteFromFile(examplesIndexContentPath, examplesOutDir);
-  builtPages += examplesIndex.pages.length;
-
-  for (const themeName of themeNames) {
-    const contentPath = path.join(examplesContentDir, `${themeName}.json`);
-    const outDir = path.join(examplesOutDir, themeName);
-    const siteContent = await buildSiteFromFile(contentPath, outDir);
-    builtPages += siteContent.pages.length;
-  }
+  const { builtPages, previewCount } = await buildThemeExamples();
 
   console.log(
-    `Built the theme preview index plus ${themeNames.length} theme example site(s) with ${builtPages} page(s) into ${path.relative(process.cwd(), examplesOutDir)}`,
+    `Built the theme preview index plus ${themeNames.length} theme example site(s) with ${builtPages} page(s) and ${previewCount} real screenshot preview(s) into ${path.relative(process.cwd(), examplesOutDir)}`,
   );
 } catch (error) {
   if (error instanceof ValidationFailure) {

--- a/src/build/static-server.ts
+++ b/src/build/static-server.ts
@@ -1,0 +1,91 @@
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+import { readFile, stat } from "node:fs/promises";
+import path from "node:path";
+
+const contentTypeByExtension: Record<string, string> = {
+  ".css": "text/css; charset=utf-8",
+  ".html": "text/html; charset=utf-8",
+  ".js": "text/javascript; charset=utf-8",
+  ".png": "image/png",
+};
+
+const resolveRequestPath = async (
+  outDir: string,
+  request: IncomingMessage,
+): Promise<string | null> => {
+  const requestPath = new URL(request.url ?? "/", "http://127.0.0.1").pathname;
+  const relativePath = decodeURIComponent(requestPath).replace(/^\/+/, "");
+  const candidatePath = path.resolve(outDir, relativePath);
+
+  if (path.relative(outDir, candidatePath).startsWith("..")) {
+    return null;
+  }
+
+  const candidateStats = await stat(candidatePath).catch(() => null);
+  if (candidateStats?.isDirectory()) {
+    return path.join(candidatePath, "index.html");
+  }
+
+  if (candidateStats?.isFile()) {
+    return candidatePath;
+  }
+
+  const indexPath = path.resolve(outDir, relativePath, "index.html");
+  if (path.relative(outDir, indexPath).startsWith("..")) {
+    return null;
+  }
+
+  const indexStats = await stat(indexPath).catch(() => null);
+  return indexStats?.isFile() ? indexPath : null;
+};
+
+export const createStaticServer = async (
+  outDir: string,
+): Promise<{ close: () => Promise<void>; origin: string }> => {
+  const server = createServer(async (request: IncomingMessage, response: ServerResponse) => {
+    try {
+      const filePath = await resolveRequestPath(outDir, request);
+      if (!filePath) {
+        response.writeHead(404).end("Not found");
+        return;
+      }
+
+      const body = await readFile(filePath);
+      response.writeHead(200, {
+        "content-type":
+          contentTypeByExtension[path.extname(filePath)] ?? "application/octet-stream",
+      });
+      response.end(body);
+    } catch (error) {
+      response.writeHead(500).end(String(error));
+    }
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      server.off("error", reject);
+      resolve();
+    });
+  });
+
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("Failed to resolve static server address.");
+  }
+
+  return {
+    close: () =>
+      new Promise<void>((resolve, reject) => {
+        server.close((error) => {
+          if (error) {
+            reject(error);
+            return;
+          }
+
+          resolve();
+        });
+      }),
+    origin: `http://127.0.0.1:${address.port}`,
+  };
+};

--- a/src/build/theme-example-previews.ts
+++ b/src/build/theme-example-previews.ts
@@ -1,0 +1,165 @@
+import { mkdir, readdir, rm } from "node:fs/promises";
+import path from "node:path";
+
+import { chromium, type BrowserContext, type Page } from "playwright";
+
+import { themeNames, type ThemeName } from "../themes/index.js";
+import { ValidationFailure, buildSiteFromFile } from "./framework.js";
+import { createStaticServer } from "./static-server.js";
+
+export const examplesContentDir = path.resolve(process.cwd(), "content/examples/themes");
+export const examplesOutDir = path.resolve(process.cwd(), "dist/examples");
+export const examplesIndexContentPath = path.join(examplesContentDir, "index.json");
+export const themePreviewImageDir = path.join("assets", "previews");
+export const themePreviewViewport = {
+  width: 390,
+  height: 700,
+} as const;
+
+export interface ThemeExampleBuildResult {
+  builtPages: number;
+  previewCount: number;
+}
+
+export const themePreviewImageHref = (themeName: ThemeName): string =>
+  path.posix.join(themePreviewImageDir, `${themeName}.png`);
+
+const themePreviewOutputPath = (outDir: string, themeName: ThemeName): string =>
+  path.join(outDir, themePreviewImageDir, `${themeName}.png`);
+
+const waitForPreviewToRender = async (page: Page): Promise<void> => {
+  await page.waitForLoadState("load");
+  await page.waitForSelector("body");
+  await page.evaluate(
+    () =>
+      new Promise<void>((resolve) => {
+        requestAnimationFrame(() => {
+          requestAnimationFrame(() => resolve());
+        });
+      }),
+  );
+};
+
+const allowOnlyLocalRequests = async (
+  browserContext: BrowserContext,
+  origin: string,
+): Promise<void> => {
+  await browserContext.route("**/*", async (route) => {
+    const requestUrl = route.request().url();
+    if (
+      requestUrl === "about:blank" ||
+      requestUrl.startsWith("data:") ||
+      requestUrl.startsWith(origin)
+    ) {
+      await route.continue();
+      return;
+    }
+
+    await route.abort();
+  });
+};
+
+const removeStalePreviewImages = async (
+  outDir: string,
+  expectedPaths: ReadonlySet<string>,
+): Promise<void> => {
+  const previewDirPath = path.join(outDir, themePreviewImageDir);
+  const entries = await readdir(previewDirPath, { withFileTypes: true }).catch((error) => {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return [];
+    }
+
+    throw error;
+  });
+
+  await Promise.all(
+    entries.map(async (entry) => {
+      const entryPath = path.join(previewDirPath, entry.name);
+      if (entry.isFile() && !expectedPaths.has(entryPath)) {
+        await rm(entryPath, { force: true });
+      }
+    }),
+  );
+};
+
+export const generateThemePreviewScreenshots = async (
+  outDir: string,
+  themesToRender: readonly ThemeName[] = themeNames,
+): Promise<number> => {
+  const previewDirPath = path.join(outDir, themePreviewImageDir);
+  const expectedPreviewPaths = new Set(
+    themesToRender.map((themeName) => themePreviewOutputPath(outDir, themeName)),
+  );
+  await mkdir(previewDirPath, { recursive: true });
+  await removeStalePreviewImages(outDir, expectedPreviewPaths);
+
+  const server = await createStaticServer(outDir);
+  const browser = await chromium.launch();
+
+  try {
+    const browserContext = await browser.newContext({
+      deviceScaleFactor: 1,
+      viewport: themePreviewViewport,
+    });
+    await allowOnlyLocalRequests(browserContext, server.origin);
+
+    try {
+      for (const themeName of themesToRender) {
+        const page = await browserContext.newPage();
+        const pageErrors: string[] = [];
+        page.on("pageerror", (error) => {
+          pageErrors.push(error.message);
+        });
+
+        await page.goto(`${server.origin}/${themeName}/`, {
+          waitUntil: "domcontentloaded",
+        });
+        await waitForPreviewToRender(page);
+        await page.screenshot({
+          path: themePreviewOutputPath(outDir, themeName),
+          type: "png",
+        });
+        await page.close();
+
+        if (pageErrors.length > 0) {
+          throw new Error(
+            `Theme preview screenshot failed for ${themeName}: ${pageErrors.join("; ")}`,
+          );
+        }
+      }
+    } finally {
+      await browserContext.close();
+    }
+  } finally {
+    await browser.close();
+    await server.close();
+  }
+
+  return themesToRender.length;
+};
+
+export const buildThemeExamples = async (
+  outDir: string = examplesOutDir,
+  contentDir: string = examplesContentDir,
+): Promise<ThemeExampleBuildResult> => {
+  let builtPages = 0;
+  const indexContentPath = path.join(contentDir, "index.json");
+  const examplesIndex = await buildSiteFromFile(indexContentPath, outDir);
+  builtPages += examplesIndex.pages.length;
+
+  for (const themeName of themeNames) {
+    const contentPath = path.join(contentDir, `${themeName}.json`);
+    const themeOutDir = path.join(outDir, themeName);
+    const siteContent = await buildSiteFromFile(contentPath, themeOutDir);
+    builtPages += siteContent.pages.length;
+  }
+
+  const previewCount = await generateThemePreviewScreenshots(outDir, themeNames);
+
+  return {
+    builtPages,
+    previewCount,
+  };
+};
+
+export { ValidationFailure };

--- a/src/components/feature-grid/feature-grid.css
+++ b/src/components/feature-grid/feature-grid.css
@@ -45,6 +45,10 @@
   align-items: start;
 }
 
+.c-feature-grid__item--stacked-image {
+  grid-template-columns: 1fr;
+}
+
 .c-feature-grid__item-media {
   margin: 0;
   display: grid;

--- a/src/components/feature-grid/feature-grid.render.ts
+++ b/src/components/feature-grid/feature-grid.render.ts
@@ -8,6 +8,7 @@ export const featureGridClassNames = [
   "c-feature-grid__items",
   "c-feature-grid__item",
   "c-feature-grid__item--has-image",
+  "c-feature-grid__item--stacked-image",
   "c-feature-grid__item--selected",
   "c-feature-grid__item-media",
   "c-feature-grid__item-image",
@@ -27,6 +28,10 @@ export const renderFeatureGrid = (data: FeatureGridData): string => {
 
         if (item.image) {
           itemClasses.push("c-feature-grid__item--has-image");
+        }
+
+        if (item.imageLayout === "stacked") {
+          itemClasses.push("c-feature-grid__item--stacked-image");
         }
 
         if (item.selected) {

--- a/src/components/feature-grid/feature-grid.schema.ts
+++ b/src/components/feature-grid/feature-grid.schema.ts
@@ -7,6 +7,7 @@ export const FeatureGridItemSchema = z
     title: z.string().min(1),
     body: z.string().min(1),
     image: ImageReferenceSchema.optional(),
+    imageLayout: z.enum(["inline", "stacked"]).optional(),
     cta: LinkSchema.optional(),
     selected: z.boolean().optional(),
   })

--- a/src/components/feature-grid/feature-grid.test.ts
+++ b/src/components/feature-grid/feature-grid.test.ts
@@ -19,6 +19,7 @@ describe("FeatureGridSchema", () => {
             height: 800,
             caption: "Optional image support keeps content flexible.",
           },
+          imageLayout: "stacked",
           selected: true,
           cta: {
             label: "See examples",
@@ -33,6 +34,7 @@ describe("FeatureGridSchema", () => {
     expect(html).toContain('<section class="c-feature-grid">');
     expect(html).toContain('<ul class="c-feature-grid__items">');
     expect(html).toContain('c-feature-grid__item--has-image');
+    expect(html).toContain('c-feature-grid__item--stacked-image');
     expect(html).toContain('<figure class="c-feature-grid__item-media">');
     expect(html).toContain('src="https://example.com/validation.jpg"');
     expect(html).toContain('width="1200" height="800"');

--- a/tests/example-previews.browser.ts
+++ b/tests/example-previews.browser.ts
@@ -1,0 +1,93 @@
+/// <reference lib="dom" />
+
+import assert from "node:assert/strict";
+import { mkdtemp, rm, stat } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { chromium } from "playwright";
+
+import {
+  buildThemeExamples,
+  themePreviewImageDir,
+  themePreviewViewport,
+} from "../src/build/theme-example-previews.js";
+import { createStaticServer } from "../src/build/static-server.js";
+import { themeNames } from "../src/themes/index.js";
+
+const runBrowserRegression = async (): Promise<void> => {
+  const outDir = await mkdtemp(path.join(os.tmpdir(), "cruftless-example-previews-"));
+  let closeServer: (() => Promise<void>) | undefined;
+
+  try {
+    const buildResult = await buildThemeExamples(outDir);
+    assert.equal(buildResult.builtPages, themeNames.length + 1);
+    assert.equal(buildResult.previewCount, themeNames.length);
+
+    await Promise.all(
+      themeNames.map((themeName) =>
+        stat(path.join(outDir, themePreviewImageDir, `${themeName}.png`)),
+      ),
+    );
+
+    const server = await createStaticServer(outDir);
+    closeServer = server.close;
+
+    const browser = await chromium.launch();
+
+    try {
+      const page = await browser.newPage({
+        viewport: { width: 1280, height: 900 },
+      });
+      const pageErrors: string[] = [];
+
+      page.on("pageerror", (error) => {
+        pageErrors.push(error.message);
+      });
+
+      await page.goto(`${server.origin}/`, {
+        waitUntil: "networkidle",
+      });
+
+      const metrics = await page.locator(".c-feature-grid__item--stacked-image").first().evaluate(
+        (item) => {
+          const image = item.querySelector(".c-feature-grid__item-image");
+          const title = item.querySelector(".c-feature-grid__item-title");
+
+          if (!(image instanceof HTMLImageElement) || !(title instanceof HTMLElement)) {
+            throw new Error("Expected a stacked feature-grid card with an image and title.");
+          }
+
+          const itemRect = item.getBoundingClientRect();
+          const imageRect = image.getBoundingClientRect();
+          const titleRect = title.getBoundingClientRect();
+
+          return {
+            imageBottom: imageRect.bottom,
+            imageNaturalHeight: image.naturalHeight,
+            imageNaturalWidth: image.naturalWidth,
+            imageWidth: imageRect.width,
+            itemWidth: itemRect.width,
+            titleTop: titleRect.top,
+          };
+        },
+      );
+
+      assert.equal(metrics.imageNaturalWidth, themePreviewViewport.width);
+      assert.equal(metrics.imageNaturalHeight, themePreviewViewport.height);
+      assert.ok(metrics.imageWidth >= metrics.itemWidth * 0.8);
+      assert.ok(metrics.titleTop >= metrics.imageBottom);
+      assert.deepEqual(pageErrors, []);
+    } finally {
+      await browser.close();
+    }
+  } finally {
+    if (closeServer) {
+      await closeServer();
+    }
+
+    await rm(outDir, { recursive: true, force: true });
+  }
+};
+
+await runBrowserRegression();

--- a/tests/theme-examples.test.ts
+++ b/tests/theme-examples.test.ts
@@ -3,13 +3,116 @@ import path from "node:path";
 
 import { describe, expect, it } from "vitest";
 
+import {
+  themePreviewImageHref,
+  themePreviewViewport,
+} from "../src/build/theme-example-previews.js";
 import { componentTypeNames } from "../src/components/index.js";
 import { SiteContentSchema } from "../src/schemas/site.schema.js";
 import { themeNames } from "../src/themes/index.js";
 
 const examplesContentDir = path.resolve(process.cwd(), "content/examples/themes");
+const examplesIndexPath = path.join(examplesContentDir, "index.json");
 
 describe("theme examples", () => {
+  it("wires the preview index to real screenshot-backed cards for every theme", async () => {
+    const rawJson = await readFile(examplesIndexPath, "utf8");
+    const siteContent = SiteContentSchema.parse(JSON.parse(rawJson) as unknown);
+    const featureGridComponents = siteContent.pages[0]?.components.filter(
+      (component) => component.type === "feature-grid",
+    );
+
+    const items = featureGridComponents?.flatMap((component) => component.items) ?? [];
+
+    expect(items).toHaveLength(themeNames.length);
+    expect(items.map((item) => item.title)).toEqual([
+      "Corporate",
+      "Brutalism",
+      "Workshop",
+      "Refined Professional",
+      "Friendly Modern",
+      "Heritage Local",
+      "Wellness Calm",
+      "High-Vis Service",
+    ]);
+
+    expect(
+      items.map((item) => ({
+        href: item.cta?.href,
+        imageAlt: item.image?.alt,
+        imageHeight: item.image?.height,
+        imageLayout: item.imageLayout,
+        imageSrc: item.image?.src,
+        imageWidth: item.image?.width,
+      })),
+    ).toEqual([
+      {
+        href: "/examples/corporate/",
+        imageAlt: "Real mobile screenshot preview of the corporate theme example page",
+        imageHeight: themePreviewViewport.height,
+        imageLayout: "stacked",
+        imageSrc: themePreviewImageHref("corporate"),
+        imageWidth: themePreviewViewport.width,
+      },
+      {
+        href: "/examples/brutalism/",
+        imageAlt: "Real mobile screenshot preview of the brutalism theme example page",
+        imageHeight: themePreviewViewport.height,
+        imageLayout: "stacked",
+        imageSrc: themePreviewImageHref("brutalism"),
+        imageWidth: themePreviewViewport.width,
+      },
+      {
+        href: "/examples/workshop/",
+        imageAlt: "Real mobile screenshot preview of the workshop theme example page",
+        imageHeight: themePreviewViewport.height,
+        imageLayout: "stacked",
+        imageSrc: themePreviewImageHref("workshop"),
+        imageWidth: themePreviewViewport.width,
+      },
+      {
+        href: "/examples/refined-professional/",
+        imageAlt: "Real mobile screenshot preview of the refined professional theme example page",
+        imageHeight: themePreviewViewport.height,
+        imageLayout: "stacked",
+        imageSrc: themePreviewImageHref("refined-professional"),
+        imageWidth: themePreviewViewport.width,
+      },
+      {
+        href: "/examples/friendly-modern/",
+        imageAlt: "Real mobile screenshot preview of the friendly modern theme example page",
+        imageHeight: themePreviewViewport.height,
+        imageLayout: "stacked",
+        imageSrc: themePreviewImageHref("friendly-modern"),
+        imageWidth: themePreviewViewport.width,
+      },
+      {
+        href: "/examples/heritage-local/",
+        imageAlt: "Real mobile screenshot preview of the heritage local theme example page",
+        imageHeight: themePreviewViewport.height,
+        imageLayout: "stacked",
+        imageSrc: themePreviewImageHref("heritage-local"),
+        imageWidth: themePreviewViewport.width,
+      },
+      {
+        href: "/examples/wellness-calm/",
+        imageAlt: "Real mobile screenshot preview of the wellness calm theme example page",
+        imageHeight: themePreviewViewport.height,
+        imageLayout: "stacked",
+        imageSrc: themePreviewImageHref("wellness-calm"),
+        imageWidth: themePreviewViewport.width,
+      },
+      {
+        href: "/examples/high-vis-service/",
+        imageAlt: "Real mobile screenshot preview of the high-vis service theme example page",
+        imageHeight: themePreviewViewport.height,
+        imageLayout: "stacked",
+        imageSrc: themePreviewImageHref("high-vis-service"),
+        imageWidth: themePreviewViewport.width,
+      },
+    ]);
+  });
+
   it("provides one example fixture for every theme", async () => {
     const fixtureFileNames = await Promise.all(
       themeNames.map(async (themeName) => {


### PR DESCRIPTION
## Summary
- generate real mobile-sized screenshot previews as part of `build:examples`
- wire the theme preview index cards to those generated images and render them full-width in stacked cards
- add schema, unit, and browser coverage for the new preview process

## Why
Issue #53 called out that the example previews should be real screenshots, not synthetic stand-ins, and that long full-page captures were too skinny and left-weighted to be useful.

## Validation
- `npm run validate:strict`

Closes #53
