### PR TITLE
[codex] tighten media avif quality

### DIFF
--- a/src/build/image-pipeline.ts
+++ b/src/build/image-pipeline.ts
@@ -446,7 +446,7 @@ const processLocalImageVariant = async (
               })
               .avif({
                 effort: 4,
-                quality: 54,
+                quality: 45,
               })
               .toBuffer()
         : transformer


### PR DESCRIPTION
Tightens AVIF quality for standalone media outputs a bit further to shave bytes from the site landing-page photo and improve Lighthouse performance on slow mobile runs.