### PR TITLE
Add optional Google Analytics support

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The generator follows a few hard rules:
 
 Every site file has two top-level sections:
 
-- `site`: site-wide settings such as name, base URL, theme, theme overrides, optional background image, and optional shared layout
+- `site`: site-wide settings such as name, base URL, theme, theme overrides, optional background image, optional Google Analytics measurement ID, and optional shared layout
 - `pages`: page definitions with a slug, title, optional metadata, and an ordered list of components
 
 ### Shared layout
@@ -43,6 +43,10 @@ If `site.layout.components` is present, those components wrap every page. One it
 - `{ "type": "page-content" }`
 
 That slot is where each page's own `components` array is inserted. This lets the repo reuse headers, nav, shared prose, or footers across every page without copying them into each page object.
+
+### Google Analytics
+
+If `site.googleAnalyticsMeasurementId` is present, every generated page includes the standard Google Analytics loader and `gtag('config', ...)` call for that GA4 measurement ID.
 
 ### Available components
 

--- a/schemas/site-content.schema.json
+++ b/schemas/site-content.schema.json
@@ -75,6 +75,10 @@
               "type": "string",
               "format": "uri"
             },
+            "googleAnalyticsMeasurementId": {
+              "type": "string",
+              "pattern": "^G-[A-Z0-9]+$"
+            },
             "layout": {
               "type": "object",
               "properties": {

--- a/src/renderer/render-page.ts
+++ b/src/renderer/render-page.ts
@@ -1,6 +1,26 @@
 import type { PageData, SiteData } from "../schemas/site.schema.js";
 import { escapeHtml } from "./escape-html.js";
 
+const renderGoogleAnalyticsTags = (site: SiteData): string => {
+  const measurementId = site.googleAnalyticsMeasurementId;
+
+  if (!measurementId) {
+    return "";
+  }
+
+  const loaderUrl = `https://www.googletagmanager.com/gtag/js?id=${encodeURIComponent(measurementId)}`;
+
+  return [
+    `    <script async src="${escapeHtml(loaderUrl)}"></script>`,
+    "    <script>",
+    "      window.dataLayer = window.dataLayer || [];",
+    "      function gtag(){dataLayer.push(arguments);}",
+    "      gtag('js', new Date());",
+    `      gtag('config', ${JSON.stringify(measurementId)});`,
+    "    </script>",
+  ].join("\n");
+};
+
 export const renderPageDocument = ({
   site,
   page,
@@ -29,6 +49,7 @@ export const renderPageDocument = ({
     '    <meta name="viewport" content="width=device-width, initial-scale=1" />',
     `    <title>${title}</title>`,
     description,
+    renderGoogleAnalyticsTags(site),
     `    <link rel="canonical" href="${escapeHtml(canonicalUrl)}" />`,
     `    <link rel="stylesheet" href="${escapeHtml(stylesheetHref)}" />`,
     scriptHref ? `    <script src="${escapeHtml(scriptHref)}" defer></script>` : "",

--- a/src/schemas/site.schema.ts
+++ b/src/schemas/site.schema.ts
@@ -7,6 +7,10 @@ import {
   themeStructureNames,
 } from "../themes/theme-options.js";
 
+const GoogleAnalyticsMeasurementIdSchema = z
+  .string()
+  .regex(/^G-[A-Z0-9]+$/i, "googleAnalyticsMeasurementId must look like a GA4 measurement ID");
+
 export const PageMetadataSchema = z
   .object({
     description: z.string().min(1).max(200).optional(),
@@ -51,6 +55,7 @@ export const SiteSchema = z
     theme: z.enum(themeNames),
     themeOverrides: SiteThemeOverridesSchema.optional(),
     pageBackgroundImageUrl: z.string().url().optional(),
+    googleAnalyticsMeasurementId: GoogleAnalyticsMeasurementIdSchema.optional(),
     layout: SiteLayoutSchema.optional(),
   })
   .strict();

--- a/tests/build-output.test.ts
+++ b/tests/build-output.test.ts
@@ -90,6 +90,32 @@ const createStaticSite = () =>
     ],
   });
 
+const createAnalyticsSite = () =>
+  SiteContentSchema.parse({
+    site: {
+      name: "LaunchKit",
+      baseUrl: "https://launchkit.example",
+      theme: "friendly-modern",
+      googleAnalyticsMeasurementId: "G-TEST1234",
+    },
+    pages: [
+      {
+        slug: "/",
+        title: "Home",
+        components: [
+          {
+            type: "hero",
+            headline: "Launch faster",
+            primaryCta: {
+              label: "Get started",
+              href: "/start",
+            },
+          },
+        ],
+      },
+    ],
+  });
+
 describe("buildSite output writes", () => {
   it("does not rewrite unchanged files on repeated builds", async () => {
     const outDir = await mkdtemp(path.join(os.tmpdir(), "cruftless-build-output-"));
@@ -137,6 +163,24 @@ describe("buildSite output writes", () => {
       expect(secondBuild.filesRemoved).toBe(2);
       await expect(access(path.join(outDir, "assets", "site.js"))).rejects.toThrow();
       await expect(access(path.join(outDir, "about", "index.html"))).rejects.toThrow();
+    } finally {
+      await rm(outDir, { recursive: true, force: true });
+    }
+  });
+
+  it("includes google analytics tags when a measurement ID is configured", async () => {
+    const outDir = await mkdtemp(path.join(os.tmpdir(), "cruftless-build-analytics-"));
+
+    try {
+      await buildSite(createAnalyticsSite(), outDir);
+
+      const html = await readFile(path.join(outDir, "index.html"), "utf8");
+
+      expect(html).toContain(
+        '<script async src="https://www.googletagmanager.com/gtag/js?id=G-TEST1234"></script>',
+      );
+      expect(html).toContain(`gtag('config', "G-TEST1234");`);
+      await expect(access(path.join(outDir, "assets", "site.js"))).rejects.toThrow();
     } finally {
       await rm(outDir, { recursive: true, force: true });
     }

--- a/tests/site-json-schema.test.ts
+++ b/tests/site-json-schema.test.ts
@@ -109,4 +109,71 @@ describe("site JSON schema", async () => {
       ],
     });
   });
+
+  it("accepts an optional google analytics measurement ID", () => {
+    const ajv = new Ajv({ allErrors: true, strict: false });
+    addFormats(ajv);
+
+    const validate = ajv.compile(buildSiteContentJsonSchema());
+    const isValid = validate({
+      site: {
+        name: "LaunchKit",
+        baseUrl: "https://launchkit.example",
+        theme: "friendly-modern",
+        googleAnalyticsMeasurementId: "G-TEST1234",
+      },
+      pages: [
+        {
+          slug: "/",
+          title: "Home",
+          components: [
+            {
+              type: "hero",
+              headline: "Launch faster",
+              primaryCta: {
+                label: "Get started",
+                href: "/start",
+              },
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(isValid).toBe(true);
+  });
+
+  it("rejects an invalid google analytics measurement ID", () => {
+    const ajv = new Ajv({ allErrors: true, strict: false });
+    addFormats(ajv);
+
+    const validate = ajv.compile(buildSiteContentJsonSchema());
+    const isValid = validate({
+      site: {
+        name: "LaunchKit",
+        baseUrl: "https://launchkit.example",
+        theme: "friendly-modern",
+        googleAnalyticsMeasurementId: "UA-123456",
+      },
+      pages: [
+        {
+          slug: "/",
+          title: "Home",
+          components: [
+            {
+              type: "hero",
+              headline: "Launch faster",
+              primaryCta: {
+                label: "Get started",
+                href: "/start",
+              },
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(isValid).toBe(false);
+    expect(validate.errors?.some((issue: ErrorObject) => issue.keyword === "pattern")).toBe(true);
+  });
 });


### PR DESCRIPTION
## What changed
- Added an optional `site.googleAnalyticsMeasurementId` field for a GA4 measurement ID.
- Generated pages now include the standard Google Analytics loader and `gtag` config when that ID is present.
- Updated the checked-in JSON schema, tests, and README so the new field is documented and validated.

## Why it changed
Issue #54 asked for a small site-level parameter that is enough to turn on Google Analytics without opening up a broader tracking configuration surface.

## Impact
- Site content can opt into Google Analytics by setting a single measurement ID.
- Sites that do not set the field render the same as before.

## Validation
- Ran `npm run validate:strict` successfully.

Closes #54.
