### PR TITLE
Raise Lighthouse LCP budget to 7s

### DIFF
--- a/src/build/lighthouse-ci.ts
+++ b/src/build/lighthouse-ci.ts
@@ -27,7 +27,7 @@ const metricThresholds = [
   {
     key: "largest-contentful-paint",
     label: "LCP",
-    maxValue: Number(process.env.LIGHTHOUSE_MAX_LCP_MS ?? 3000),
+    maxValue: Number(process.env.LIGHTHOUSE_MAX_LCP_MS ?? 7000),
     format: (value: number) => `${Math.round(value)}ms`,
   },
   ...(process.env.LIGHTHOUSE_MAX_TBT_MS


### PR DESCRIPTION
Increase the shared Lighthouse LCP budget to 7 seconds. The site-level gate should keep enforcing category scores, but LCP should no longer be the blocking metric for these brochure-style sites.