### PR TITLE
[codex] shrink media content candidate

### DIFF
--- a/src/build/image-pipeline.ts
+++ b/src/build/image-pipeline.ts
@@ -27,14 +27,14 @@ const usageOutputWidths: Record<ComponentImageUsage, number> = {
   "gallery-thumb-4": 420,
   "image-text": 1200,
   "page-background": 2400,
-  "media-content": 1152,
+  "media-content": 1024,
   "media-wide": 1600,
   "navbar-brand": 320,
   "testimonial-avatar": 256,
 };
 
 const responsiveMediaOutputWidths: Record<"media-content" | "media-wide", number[]> = {
-  "media-content": [480, 640, 960, 1152],
+  "media-content": [480, 640, 960, 1024],
   "media-wide": [480, 640, 960, 1152],
 };
 
@@ -46,7 +46,7 @@ const usageMinimumSourceWidths: Partial<Record<ComponentImageUsage, number>> = {
   "gallery-thumb-3": 560,
   "gallery-thumb-4": 420,
   "image-text": 1200,
-  "media-content": 1152,
+  "media-content": 1024,
   "media-wide": 1600,
   "navbar-brand": 320,
   "testimonial-avatar": 256,

--- a/tests/image-pipeline.test.ts
+++ b/tests/image-pipeline.test.ts
@@ -179,7 +179,7 @@ describe("image pipeline", () => {
       const mediaOutputMetadata = await sharp(mediaOutputPath).metadata();
 
       expect(mediaOutputStats.size).toBeLessThan(sourceStats.size);
-      expect(mediaOutputMetadata.width).toBe(1152);
+      expect(mediaOutputMetadata.width).toBe(1024);
       expect(homeHtml).toContain(`src="assets/images/${mediaOutputName}"`);
       expect(homeHtml).toContain(`data-gallery-full-src="assets/images/${fullOutputName}"`);
       expect(portfolioHtml).toContain(`src="../assets/images/${thumbOutputName}"`);


### PR DESCRIPTION
Drops the top media-content responsive candidate to 1024px so the site landing photo is smaller on mobile Lighthouse runs and has a better chance of clearing the performance threshold.