### PR TITLE
[codex] Keep spare viewport space below page content

### DIFF
--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -48,6 +48,7 @@ button:focus-visible {
 
 .l-page {
   display: grid;
+  align-content: start;
   gap: 0;
   min-height: inherit;
 }

--- a/tests/full-height.browser.ts
+++ b/tests/full-height.browser.ts
@@ -19,6 +19,27 @@ const createShortPageFixture = () =>
       name: "LaunchKit",
       baseUrl: "https://launchkit.example",
       theme: "friendly-modern",
+      layout: {
+        components: [
+          {
+            type: "navigation-bar",
+            brandText: "LaunchKit",
+            links: [
+              {
+                label: "Home",
+                href: "/",
+              },
+              {
+                label: "Contact",
+                href: "/contact",
+              },
+            ],
+          },
+          {
+            type: "page-content",
+          },
+        ],
+      },
     },
     pages: [
       {
@@ -69,12 +90,18 @@ const runBrowserRegression = async (): Promise<void> => {
 
         return {
           bodyHeight: document.body.getBoundingClientRect().height,
+          bottomSlack:
+            pageRoot.getBoundingClientRect().bottom -
+            Array.from(pageRoot.children).at(-1)!.getBoundingClientRect().bottom,
+          firstChildHeight: Array.from(pageRoot.children).at(0)!.getBoundingClientRect().height,
           pageHeight: pageRoot.getBoundingClientRect().height,
           viewportHeight: window.innerHeight,
         };
       });
 
       assert.ok(metrics.bodyHeight >= metrics.viewportHeight - 1);
+      assert.ok(metrics.bottomSlack > 24);
+      assert.ok(metrics.firstChildHeight < metrics.viewportHeight * 0.25);
       assert.ok(metrics.pageHeight >= metrics.viewportHeight - 1);
       assert.deepEqual(pageErrors, []);
     } finally {


### PR DESCRIPTION
## What changed
- keep the shared `.l-page` grid aligned to the top of the viewport instead of stretching its rows across leftover height
- extend the browser regression to cover a short page that includes the navigation bar
- assert that extra viewport space remains below the last rendered section instead of inflating earlier content

## Why
Short pages were still filling the viewport, but CSS Grid was distributing the unused height across rows. That caused the navigation bar and other content blocks to appear spaced out when there was not much page content.

## Impact
Generated pages still use the full screen height, but spare space now collects at the bottom of the page where it belongs.

## Validation
- `npm run test:browser`
- `npm run build`