### PR TITLE
Restore media fetch priority default

### DIFF
--- a/src/components/media/media.render.ts
+++ b/src/components/media/media.render.ts
@@ -46,7 +46,7 @@ export const renderMedia = (
 
   return [
     `<figure class="c-media c-media--size-${escapeHtml(data.size)}">`,
-    `  <img class="c-media__image" src="${escapeHtml(resolvedImage.src)}" alt="${escapeHtml(altText)}"${intrinsicDimensions}${srcsetAttribute}${sizesAttribute}${styleAttribute} loading="lazy" decoding="async" />`,
+    `  <img class="c-media__image" src="${escapeHtml(resolvedImage.src)}" alt="${escapeHtml(altText)}"${intrinsicDimensions}${srcsetAttribute}${sizesAttribute}${styleAttribute} fetchpriority="high" decoding="async" />`,
     data.caption ? `  <figcaption class="c-media__caption">${escapeHtml(data.caption)}</figcaption>` : "",
     "</figure>",
   ]

--- a/src/components/media/media.test.ts
+++ b/src/components/media/media.test.ts
@@ -20,7 +20,7 @@ describe("MediaSchema", () => {
     expect(html).toContain('<figure class="c-media c-media--size-content">');
     expect(html).toContain('<img class="c-media__image"');
     expect(html).toContain('alt="Founder standing in the studio"');
-    expect(html).toContain('loading="lazy"');
+    expect(html).toContain('fetchpriority="high"');
     expect(html).toContain('decoding="async"');
     expect(html).toContain('style="width: 1600px; height: 900px;"');
     expect(html).not.toContain('width="1600" height="900"');
@@ -48,7 +48,7 @@ describe("MediaSchema", () => {
 
     expect(html).toContain('width="1600" height="900"');
     expect(html).not.toContain('style="width:');
-    expect(html).toContain('loading="lazy"');
+    expect(html).toContain('fetchpriority="high"');
   });
 
   it("rejects unknown fields", () => {


### PR DESCRIPTION
Revert the global lazy-loading default for media images. The shared media component should keep its previous high-priority behavior; the site-specific homepage placement changes are enough to keep the florist image out of the first mobile viewport.