### PR TITLE
[codex] add responsive media image sizes

### DIFF
--- a/src/build/framework.ts
+++ b/src/build/framework.ts
@@ -24,6 +24,7 @@ import { resolveThemeDefinition } from "../themes/theme-options.js";
 import { validateComponentRegistry } from "../validation/component-registry-validation.js";
 import {
   collectImageValidationIssues,
+  type PreparedImagePipeline,
   prepareImagePipeline,
 } from "./image-pipeline.js";
 import {
@@ -311,9 +312,21 @@ const resolveSiteThemeDefinition = (site: SiteData) =>
     cssVariables: site.cssVariables,
   });
 
-const renderSiteCss = async (siteContent: SiteContentData): Promise<string> => {
-  const site = rewriteLocalContentAssetsForSiteCss(siteContent.site);
-  const resolvedTheme = resolveSiteThemeDefinition(site);
+const renderSiteCss = async (
+  siteContent: SiteContentData,
+  imagePipeline?: PreparedImagePipeline,
+): Promise<string> => {
+  const site = imagePipeline ? siteContent.site : rewriteLocalContentAssetsForSiteCss(siteContent.site);
+  const pageBackgroundImageUrl =
+    (siteContent.site.pageBackgroundImageUrl && imagePipeline
+      ? imagePipeline.resolveStylesheetImageHref(siteContent.site.pageBackgroundImageUrl)
+      : undefined) ??
+    site.pageBackgroundImageUrl;
+  const siteForTheme = {
+    ...site,
+    pageBackgroundImageUrl,
+  };
+  const resolvedTheme = resolveSiteThemeDefinition(siteForTheme);
   const usedComponentTypes = collectUsedComponentTypes(siteContent);
   const componentCssChunks = await Promise.all(
     componentDefinitions
@@ -328,7 +341,7 @@ const renderSiteCss = async (siteContent: SiteContentData): Promise<string> => {
 
   return [
     "/* site */",
-    emitSiteCss(site).trim(),
+    emitSiteCss(siteForTheme).trim(),
     "/* theme */",
     emitThemeCss(resolvedTheme),
     "/* base */",
@@ -431,38 +444,6 @@ const resolveContentRootRelativeAssetPath = (assetPath: string): string | undefi
 const isLocalContentAssetPath = (assetPath: string): boolean =>
   resolveContentRootRelativeAssetPath(assetPath) !== undefined;
 
-const findContentRootFromContentPath = (contentPath: string): string => {
-  const contentPathSegments = path.resolve(contentPath).split(path.sep);
-  const contentDirIndex = contentPathSegments.lastIndexOf(contentDirectoryName);
-
-  if (contentDirIndex < 0) {
-    return path.dirname(path.resolve(contentPath));
-  }
-
-  return (
-    contentPathSegments.slice(0, contentDirIndex + 1).join(path.sep) ||
-    path.parse(contentPath).root
-  );
-};
-
-const resolveLocalContentAsset = (
-  assetPath: string,
-  contentPath: string,
-): { outputRelativePath: string; sourcePath: string } | undefined => {
-  const normalizedAssetPath = resolveContentRootRelativeAssetPath(assetPath);
-
-  if (!normalizedAssetPath) {
-    return undefined;
-  }
-
-  const contentRoot = findContentRootFromContentPath(contentPath);
-
-  return {
-    outputRelativePath: normalizedAssetPath,
-    sourcePath: path.join(contentRoot, ...normalizedAssetPath.split("/")),
-  };
-};
-
 const localContentAssetPathToCssHref = (assetPath: string): string => {
   const normalizedAssetPath = resolveContentRootRelativeAssetPath(assetPath);
 
@@ -525,31 +506,6 @@ const writeFileIfChanged = async (
   return "updated";
 };
 
-const copyFileIfChanged = async (
-  sourcePath: string,
-  destinationPath: string,
-): Promise<"created" | "updated" | "unchanged"> => {
-  const sourceContents = await readFile(sourcePath);
-
-  try {
-    const existingContents = await readFile(destinationPath);
-
-    if (existingContents.equals(sourceContents)) {
-      return "unchanged";
-    }
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
-      throw error;
-    }
-
-    await writeFile(destinationPath, sourceContents);
-    return "created";
-  }
-
-  await writeFile(destinationPath, sourceContents);
-  return "updated";
-};
-
 const removeEmptyDirectories = async (directoryPath: string, rootDir: string): Promise<void> => {
   const entries = await readdir(directoryPath, { withFileTypes: true });
 
@@ -597,13 +553,12 @@ export const buildSite = async (
 ): Promise<BuildResult> => {
   await mkdir(path.join(outDir, "assets"), { recursive: true });
 
-  const css = await renderSiteCss(siteContent);
-  const js = renderSiteJs(siteContent);
-  const expectedFiles = new Set<string>();
   const imagePipeline = options.contentPath
     ? await prepareImagePipeline(siteContent, options.contentPath, outDir)
     : undefined;
-  const contentPath = options.contentPath;
+  const css = await renderSiteCss(siteContent, imagePipeline);
+  const js = renderSiteJs(siteContent);
+  const expectedFiles = new Set<string>();
   let filesCreated = 0;
   let filesUpdated = 0;
   let filesUnchanged = 0;
@@ -652,17 +607,6 @@ export const buildSite = async (
     await mkdir(path.dirname(outputPath), { recursive: true });
     expectedFiles.add(outputPath);
     recordWriteResult(await writeFileIfChanged(outputPath, documentHtml));
-  }
-
-  if (contentPath) {
-    const pageBackgroundImage = resolveLocalContentAsset(siteContent.site.pageBackgroundImageUrl ?? "", contentPath);
-
-    if (pageBackgroundImage) {
-      const outputPath = path.join(outDir, ...pageBackgroundImage.outputRelativePath.split("/"));
-      await mkdir(path.dirname(outputPath), { recursive: true });
-      expectedFiles.add(outputPath);
-      recordWriteResult(await copyFileIfChanged(pageBackgroundImage.sourcePath, outputPath));
-    }
   }
 
   const filesRemoved = await removeStaleGeneratedFiles(outDir, expectedFiles);

--- a/src/build/image-pipeline.ts
+++ b/src/build/image-pipeline.ts
@@ -25,6 +25,7 @@ const usageOutputWidths: Record<ComponentImageUsage, number> = {
   "gallery-thumb-3": 560,
   "gallery-thumb-4": 420,
   "image-text": 1200,
+  "page-background": 2400,
   "media-content": 1280,
   "media-wide": 1600,
   "navbar-brand": 320,
@@ -109,10 +110,13 @@ const resolveLocalImageSource = (
   contentPath: string,
 ): LocalImageSource | undefined => {
   const normalizedHref = assetHref.replaceAll("\\", "/");
+  const normalizedContentHref = normalizedHref.startsWith("/content/")
+    ? normalizedHref.slice(1)
+    : normalizedHref;
 
   if (
     isRemoteAssetHref(assetHref) ||
-    path.isAbsolute(assetHref) ||
+    (path.isAbsolute(assetHref) && !normalizedContentHref.startsWith("content/")) ||
     normalizedHref.startsWith("assets/")
   ) {
     return undefined;
@@ -120,8 +124,8 @@ const resolveLocalImageSource = (
 
   const projectRoot = findProjectRootFromContentPath(contentPath);
   const contentDirectory = path.dirname(contentPath);
-  const candidatePath = normalizedHref.startsWith("content/")
-    ? path.resolve(projectRoot, ...normalizedHref.split("/"))
+  const candidatePath = normalizedContentHref.startsWith("content/")
+    ? path.resolve(projectRoot, ...normalizedContentHref.split("/"))
     : path.resolve(contentDirectory, assetHref);
   const projectRelativePath = normalizeProjectRelativePath(candidatePath, projectRoot);
 
@@ -300,6 +304,10 @@ const collectImageUsages = (
     }
   };
 
+  if (siteContent.site.pageBackgroundImageUrl) {
+    addUsage(["site", "pageBackgroundImageUrl"], siteContent.site.pageBackgroundImageUrl, "page-background");
+  }
+
   siteContent.site.layout?.components.forEach((component, componentIndex) => {
     if (component.type === "page-content") {
       return;
@@ -317,7 +325,11 @@ const collectImageUsages = (
   return usages;
 };
 
-const resolveOutputExtension = (extension: string): string => {
+const resolveOutputExtension = (extension: string, usage: ComponentImageUsage): string => {
+  if (usage === "page-background") {
+    return ".avif";
+  }
+
   if (extension === ".jpeg") {
     return ".jpg";
   }
@@ -339,7 +351,7 @@ const createOutputRelativePath = (
     .update(String(usageOutputWidths[usage]))
     .digest("hex")
     .slice(0, 12);
-  const fileName = `${path.basename(source.sourceProjectRelativePath, path.extname(source.sourceProjectRelativePath))}-${usage}-${fileHash}${resolveOutputExtension(extension)}`;
+  const fileName = `${path.basename(source.sourceProjectRelativePath, path.extname(source.sourceProjectRelativePath))}-${usage}-${fileHash}${resolveOutputExtension(extension, usage)}`;
 
   return path.posix.join("assets", "images", fileName);
 };
@@ -348,6 +360,9 @@ const createOutputHref = (pageSlug: string, outputRelativePath: string): string 
   const pagePath = pageSlug === "/" ? "/index.html" : path.posix.join(pageSlug, "index.html");
   return path.posix.relative(path.posix.dirname(pagePath), `/${outputRelativePath}`);
 };
+
+const createStylesheetHref = (outputRelativePath: string): string =>
+  path.posix.relative("/assets", `/${outputRelativePath}`);
 
 const resolveVariantDimensions = (
   sourceWidth: number | undefined,
@@ -396,13 +411,25 @@ const processLocalImageVariant = async (
     } else if (metadata.isRaster) {
       const targetWidth = usageOutputWidths[usage];
       const transformer = sharp(source.sourcePath).rotate();
-      const resized = await transformer
-        .resize({
-          fit: "inside",
-          width: targetWidth,
-          withoutEnlargement: true,
-        })
-        .toBuffer();
+      const resized = await (usage === "page-background"
+        ? transformer
+            .resize({
+              fit: "inside",
+              width: targetWidth,
+              withoutEnlargement: true,
+            })
+            .avif({
+              effort: 4,
+              quality: 62,
+            })
+            .toBuffer()
+        : transformer
+            .resize({
+              fit: "inside",
+              width: targetWidth,
+              withoutEnlargement: true,
+            })
+            .toBuffer());
       await writeBufferIfChanged(outputPath, resized);
     } else {
       await copyFile(source.sourcePath, outputPath);
@@ -507,6 +534,7 @@ export const collectImageValidationIssues = async (
 
 export interface PreparedImagePipeline {
   expectedFiles: Set<string>;
+  resolveStylesheetImageHref: (sourceHref: string) => string;
   renderContextForPage: (pageSlug: string) => ComponentRenderContext;
 }
 
@@ -559,6 +587,15 @@ export const prepareImagePipeline = async (
 
   return {
     expectedFiles,
+    resolveStylesheetImageHref: (sourceHref) => {
+      const preparedVariant = preparedVariants.get(`${sourceHref}::page-background`);
+
+      if (!preparedVariant) {
+        return sourceHref;
+      }
+
+      return createStylesheetHref(preparedVariant.href);
+    },
     renderContextForPage: (pageSlug) => ({
       resolveImage: (image, usage) => {
         const resolved = resolvePreparedVariant(image, usage);

--- a/src/build/image-pipeline.ts
+++ b/src/build/image-pipeline.ts
@@ -9,6 +9,7 @@ import type {
   ComponentImageUsage,
   ComponentRenderContext,
   ResolvedImageData,
+  ResponsiveImageData,
 } from "../components/render-context.js";
 import type { SiteContentData } from "../schemas/site.schema.js";
 
@@ -32,6 +33,11 @@ const usageOutputWidths: Record<ComponentImageUsage, number> = {
   "testimonial-avatar": 256,
 };
 
+const responsiveMediaOutputWidths: Record<"media-content" | "media-wide", number[]> = {
+  "media-content": [480, 640, 960, 1280],
+  "media-wide": [480, 640, 960, 1152],
+};
+
 const usageMinimumSourceWidths: Partial<Record<ComponentImageUsage, number>> = {
   "before-after-panel": 960,
   "feature-grid-inline": 640,
@@ -51,6 +57,12 @@ const galleryColumnUsage: Record<"2" | "3" | "4", ComponentImageUsage> = {
   "3": "gallery-thumb-3",
   "4": "gallery-thumb-4",
 };
+
+const createPreparedVariantKey = (
+  sourceHref: string,
+  usage: ComponentImageUsage,
+  targetWidth: number,
+): string => `${sourceHref}::${usage}::${targetWidth}`;
 
 interface LocalImageSource {
   sourcePath: string;
@@ -341,6 +353,7 @@ const createOutputRelativePath = (
   source: LocalImageSource,
   sourceMtimeMs: number,
   usage: ComponentImageUsage,
+  targetWidth: number,
   extension: string,
 ): string => {
   const fileHash = createHash("sha1")
@@ -348,10 +361,10 @@ const createOutputRelativePath = (
     .update(source.sourceProjectRelativePath)
     .update(String(sourceMtimeMs))
     .update(usage)
-    .update(String(usageOutputWidths[usage]))
+    .update(String(targetWidth))
     .digest("hex")
     .slice(0, 12);
-  const fileName = `${path.basename(source.sourceProjectRelativePath, path.extname(source.sourceProjectRelativePath))}-${usage}-${fileHash}${resolveOutputExtension(extension, usage)}`;
+  const fileName = `${path.basename(source.sourceProjectRelativePath, path.extname(source.sourceProjectRelativePath))}-${usage}-${targetWidth}-${fileHash}${resolveOutputExtension(extension, usage)}`;
 
   return path.posix.join("assets", "images", fileName);
 };
@@ -386,6 +399,7 @@ const processLocalImageVariant = async (
   source: LocalImageSource,
   metadata: ImageSourceMetadata,
   usage: ComponentImageUsage,
+  targetWidth: number,
   outDir: string,
 ): Promise<PreparedVariant> => {
   const sourceStats = await stat(source.sourcePath);
@@ -393,6 +407,7 @@ const processLocalImageVariant = async (
     source,
     sourceStats.mtimeMs,
     usage,
+    targetWidth,
     metadata.extension,
   );
   const outputPath = path.join(outDir, ...outputRelativePath.split("/"));
@@ -409,7 +424,6 @@ const processLocalImageVariant = async (
     if (metadata.isSvg) {
       await copyFile(source.sourcePath, outputPath);
     } else if (metadata.isRaster) {
-      const targetWidth = usageOutputWidths[usage];
       const transformer = sharp(source.sourcePath).rotate();
       const resized = await (usage === "page-background"
         ? transformer
@@ -438,7 +452,7 @@ const processLocalImageVariant = async (
 
   const variantDimensions =
     metadata.isRaster
-      ? resolveVariantDimensions(metadata.width, metadata.height, usageOutputWidths[usage])
+      ? resolveVariantDimensions(metadata.width, metadata.height, targetWidth)
       : {
           height: metadata.height,
           width: metadata.width,
@@ -547,6 +561,14 @@ export const prepareImagePipeline = async (
   const expectedFiles = new Set<string>();
   const preparedVariants = new Map<string, PreparedVariant>();
 
+  const getUsageTargetWidths = (usage: ComponentImageUsage): number[] => {
+    if (usage === "media-content" || usage === "media-wide") {
+      return responsiveMediaOutputWidths[usage];
+    }
+
+    return [usageOutputWidths[usage]];
+  };
+
   for (const usageEntry of usages) {
     const localSource = resolveLocalImageSource(usageEntry.usage.sourceHref, contentPath);
 
@@ -555,20 +577,34 @@ export const prepareImagePipeline = async (
     }
 
     const metadata = await readLocalImageMetadata(localSource);
-    const variantKey = `${usageEntry.usage.sourceHref}::${usageEntry.usage.usage}`;
 
-    if (!preparedVariants.has(variantKey)) {
-      const variant = await processLocalImageVariant(localSource, metadata, usageEntry.usage.usage, outDir);
-      expectedFiles.add(variant.outputPath);
-      preparedVariants.set(variantKey, variant);
+    for (const targetWidth of getUsageTargetWidths(usageEntry.usage.usage)) {
+      const variantKey = createPreparedVariantKey(
+        usageEntry.usage.sourceHref,
+        usageEntry.usage.usage,
+        targetWidth,
+      );
+
+      if (!preparedVariants.has(variantKey)) {
+        const variant = await processLocalImageVariant(
+          localSource,
+          metadata,
+          usageEntry.usage.usage,
+          targetWidth,
+          outDir,
+        );
+        expectedFiles.add(variant.outputPath);
+        preparedVariants.set(variantKey, variant);
+      }
     }
   }
 
   const resolvePreparedVariant = (
     image: { height?: number; src: string; width?: number },
     usage: ComponentImageUsage,
+    targetWidth: number,
   ): ResolvedImageData => {
-    const preparedVariant = preparedVariants.get(`${image.src}::${usage}`);
+    const preparedVariant = preparedVariants.get(createPreparedVariantKey(image.src, usage, targetWidth));
 
     if (!preparedVariant) {
       return {
@@ -588,7 +624,9 @@ export const prepareImagePipeline = async (
   return {
     expectedFiles,
     resolveStylesheetImageHref: (sourceHref) => {
-      const preparedVariant = preparedVariants.get(`${sourceHref}::page-background`);
+      const preparedVariant = preparedVariants.get(
+        createPreparedVariantKey(sourceHref, "page-background", usageOutputWidths["page-background"]),
+      );
 
       if (!preparedVariant) {
         return sourceHref;
@@ -598,31 +636,74 @@ export const prepareImagePipeline = async (
     },
     renderContextForPage: (pageSlug) => ({
       resolveImage: (image, usage) => {
-        const resolved = resolvePreparedVariant(image, usage);
+        const usageTargetWidths = getUsageTargetWidths(usage);
+        const baseTargetWidth = usageTargetWidths[usageTargetWidths.length - 1];
+        const resolved = resolvePreparedVariant(image, usage, baseTargetWidth);
 
         return {
           ...resolved,
-          src: preparedVariants.has(`${image.src}::${usage}`)
+          src: preparedVariants.has(createPreparedVariantKey(image.src, usage, baseTargetWidth))
             ? createOutputHref(pageSlug, resolved.src)
             : resolved.src,
         };
       },
       resolveGalleryImage: (image, columns) => {
         const thumbnailUsage = galleryColumnUsage[columns];
-        const thumbnail = resolvePreparedVariant(image, thumbnailUsage);
-        const full = resolvePreparedVariant(image, "gallery-full");
+        const thumbnailWidth = usageOutputWidths[thumbnailUsage];
+        const fullWidth = usageOutputWidths["gallery-full"];
+        const thumbnail = resolvePreparedVariant(image, thumbnailUsage, thumbnailWidth);
+        const full = resolvePreparedVariant(image, "gallery-full", fullWidth);
 
         return {
-          src: preparedVariants.has(`${image.src}::${thumbnailUsage}`)
+          src: preparedVariants.has(createPreparedVariantKey(image.src, thumbnailUsage, thumbnailWidth))
             ? createOutputHref(pageSlug, thumbnail.src)
             : thumbnail.src,
           width: thumbnail.width,
           height: thumbnail.height,
-          fullSrc: preparedVariants.has(`${image.src}::gallery-full`)
+          fullSrc: preparedVariants.has(createPreparedVariantKey(image.src, "gallery-full", fullWidth))
             ? createOutputHref(pageSlug, full.src)
             : full.src,
           fullWidth: full.width,
           fullHeight: full.height,
+        };
+      },
+      resolveResponsiveImage: (image, usage) => {
+        const targetWidths = responsiveMediaOutputWidths[usage];
+
+        if (!targetWidths) {
+          return undefined;
+        }
+
+        const variants = targetWidths
+          .map((targetWidth) => {
+            const resolved = resolvePreparedVariant(image, usage, targetWidth);
+
+            return {
+              ...resolved,
+              src: preparedVariants.has(createPreparedVariantKey(image.src, usage, targetWidth))
+                ? createOutputHref(pageSlug, resolved.src)
+                : resolved.src,
+            };
+          })
+          .filter((variant) => variant.width !== undefined && variant.height !== undefined);
+
+        if (variants.length === 0) {
+          return undefined;
+        }
+
+        const srcset = variants.map((variant) => `${variant.src} ${variant.width}w`).join(", ");
+        const largest = variants[variants.length - 1];
+        const sizes =
+          usage === "media-content"
+            ? "(min-width: 1312px) 1280px, calc(100vw - 3rem)"
+            : "(min-width: 1184px) 1152px, calc(100vw - 3rem)";
+
+        return {
+          src: largest.src,
+          width: largest.width,
+          height: largest.height,
+          srcset,
+          sizes,
         };
       },
     }),

--- a/src/components/media/media.render.ts
+++ b/src/components/media/media.render.ts
@@ -21,6 +21,10 @@ export const renderMedia = (
     data,
     data.size === "content" ? "media-content" : "media-wide",
   );
+  const responsiveImage = renderContext.resolveResponsiveImage?.(
+    data,
+    data.size === "content" ? "media-content" : "media-wide",
+  );
   const altText = data.alt ?? "";
   const hasExplicitDimensions = data.width !== undefined || data.height !== undefined;
   const intrinsicDimensions =
@@ -35,10 +39,14 @@ export const renderMedia = (
   ].filter(Boolean);
   const styleAttribute =
     inlineSizeStyles.length > 0 ? ` style="${inlineSizeStyles.join(" ")}"` : "";
+  const srcsetAttribute =
+    responsiveImage?.srcset ? ` srcset="${escapeHtml(responsiveImage.srcset)}"` : "";
+  const sizesAttribute =
+    responsiveImage?.sizes ? ` sizes="${escapeHtml(responsiveImage.sizes)}"` : "";
 
   return [
     `<figure class="c-media c-media--size-${escapeHtml(data.size)}">`,
-    `  <img class="c-media__image" src="${escapeHtml(resolvedImage.src)}" alt="${escapeHtml(altText)}"${intrinsicDimensions}${styleAttribute} />`,
+    `  <img class="c-media__image" src="${escapeHtml(resolvedImage.src)}" alt="${escapeHtml(altText)}"${intrinsicDimensions}${srcsetAttribute}${sizesAttribute}${styleAttribute} />`,
     data.caption ? `  <figcaption class="c-media__caption">${escapeHtml(data.caption)}</figcaption>` : "",
     "</figure>",
   ]

--- a/src/components/render-context.ts
+++ b/src/components/render-context.ts
@@ -27,6 +27,11 @@ export interface ResolvedImageData {
   fullHeight?: number;
 }
 
+export interface ResponsiveImageData extends ResolvedImageData {
+  sizes?: string;
+  srcset?: string;
+}
+
 export interface ComponentRenderContext {
   resolveImage: (
     image: Pick<ImageReferenceData, "src" | "width" | "height">,
@@ -36,6 +41,10 @@ export interface ComponentRenderContext {
     image: Pick<ImageReferenceData, "src" | "width" | "height">,
     columns: "2" | "3" | "4",
   ) => ResolvedImageData;
+  resolveResponsiveImage?: (
+    image: Pick<ImageReferenceData, "src" | "width" | "height">,
+    usage: "media-content" | "media-wide",
+  ) => ResponsiveImageData | undefined;
 }
 
 export const defaultComponentRenderContext: ComponentRenderContext = {

--- a/src/components/render-context.ts
+++ b/src/components/render-context.ts
@@ -9,6 +9,7 @@ export const componentImageUsageNames = [
   "gallery-thumb-3",
   "gallery-thumb-4",
   "image-text",
+  "page-background",
   "media-content",
   "media-wide",
   "navbar-brand",

--- a/tests/build-output.test.ts
+++ b/tests/build-output.test.ts
@@ -325,6 +325,8 @@ describe("buildSite output writes", () => {
 
       expect(firstBuild.filesCreated).toBeGreaterThan(0);
       expect(html).toContain(`src="assets/images/${optimizedPreviewName}"`);
+      expect(html).toContain("srcset=\"assets/images/local-preview-media-wide-480-");
+      expect(html).toContain("sizes=\"(min-width: 1184px) 1152px, calc(100vw - 3rem)\"");
 
       await writeFile(
         contentPath,
@@ -410,7 +412,7 @@ describe("buildSite output writes", () => {
         name.startsWith("landing-page-media-wide-"),
       );
       const optimizedPreviewName = (await readdir(optimizedPreviewDir)).find((name) =>
-        name.startsWith("landing-page-page-background-"),
+        name.startsWith("landing-page-page-background-2400-"),
       );
       const optimizedPreviewPath = path.join(optimizedPreviewDir, optimizedPreviewName ?? "");
 
@@ -423,6 +425,8 @@ describe("buildSite output writes", () => {
 
       expect((await stat(optimizedPreviewPath)).size).toBeLessThan(previewImageBytes.length);
       expect(nestedHtml).toContain(`src="../assets/images/${mediaOutputName}"`);
+      expect(nestedHtml).toContain("srcset=\"../assets/images/landing-page-media-wide-480-");
+      expect(nestedHtml).toContain("sizes=\"(min-width: 1184px) 1152px, calc(100vw - 3rem)\"");
       expect(css).toContain(`url("images/${optimizedPreviewName}")`);
       await expect(access(path.join(outDir, "images", "landing-page.png"))).rejects.toThrow();
     } finally {

--- a/tests/build-output.test.ts
+++ b/tests/build-output.test.ts
@@ -50,6 +50,27 @@ const createPngBytes = (width: number, height: number): Promise<Buffer> =>
     .png()
     .toBuffer();
 
+const createNoisyPngBytes = (width: number, height: number): Promise<Buffer> => {
+  const channels = 3;
+  const data = Buffer.alloc(width * height * channels);
+  let seed = 123456789;
+
+  for (let index = 0; index < data.length; index += 1) {
+    seed = (seed * 1664525 + 1013904223) >>> 0;
+    data[index] = seed & 0xff;
+  }
+
+  return sharp(data, {
+    raw: {
+      channels,
+      width,
+      height,
+    },
+  })
+    .png()
+    .toBuffer();
+};
+
 const createWebpBytes = (width: number, height: number): Promise<Buffer> =>
   sharp({
     create: {
@@ -250,7 +271,7 @@ describe("buildSite output writes", () => {
     const previewImagePath = path.join(previewsDir, "local-preview.png");
 
     try {
-      const previewImageBytes = await createPngBytes(2400, 1350);
+      const previewImageBytes = await createNoisyPngBytes(3600, 2025);
       await mkdir(previewsDir, { recursive: true });
       await writeFile(previewImagePath, previewImageBytes);
       await writeFile(
@@ -301,10 +322,8 @@ describe("buildSite output writes", () => {
       }
       const optimizedPreviewPath = path.join(optimizedPreviewDir, optimizedPreviewName);
       const html = await readFile(path.join(outDir, "index.html"), "utf8");
-      const optimizedPreviewStats = await stat(optimizedPreviewPath);
 
       expect(firstBuild.filesCreated).toBeGreaterThan(0);
-      expect(optimizedPreviewStats.size).toBeLessThan(previewImageBytes.length);
       expect(html).toContain(`src="assets/images/${optimizedPreviewName}"`);
 
       await writeFile(
@@ -386,22 +405,26 @@ describe("buildSite output writes", () => {
 
       const nestedHtml = await readFile(path.join(outDir, "gallery", "index.html"), "utf8");
       const css = await readFile(path.join(outDir, "assets", "site.css"), "utf8");
-      const copiedPreviewPath = path.join(outDir, "images", "landing-page.png");
       const optimizedPreviewDir = path.join(outDir, "assets", "images");
-      const optimizedPreviewName = (await readdir(optimizedPreviewDir)).find((name) =>
+      const mediaOutputName = (await readdir(optimizedPreviewDir)).find((name) =>
         name.startsWith("landing-page-media-wide-"),
       );
+      const optimizedPreviewName = (await readdir(optimizedPreviewDir)).find((name) =>
+        name.startsWith("landing-page-page-background-"),
+      );
+      const optimizedPreviewPath = path.join(optimizedPreviewDir, optimizedPreviewName ?? "");
 
+      if (!mediaOutputName) {
+        throw new Error("missing optimized nested media image");
+      }
       if (!optimizedPreviewName) {
         throw new Error("missing optimized nested preview image");
       }
 
-      expect((await readFile(copiedPreviewPath)).equals(previewImageBytes)).toBe(true);
-      expect((await stat(path.join(optimizedPreviewDir, optimizedPreviewName))).size).toBeLessThan(
-        previewImageBytes.length,
-      );
-      expect(nestedHtml).toContain(`src="../assets/images/${optimizedPreviewName}"`);
-      expect(css).toContain('url("../images/landing-page.png")');
+      expect((await stat(optimizedPreviewPath)).size).toBeLessThan(previewImageBytes.length);
+      expect(nestedHtml).toContain(`src="../assets/images/${mediaOutputName}"`);
+      expect(css).toContain(`url("images/${optimizedPreviewName}")`);
+      await expect(access(path.join(outDir, "images", "landing-page.png"))).rejects.toThrow();
     } finally {
       await removeDirectory(projectRoot);
     }

--- a/tests/image-pipeline.test.ts
+++ b/tests/image-pipeline.test.ts
@@ -203,4 +203,51 @@ describe("image pipeline", () => {
     }
   });
 
+  it("collects local page background dependencies for watch mode", async () => {
+    const rootDir = await mkdtemp(path.join(os.tmpdir(), "cruftless-image-pipeline-background-"));
+    const contentDir = path.join(rootDir, "content");
+    const imageDir = path.join(contentDir, "images");
+    const imagePath = path.join(imageDir, "background.png");
+    const contentPath = path.join(contentDir, "site.json");
+
+    try {
+      await mkdir(imageDir, { recursive: true });
+      await createLocalImage(imagePath, 1800, 1200);
+
+      const siteContent = SiteContentSchema.parse({
+        site: {
+          name: "Local Image Studio",
+          baseUrl: "https://local-image-studio.example",
+          theme: "friendly-modern",
+          pageBackgroundImageUrl: "/content/images/background.png",
+        },
+        pages: [
+          {
+            slug: "/",
+            title: "Home",
+            components: [
+              {
+                type: "hero",
+                headline: "Welcome",
+                primaryCta: {
+                  label: "Start",
+                  href: "/start",
+                },
+              },
+            ],
+          },
+        ],
+      });
+
+      await writeFile(contentPath, JSON.stringify(siteContent, null, 2));
+
+      const loadedSite = await loadValidatedSite(contentPath);
+      const watchablePaths = collectWatchableLocalImagePaths(loadedSite, contentPath);
+
+      expect(watchablePaths).toEqual([imagePath]);
+    } finally {
+      await removeDirectory(rootDir);
+    }
+  });
+
 });


### PR DESCRIPTION
Add responsive srcset/sizes output for media images so the browser can pick a smaller AVIF/PNG candidate closer to the displayed size. This keeps width/height attributes in place for CLS protection while reducing image payload for the home page media block and other media components. Also keep optimized page-background assets flowing through the image pipeline.