### PR TITLE
[codex] use scrolling page background

### DIFF
--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -25,7 +25,7 @@ body {
   background-position: left top;
   background-repeat: no-repeat;
   background-size: cover;
-  background-attachment: fixed;
+  background-attachment: scroll;
   color: var(--color-text);
 }
 

--- a/tests/78th-street-studios-example.test.ts
+++ b/tests/78th-street-studios-example.test.ts
@@ -71,6 +71,7 @@ describe("78th Street Studios example", () => {
       expect(css).toContain("background: var(--page-background);");
       expect(css).toContain("background-image: var(--site-page-background-image, none);");
       expect(css).toContain("background-position: left top;");
+      expect(css).toContain("background-attachment: scroll;");
       expect(css).toContain(
         'url("https://78thstreetstudios.com/sites/78thstreetstudios.com/files/styles/adaptive/public/media/images/background/IMG_CFD448348658-1.jpeg?itok=FLmeLmsX")',
       );


### PR DESCRIPTION
Changes the page background attachment from `fixed` to `scroll`.

Why:
- `fixed` can be quirky on mobile and is more expensive to paint.
- `scroll` keeps the page background stable without introducing viewport-pinned background behavior.

What changed:
- Updated the base page stylesheet to use `background-attachment: scroll`.
- Kept the page background color and left-aligned page background image behavior intact.
- Updated the 78th Street Studios example test to assert the new default.

Validation:
- `npm run lint:ts`
- `npm test`