### PR TITLE
[codex] fix navbar mobile CLS

### DIFF
--- a/src/components/navigation-bar/navigation-bar.css
+++ b/src/components/navigation-bar/navigation-bar.css
@@ -169,3 +169,13 @@
 .c-navbar[data-navigation-bar-mode="inline"] .c-navbar__panel {
   display: none;
 }
+
+@media (width <= 40rem) {
+  .c-navbar__inline-nav {
+    display: none;
+  }
+
+  .c-navbar__menu-button {
+    display: inline-flex;
+  }
+}


### PR DESCRIPTION
Adds a mobile-first navbar collapsed default so the header does not shift after initial paint on Lighthouse mobile runs.