### PR TITLE
[codex] apply page background to body

### DIFF
--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -12,7 +12,6 @@ html {
   min-height: 100%;
   font-family: var(--font-family-body);
   line-height: var(--line-height-body);
-  background: var(--page-background);
   color: var(--color-text);
 }
 
@@ -21,7 +20,7 @@ body {
   min-height: 100vh;
   min-height: 100svh;
   min-height: 100dvh;
-  background-color: transparent;
+  background: var(--page-background);
   background-image: var(--site-page-background-image, none);
   background-position: left top;
   background-repeat: no-repeat;

--- a/tests/78th-street-studios-example.test.ts
+++ b/tests/78th-street-studios-example.test.ts
@@ -68,6 +68,7 @@ describe("78th Street Studios example", () => {
       expect(css).toContain("--color-accent: #ff9e64;");
       expect(js).toContain("resolveNavigationBarMode");
       expect(css).toContain("--site-page-background-image:");
+      expect(css).toContain("background: var(--page-background);");
       expect(css).toContain("background-image: var(--site-page-background-image, none);");
       expect(css).toContain("background-position: left top;");
       expect(css).toContain(


### PR DESCRIPTION
Moves the page-level background color onto `body` instead of leaving it on `html`.

Why:
- The navbar was sitting against the wrong canvas layer when page/theme background variables were in play.
- Applying `--page-background` on `body` keeps the overall page background consistent for the navbar and the rest of the page.

What changed:
- Removed the `html` background assignment from the base stylesheet.
- Set `body` to use `background: var(--page-background)` while preserving the page background image layer.
- Added a regression assertion in the 78th Street Studios example test.

Validation:
- `npm run lint:ts`
- `npm test`