### PR TITLE
[codex] page background image support

### DIFF
--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -21,7 +21,12 @@ body {
   min-height: 100vh;
   min-height: 100svh;
   min-height: 100dvh;
-  background: transparent;
+  background-color: transparent;
+  background-image: var(--site-page-background-image, none);
+  background-position: center top;
+  background-repeat: no-repeat;
+  background-size: cover;
+  background-attachment: fixed;
   color: var(--color-text);
 }
 

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -23,7 +23,7 @@ body {
   min-height: 100dvh;
   background-color: transparent;
   background-image: var(--site-page-background-image, none);
-  background-position: center top;
+  background-position: left top;
   background-repeat: no-repeat;
   background-size: cover;
   background-attachment: fixed;

--- a/src/themes/theme-validation.test.ts
+++ b/src/themes/theme-validation.test.ts
@@ -207,6 +207,11 @@ describe("theme validation", () => {
     expect(findUnknownCssVarTokens(".demo { color: var(--not-a-token); }")).toEqual([
       "--not-a-token",
     ]);
+    expect(
+      findUnknownCssVarTokens(
+        ".demo { background-image: var(--site-page-background-image, none); }",
+      ),
+    ).toEqual([]);
   });
 
   it("rejects theme CSS that references unknown tokens", () => {

--- a/src/validation/theme-validation.ts
+++ b/src/validation/theme-validation.ts
@@ -5,6 +5,7 @@ import { assertExactThemeTokens, themeTokenSet } from "../themes/tokens.js";
 import type { ValidationIssue } from "./site-validation.js";
 
 const CSS_VAR_PATTERN = /var\((--[a-z0-9-]+)/gi;
+const ALLOWED_NON_THEME_CSS_VAR_PREFIXES = ["--site-"] as const;
 const DECLARATION_PATTERN = /^\s*([a-z-]+|--[a-z0-9-]+)\s*:\s*(.*)$/i;
 const DISALLOWED_CSS_PROPERTIES = new Set([
   "float",
@@ -128,9 +129,13 @@ export const findUnknownCssVarTokens = (css: string): string[] => {
     foundTokens.add(match[1]);
   }
 
-  return [...foundTokens].filter(
-    (tokenName) => !themeTokenSet.has(tokenName as ThemeTokenName),
-  );
+  return [...foundTokens].filter((tokenName) => {
+    if (themeTokenSet.has(tokenName as ThemeTokenName)) {
+      return false;
+    }
+
+    return !ALLOWED_NON_THEME_CSS_VAR_PREFIXES.some((prefix) => tokenName.startsWith(prefix));
+  });
 };
 
 export const validateThemeDefinition = (

--- a/tests/78th-street-studios-example.test.ts
+++ b/tests/78th-street-studios-example.test.ts
@@ -69,6 +69,7 @@ describe("78th Street Studios example", () => {
       expect(js).toContain("resolveNavigationBarMode");
       expect(css).toContain("--site-page-background-image:");
       expect(css).toContain("background-image: var(--site-page-background-image, none);");
+      expect(css).toContain("background-position: left top;");
       expect(css).toContain(
         'url("https://78thstreetstudios.com/sites/78thstreetstudios.com/files/styles/adaptive/public/media/images/background/IMG_CFD448348658-1.jpeg?itok=FLmeLmsX")',
       );

--- a/tests/78th-street-studios-example.test.ts
+++ b/tests/78th-street-studios-example.test.ts
@@ -68,6 +68,7 @@ describe("78th Street Studios example", () => {
       expect(css).toContain("--color-accent: #ff9e64;");
       expect(js).toContain("resolveNavigationBarMode");
       expect(css).toContain("--site-page-background-image:");
+      expect(css).toContain("background-image: var(--site-page-background-image, none);");
       expect(css).toContain(
         'url("https://78thstreetstudios.com/sites/78thstreetstudios.com/files/styles/adaptive/public/media/images/background/IMG_CFD448348658-1.jpeg?itok=FLmeLmsX")',
       );


### PR DESCRIPTION
## What changed
- Added support for `--site-page-background-image` to the shared page shell.
- Positioned the page background image at the left edge instead of centering it.
- Allowed `--site-*` CSS custom properties through theme validation so the site-owned variable is valid.

## Why
- The site background image was being emitted but not consumed by the page layout.
- Left anchoring better matches the intended composition for the 78th Street Studios background image.

## Validation
- `npx vitest run tests/78th-street-studios-example.test.ts src/themes/theme-validation.test.ts`
- `node scripts/shared-site-gen.mjs dev:prepare`
