### PR TITLE
[codex] optimize local component images

### DIFF
--- a/src/build/framework.ts
+++ b/src/build/framework.ts
@@ -463,18 +463,6 @@ const resolveLocalContentAsset = (
   };
 };
 
-const pageSlugToLocalContentAssetHref = (slug: string, assetPath: string): string => {
-  const normalizedAssetPath = resolveContentRootRelativeAssetPath(assetPath);
-
-  if (!normalizedAssetPath) {
-    return assetPath;
-  }
-  const pagePath = slug === "/" ? "/index.html" : path.posix.join(slug, "index.html");
-  const relativePath = path.posix.relative(path.posix.dirname(pagePath), `/${normalizedAssetPath}`);
-
-  return `${relativePath || path.posix.basename(normalizedAssetPath)}${extractUrlSuffix(assetPath)}`;
-};
-
 const localContentAssetPathToCssHref = (assetPath: string): string => {
   const normalizedAssetPath = resolveContentRootRelativeAssetPath(assetPath);
 
@@ -486,27 +474,6 @@ const localContentAssetPathToCssHref = (assetPath: string): string => {
   return `${relativePath || path.posix.basename(normalizedAssetPath)}${extractUrlSuffix(assetPath)}`;
 };
 
-const rewriteLocalContentAssetsForPage = <T>(value: T, slug: string): T => {
-  if (Array.isArray(value)) {
-    return value.map((entry) => rewriteLocalContentAssetsForPage(entry, slug)) as T;
-  }
-
-  if (typeof value !== "object" || value === null) {
-    return value;
-  }
-
-  const record = value as Record<string, unknown>;
-  const rewrittenEntries = Object.entries(record).map(([key, entry]) => {
-    if (key === "src" && typeof entry === "string" && isLocalContentAssetPath(entry)) {
-      return [key, pageSlugToLocalContentAssetHref(slug, entry)];
-    }
-
-    return [key, rewriteLocalContentAssetsForPage(entry, slug)];
-  });
-
-  return Object.fromEntries(rewrittenEntries) as T;
-};
-
 const rewriteLocalContentAssetsForSiteCss = (site: SiteData): SiteData => {
   if (!site.pageBackgroundImageUrl || !isLocalContentAssetPath(site.pageBackgroundImageUrl)) {
     return site;
@@ -516,27 +483,6 @@ const rewriteLocalContentAssetsForSiteCss = (site: SiteData): SiteData => {
     ...site,
     pageBackgroundImageUrl: localContentAssetPathToCssHref(site.pageBackgroundImageUrl),
   };
-};
-
-const collectObjectImageSources = (value: unknown): string[] => {
-  if (Array.isArray(value)) {
-    return value.flatMap((entry) => collectObjectImageSources(entry));
-  }
-
-  if (typeof value !== "object" || value === null) {
-    return [];
-  }
-
-  const record = value as Record<string, unknown>;
-  const imageSources = typeof record.src === "string" ? [record.src] : [];
-  const backgroundImageSources =
-    typeof record.pageBackgroundImageUrl === "string" ? [record.pageBackgroundImageUrl] : [];
-
-  return [
-    ...imageSources,
-    ...backgroundImageSources,
-    ...Object.values(record).flatMap((entry) => collectObjectImageSources(entry)),
-  ];
 };
 
 const collectFilesRecursively = async (directoryPath: string): Promise<string[]> => {
@@ -692,10 +638,7 @@ export const buildSite = async (
 
   for (const [pageIndex, page] of siteContent.pages.entries()) {
     const renderContext = imagePipeline?.renderContextForPage(page.slug) ?? defaultComponentRenderContext;
-    const bodyHtml = rewriteLocalContentAssetsForPage(
-      resolvePageComponents(siteContent.site, page, pageIndex),
-      page.slug,
-    )
+    const bodyHtml = resolvePageComponents(siteContent.site, page, pageIndex)
       .map((component) => renderComponent(component, renderContext))
       .join("\n");
     const documentHtml = renderPageDocument({
@@ -712,18 +655,13 @@ export const buildSite = async (
   }
 
   if (contentPath) {
-    const localContentAssets = new Map(
-      collectObjectImageSources(siteContent)
-        .map((assetPath) => resolveLocalContentAsset(assetPath, contentPath))
-        .filter((asset): asset is { outputRelativePath: string; sourcePath: string } => asset !== undefined)
-        .map((asset) => [asset.outputRelativePath, asset.sourcePath]),
-    );
+    const pageBackgroundImage = resolveLocalContentAsset(siteContent.site.pageBackgroundImageUrl ?? "", contentPath);
 
-    for (const [outputRelativePath, sourcePath] of localContentAssets) {
-      const outputPath = path.join(outDir, ...outputRelativePath.split("/"));
+    if (pageBackgroundImage) {
+      const outputPath = path.join(outDir, ...pageBackgroundImage.outputRelativePath.split("/"));
       await mkdir(path.dirname(outputPath), { recursive: true });
       expectedFiles.add(outputPath);
-      recordWriteResult(await copyFileIfChanged(sourcePath, outputPath));
+      recordWriteResult(await copyFileIfChanged(pageBackgroundImage.sourcePath, outputPath));
     }
   }
 

--- a/src/build/image-pipeline.ts
+++ b/src/build/image-pipeline.ts
@@ -90,17 +90,6 @@ const metadataCache = new Map<string, { metadata: ImageSourceMetadata; mtimeMs: 
 
 const isRemoteAssetHref = (href: string): boolean => /^[a-z]+:/iu.test(href) || href.startsWith("//");
 
-const isPassthroughLocalAssetHref = (href: string): boolean => {
-  const normalizedHref = href.trim().replaceAll("\\", "/");
-
-  return (
-    normalizedHref.length > 0 &&
-    !isRemoteAssetHref(normalizedHref) &&
-    !path.isAbsolute(normalizedHref) &&
-    !normalizedHref.startsWith("assets/")
-  );
-};
-
 const normalizeProjectRelativePath = (filePath: string, projectRoot: string): string =>
   path.relative(projectRoot, filePath).replaceAll("\\", "/");
 
@@ -531,10 +520,6 @@ export const prepareImagePipeline = async (
   const preparedVariants = new Map<string, PreparedVariant>();
 
   for (const usageEntry of usages) {
-    if (isPassthroughLocalAssetHref(usageEntry.usage.sourceHref)) {
-      continue;
-    }
-
     const localSource = resolveLocalImageSource(usageEntry.usage.sourceHref, contentPath);
 
     if (!localSource) {

--- a/tests/build-output.test.ts
+++ b/tests/build-output.test.ts
@@ -1,4 +1,4 @@
-import { access, mkdir, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { access, mkdir, mkdtemp, readFile, readdir, rm, stat, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 
@@ -14,16 +14,16 @@ const waitForMtimeTick = async (): Promise<void> =>
   });
 
 const removeDirectory = async (directoryPath: string): Promise<void> => {
-  for (let attempt = 0; attempt < 20; attempt += 1) {
+  for (let attempt = 0; attempt < 50; attempt += 1) {
     try {
       await rm(directoryPath, { recursive: true, force: true });
       return;
     } catch (error) {
       const errorCode = (error as NodeJS.ErrnoException).code;
 
-      if ((errorCode === "EBUSY" || errorCode === "EPERM") && attempt < 19) {
+      if ((errorCode === "EBUSY" || errorCode === "EPERM") && attempt < 49) {
         await new Promise((resolve) => {
-          setTimeout(resolve, 100);
+          setTimeout(resolve, 200);
         });
         continue;
       }
@@ -241,7 +241,7 @@ describe("buildSite output writes", () => {
     }
   });
 
-  it("copies referenced content preview images into dist and removes them when no longer needed", async () => {
+  it("optimizes referenced content preview images into assets and removes them when no longer needed", async () => {
     const projectRoot = await mkdtemp(path.join(os.tmpdir(), "cruftless-build-local-assets-"));
     const contentDir = path.join(projectRoot, "content");
     const previewsDir = path.join(contentDir, "examples", "previews");
@@ -250,7 +250,7 @@ describe("buildSite output writes", () => {
     const previewImagePath = path.join(previewsDir, "local-preview.png");
 
     try {
-      const previewImageBytes = await createPngBytes(1600, 900);
+      const previewImageBytes = await createPngBytes(2400, 1350);
       await mkdir(previewsDir, { recursive: true });
       await writeFile(previewImagePath, previewImageBytes);
       await writeFile(
@@ -292,12 +292,20 @@ describe("buildSite output writes", () => {
       );
 
       const firstBuild = await buildSite(await loadValidatedSite(contentPath), outDir, { contentPath });
-      const copiedPreviewPath = path.join(outDir, "examples", "previews", "local-preview.png");
+      const optimizedPreviewDir = path.join(outDir, "assets", "images");
+      const optimizedPreviewName = (await readdir(optimizedPreviewDir)).find((name) =>
+        name.startsWith("local-preview-media-wide-"),
+      );
+      if (!optimizedPreviewName) {
+        throw new Error("missing optimized preview image");
+      }
+      const optimizedPreviewPath = path.join(optimizedPreviewDir, optimizedPreviewName);
       const html = await readFile(path.join(outDir, "index.html"), "utf8");
+      const optimizedPreviewStats = await stat(optimizedPreviewPath);
 
       expect(firstBuild.filesCreated).toBeGreaterThan(0);
-      expect((await readFile(copiedPreviewPath)).equals(previewImageBytes)).toBe(true);
-      expect(html).toContain('src="examples/previews/local-preview.png"');
+      expect(optimizedPreviewStats.size).toBeLessThan(previewImageBytes.length);
+      expect(html).toContain(`src="assets/images/${optimizedPreviewName}"`);
 
       await writeFile(
         contentPath,
@@ -333,7 +341,7 @@ describe("buildSite output writes", () => {
 
       const secondBuild = await buildSite(await loadValidatedSite(contentPath), outDir, { contentPath });
       expect(secondBuild.filesRemoved).toBeGreaterThan(0);
-      await expect(access(copiedPreviewPath)).rejects.toThrow();
+      await expect(access(optimizedPreviewPath)).rejects.toThrow();
     } finally {
       await removeDirectory(projectRoot);
     }
@@ -348,7 +356,7 @@ describe("buildSite output writes", () => {
     const previewImagePath = path.join(previewsDir, "landing-page.png");
 
     try {
-      const previewImageBytes = await createPngBytes(1600, 900);
+      const previewImageBytes = await createPngBytes(2400, 1350);
       await mkdir(previewsDir, { recursive: true });
       await writeFile(previewImagePath, previewImageBytes);
       const siteContent = {
@@ -365,7 +373,7 @@ describe("buildSite output writes", () => {
             components: [
               {
                 type: "media",
-                src: "/content/images/landing-page.png",
+                src: "content/images/landing-page.png",
                 alt: "Locally stored gallery image",
                 size: "wide",
               },
@@ -379,16 +387,27 @@ describe("buildSite output writes", () => {
       const nestedHtml = await readFile(path.join(outDir, "gallery", "index.html"), "utf8");
       const css = await readFile(path.join(outDir, "assets", "site.css"), "utf8");
       const copiedPreviewPath = path.join(outDir, "images", "landing-page.png");
+      const optimizedPreviewDir = path.join(outDir, "assets", "images");
+      const optimizedPreviewName = (await readdir(optimizedPreviewDir)).find((name) =>
+        name.startsWith("landing-page-media-wide-"),
+      );
+
+      if (!optimizedPreviewName) {
+        throw new Error("missing optimized nested preview image");
+      }
 
       expect((await readFile(copiedPreviewPath)).equals(previewImageBytes)).toBe(true);
-      expect(nestedHtml).toContain('src="../images/landing-page.png"');
+      expect((await stat(path.join(optimizedPreviewDir, optimizedPreviewName))).size).toBeLessThan(
+        previewImageBytes.length,
+      );
+      expect(nestedHtml).toContain(`src="../assets/images/${optimizedPreviewName}"`);
       expect(css).toContain('url("../images/landing-page.png")');
     } finally {
       await removeDirectory(projectRoot);
     }
   });
 
-  it("copies and rewrites content-relative navigation brand images", async () => {
+  it("optimizes and rewrites content-relative navigation brand images", async () => {
     const projectRoot = await mkdtemp(path.join(os.tmpdir(), "cruftless-build-navbar-brand-image-"));
     const contentDir = path.join(projectRoot, "content");
     const imagesDir = path.join(contentDir, "Images");
@@ -396,62 +415,66 @@ describe("buildSite output writes", () => {
     const outDir = path.join(projectRoot, "dist");
     const brandImagePath = path.join(imagesDir, "brand-logo.webp");
 
-    try {
-      const brandImageBytes = await createWebpBytes(640, 200);
-      await mkdir(imagesDir, { recursive: true });
-      await writeFile(brandImagePath, brandImageBytes);
-      const siteContent = {
-        site: {
-          name: "LaunchKit",
-          baseUrl: "https://launchkit.example",
-          theme: "friendly-modern",
-          layout: {
-            components: [
-              {
-                type: "navigation-bar",
-                brandText: "LaunchKit",
-                brandImage: {
-                  src: "Images/brand-logo.webp",
-                  alt: "LaunchKit logo",
+    const brandImageBytes = await createWebpBytes(640, 200);
+    await mkdir(imagesDir, { recursive: true });
+    await writeFile(brandImagePath, brandImageBytes);
+    const siteContent = {
+      site: {
+        name: "LaunchKit",
+        baseUrl: "https://launchkit.example",
+        theme: "friendly-modern",
+        layout: {
+          components: [
+            {
+              type: "navigation-bar",
+              brandText: "LaunchKit",
+              brandImage: {
+                src: "Images/brand-logo.webp",
+                alt: "LaunchKit logo",
+              },
+              links: [
+                {
+                  label: "Home",
+                  href: "/",
                 },
-                links: [
-                  {
-                    label: "Home",
-                    href: "/",
-                  },
-                ],
-              },
-              {
-                type: "page-content",
-              },
-            ],
-          },
+              ],
+            },
+            {
+              type: "page-content",
+            },
+          ],
         },
-        pages: [
-          {
-            slug: "/about",
-            title: "About",
-            components: [
-              {
-                type: "prose",
-                title: "About LaunchKit",
-                paragraphs: ["Built for content-relative assets."],
-              },
-            ],
-          },
-        ],
-      };
+      },
+      pages: [
+        {
+          slug: "/about",
+          title: "About",
+          components: [
+            {
+              type: "prose",
+              title: "About LaunchKit",
+              paragraphs: ["Built for content-relative assets."],
+            },
+          ],
+        },
+      ],
+    };
 
-      await writeFile(contentPath, `${JSON.stringify(siteContent, null, 2)}\n`, "utf8");
-      await buildSite(siteContent as Parameters<typeof buildSite>[0], outDir, { contentPath });
+    await writeFile(contentPath, `${JSON.stringify(siteContent, null, 2)}\n`, "utf8");
+    await buildSite(siteContent as Parameters<typeof buildSite>[0], outDir, { contentPath });
 
-      const aboutHtml = await readFile(path.join(outDir, "about", "index.html"), "utf8");
-      const copiedBrandImagePath = path.join(outDir, "Images", "brand-logo.webp");
+    const aboutHtml = await readFile(path.join(outDir, "about", "index.html"), "utf8");
+    const optimizedBrandDir = path.join(outDir, "assets", "images");
+    const optimizedBrandName = (await readdir(optimizedBrandDir)).find((name) =>
+      name.startsWith("brand-logo-navbar-brand-"),
+    );
 
-      expect((await readFile(copiedBrandImagePath)).equals(brandImageBytes)).toBe(true);
-      expect(aboutHtml).toContain('src="../Images/brand-logo.webp"');
-    } finally {
-      await removeDirectory(projectRoot);
+    if (!optimizedBrandName) {
+      throw new Error("missing optimized brand image");
     }
-  });
+    const optimizedBrandImagePath = path.join(optimizedBrandDir, optimizedBrandName);
+
+    expect((await stat(optimizedBrandImagePath)).size).toBeLessThan(brandImageBytes.length);
+    expect(aboutHtml).toContain(`src="../assets/images/${optimizedBrandName}"`);
+  }, 15000);
 });

--- a/tests/image-pipeline.test.ts
+++ b/tests/image-pipeline.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, mkdir, readFile, readdir, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, mkdir, readFile, readdir, rm, stat, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 
@@ -148,7 +148,7 @@ describe("image pipeline", () => {
     }
   });
 
-  it("copies local content images and rewrites page HTML to reference them relatively", async () => {
+  it("optimizes local content images into assets and rewrites page HTML to reference them there", async () => {
     const fixture = await createLocalImageProject(1800, 1200);
     const outDir = path.join(fixture.rootDir, "dist");
 
@@ -157,14 +157,34 @@ describe("image pipeline", () => {
 
       const homeHtml = await readFile(path.join(outDir, "index.html"), "utf8");
       const portfolioHtml = await readFile(path.join(outDir, "portfolio", "index.html"), "utf8");
-      const copiedImagePath = path.join(outDir, "images", "showroom.png");
+      const outputImagesDir = path.join(outDir, "assets", "images");
+      const outputImageNames = await readdir(outputImagesDir);
+      const mediaOutputName = outputImageNames.find((name) =>
+        name.startsWith("showroom-media-content-"),
+      );
+      const fullOutputName = outputImageNames.find((name) =>
+        name.startsWith("showroom-gallery-full-"),
+      );
+      const thumbOutputName = outputImageNames.find((name) =>
+        name.startsWith("showroom-gallery-thumb-3-"),
+      );
 
-      expect((await readFile(copiedImagePath)).equals(await readFile(fixture.imagePath))).toBe(true);
-      expect(homeHtml).toContain('src="images/showroom.png"');
-      expect(homeHtml).toContain('data-gallery-full-src="images/showroom.png"');
-      expect(portfolioHtml).toContain('src="../images/showroom.png"');
-      expect(portfolioHtml).toContain('data-gallery-full-src="../images/showroom.png"');
-      await expect(readdir(path.join(outDir, "assets", "images"))).rejects.toThrow();
+      if (!mediaOutputName || !fullOutputName || !thumbOutputName) {
+        throw new Error(`missing optimized image output: ${outputImageNames.join(", ")}`);
+      }
+
+      const sourceStats = await stat(fixture.imagePath);
+      const mediaOutputPath = path.join(outputImagesDir, mediaOutputName);
+      const mediaOutputStats = await stat(mediaOutputPath);
+      const mediaOutputMetadata = await sharp(mediaOutputPath).metadata();
+
+      expect(mediaOutputStats.size).toBeLessThan(sourceStats.size);
+      expect(mediaOutputMetadata.width).toBe(1280);
+      expect(homeHtml).toContain(`src="assets/images/${mediaOutputName}"`);
+      expect(homeHtml).toContain(`data-gallery-full-src="assets/images/${fullOutputName}"`);
+      expect(portfolioHtml).toContain(`src="../assets/images/${thumbOutputName}"`);
+      expect(portfolioHtml).toContain(`data-gallery-full-src="../assets/images/${fullOutputName}"`);
+      await expect(readdir(path.join(outDir, "images"))).rejects.toThrow();
     } finally {
       await removeDirectory(fixture.rootDir);
     }


### PR DESCRIPTION
Route local component images through the image pipeline so they render from assets/images instead of being copied raw. This shrinks the florist photo and other local component images in both resolution and file size while keeping page background assets copied separately. Includes regression updates for build output and image-pipeline behavior.