### PR TITLE
[codex] Fix mobile full-height layout

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -10,6 +10,8 @@
         "deg",
         "fr",
         "rem",
+        "svh",
+        "dvh",
         "vh",
         "vw"
       ],

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "lint:css": "stylelint \"src/**/*.css\"",
     "lint:ts": "tsc --noEmit",
     "test": "vitest run",
-    "test:browser": "tsx tests/navigation-bar.browser.ts && tsx tests/example-previews.browser.ts",
+    "test:browser": "tsx tests/navigation-bar.browser.ts && tsx tests/example-previews.browser.ts && tsx tests/full-height.browser.ts",
     "validate:dist-links": "node scripts/validate-dist-links.mjs",
     "validate:strict": "npm run schema:check && npm run lint:ts && npm run lint:css && npm run test && npm run test:browser && npm run validate && npm run validate:example:78th && npm run validate:example:baird && npm run validate:examples && npm run build && npm run build:example:78th && npm run build:example:baird && npm run build:examples && npm run validate:dist-links",
     "check": "npm run validate:strict"

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -9,6 +9,7 @@
 }
 
 html {
+  min-height: 100%;
   font-family: var(--font-family-body);
   line-height: var(--line-height-body);
   background: var(--page-background);
@@ -18,6 +19,8 @@ html {
 body {
   margin: 0;
   min-height: 100vh;
+  min-height: 100svh;
+  min-height: 100dvh;
   background: transparent;
   color: var(--color-text);
 }
@@ -46,6 +49,7 @@ button:focus-visible {
 .l-page {
   display: grid;
   gap: 0;
+  min-height: inherit;
 }
 
 .c-button {

--- a/tests/component-css-widths.test.ts
+++ b/tests/component-css-widths.test.ts
@@ -55,6 +55,15 @@ describe("component width tokens", () => {
     expect(css).toContain("color: var(--color-primary-contrast);");
   });
 
+  it("uses mobile-safe viewport units for short-page layouts", async () => {
+    const css = await readBaseCss();
+
+    expect(css).toContain("min-height: 100svh;");
+    expect(css).toContain("min-height: 100dvh;");
+    expect(css).toContain(".l-page {");
+    expect(css).toContain("min-height: inherit;");
+  });
+
   it("keeps google maps width modes split between content and container tokens", async () => {
     const css = await readComponentCss("google-maps");
 

--- a/tests/full-height.browser.ts
+++ b/tests/full-height.browser.ts
@@ -1,0 +1,92 @@
+/// <reference lib="dom" />
+
+import assert from "node:assert/strict";
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { chromium } from "playwright";
+
+import { buildSite } from "../src/build/framework.js";
+import { createStaticServer } from "../src/build/static-server.js";
+import { SiteContentSchema } from "../src/schemas/site.schema.js";
+
+const phoneViewport = { width: 390, height: 844 };
+
+const createShortPageFixture = () =>
+  SiteContentSchema.parse({
+    site: {
+      name: "LaunchKit",
+      baseUrl: "https://launchkit.example",
+      theme: "friendly-modern",
+    },
+    pages: [
+      {
+        slug: "/",
+        title: "Home",
+        components: [
+          {
+            type: "prose",
+            title: "Short page",
+            paragraphs: ["This page is intentionally short so the layout must fill the viewport."],
+          },
+        ],
+      },
+    ],
+  });
+
+const runBrowserRegression = async (): Promise<void> => {
+  const outDir = await mkdtemp(path.join(os.tmpdir(), "cruftless-full-height-browser-"));
+  let closeServer: (() => Promise<void>) | undefined;
+
+  try {
+    await buildSite(createShortPageFixture(), outDir);
+    const server = await createStaticServer(outDir);
+    closeServer = server.close;
+
+    const browser = await chromium.launch();
+
+    try {
+      const page = await browser.newPage({
+        viewport: phoneViewport,
+      });
+      const pageErrors: string[] = [];
+
+      page.on("pageerror", (error) => {
+        pageErrors.push(error.message);
+      });
+
+      await page.goto(`${server.origin}/`, {
+        waitUntil: "networkidle",
+      });
+
+      const metrics = await page.evaluate(() => {
+        const pageRoot = document.querySelector(".l-page");
+
+        if (!(pageRoot instanceof HTMLElement)) {
+          throw new Error("Expected the page root element to exist.");
+        }
+
+        return {
+          bodyHeight: document.body.getBoundingClientRect().height,
+          pageHeight: pageRoot.getBoundingClientRect().height,
+          viewportHeight: window.innerHeight,
+        };
+      });
+
+      assert.ok(metrics.bodyHeight >= metrics.viewportHeight - 1);
+      assert.ok(metrics.pageHeight >= metrics.viewportHeight - 1);
+      assert.deepEqual(pageErrors, []);
+    } finally {
+      await browser.close();
+    }
+  } finally {
+    if (closeServer) {
+      await closeServer();
+    }
+
+    await rm(outDir, { recursive: true, force: true });
+  }
+};
+
+await runBrowserRegression();


### PR DESCRIPTION
## Summary
- use mobile-safe viewport units in the built-in base layout CSS
- stretch the top-level page wrapper so short pages reach the bottom of the viewport
- add CSS and browser regressions for the short-page mobile case

## Why
The built-in layout relied on `100vh` alone, and the main page wrapper did not inherit the full-page minimum height. On mobile browsers that could leave short pages stopping above the bottom edge.

## Impact
Pages using the built-in CSS now fill the viewport more reliably on phones without requiring custom CSS.

## Validation
- `npm run validate:strict`

Closes #58
