### PR TITLE
Lazy-load media images by default

### DIFF
--- a/src/components/media/media.render.ts
+++ b/src/components/media/media.render.ts
@@ -46,7 +46,7 @@ export const renderMedia = (
 
   return [
     `<figure class="c-media c-media--size-${escapeHtml(data.size)}">`,
-    `  <img class="c-media__image" src="${escapeHtml(resolvedImage.src)}" alt="${escapeHtml(altText)}"${intrinsicDimensions}${srcsetAttribute}${sizesAttribute}${styleAttribute} fetchpriority="high" decoding="async" />`,
+    `  <img class="c-media__image" src="${escapeHtml(resolvedImage.src)}" alt="${escapeHtml(altText)}"${intrinsicDimensions}${srcsetAttribute}${sizesAttribute}${styleAttribute} loading="lazy" decoding="async" />`,
     data.caption ? `  <figcaption class="c-media__caption">${escapeHtml(data.caption)}</figcaption>` : "",
     "</figure>",
   ]

--- a/src/components/media/media.test.ts
+++ b/src/components/media/media.test.ts
@@ -20,7 +20,7 @@ describe("MediaSchema", () => {
     expect(html).toContain('<figure class="c-media c-media--size-content">');
     expect(html).toContain('<img class="c-media__image"');
     expect(html).toContain('alt="Founder standing in the studio"');
-    expect(html).toContain('fetchpriority="high"');
+    expect(html).toContain('loading="lazy"');
     expect(html).toContain('decoding="async"');
     expect(html).toContain('style="width: 1600px; height: 900px;"');
     expect(html).not.toContain('width="1600" height="900"');
@@ -48,7 +48,7 @@ describe("MediaSchema", () => {
 
     expect(html).toContain('width="1600" height="900"');
     expect(html).not.toContain('style="width:');
-    expect(html).toContain('fetchpriority="high"');
+    expect(html).toContain('loading="lazy"');
   });
 
   it("rejects unknown fields", () => {


### PR DESCRIPTION
Make standalone media images load lazily instead of forcing high fetch priority. This keeps supporting images from competing with above-the-fold content in Lighthouse, which should help the homepage pass with the florist photo back on the site.