### PR TITLE
Support per-media loading hints

### DIFF
--- a/schemas/site-content.schema.json
+++ b/schemas/site-content.schema.json
@@ -1117,6 +1117,13 @@
                                 "minLength": 1,
                                 "maxLength": 280
                               },
+                              "loading": {
+                                "type": "string",
+                                "enum": [
+                                  "eager",
+                                  "lazy"
+                                ]
+                              },
                               "width": {
                                 "type": "integer",
                                 "exclusiveMinimum": 0,

--- a/src/components/media/media.render.ts
+++ b/src/components/media/media.render.ts
@@ -43,10 +43,13 @@ export const renderMedia = (
     responsiveImage?.srcset ? ` srcset="${escapeHtml(responsiveImage.srcset)}"` : "";
   const sizesAttribute =
     responsiveImage?.sizes ? ` sizes="${escapeHtml(responsiveImage.sizes)}"` : "";
+  const loadingAttribute = data.loading ? ` loading="${escapeHtml(data.loading)}"` : "";
+  const fetchPriorityAttribute =
+    data.loading === "lazy" ? ' fetchpriority="low"' : ' fetchpriority="high"';
 
   return [
     `<figure class="c-media c-media--size-${escapeHtml(data.size)}">`,
-    `  <img class="c-media__image" src="${escapeHtml(resolvedImage.src)}" alt="${escapeHtml(altText)}"${intrinsicDimensions}${srcsetAttribute}${sizesAttribute}${styleAttribute} fetchpriority="high" decoding="async" />`,
+    `  <img class="c-media__image" src="${escapeHtml(resolvedImage.src)}" alt="${escapeHtml(altText)}"${intrinsicDimensions}${srcsetAttribute}${sizesAttribute}${styleAttribute}${loadingAttribute}${fetchPriorityAttribute} decoding="async" />`,
     data.caption ? `  <figcaption class="c-media__caption">${escapeHtml(data.caption)}</figcaption>` : "",
     "</figure>",
   ]

--- a/src/components/media/media.schema.ts
+++ b/src/components/media/media.schema.ts
@@ -6,6 +6,7 @@ export const MediaSchemaBase = z
     src: z.string().min(1).max(2048),
     alt: z.string().max(200).optional(),
     caption: z.string().min(1).max(280).optional(),
+    loading: z.enum(["eager", "lazy"]).optional(),
     width: z.number().int().positive().max(10000).optional(),
     height: z.number().int().positive().max(10000).optional(),
     size: z.enum(["content", "wide"]).default("wide"),

--- a/src/components/media/media.test.ts
+++ b/src/components/media/media.test.ts
@@ -51,6 +51,30 @@ describe("MediaSchema", () => {
     expect(html).toContain('fetchpriority="high"');
   });
 
+  it("supports lazy loading media blocks with lower fetch priority", () => {
+    const parsed = MediaSchema.parse({
+      type: "media",
+      src: "https://example.com/studio.jpg",
+      alt: "Founder standing in the studio",
+      size: "content",
+      loading: "lazy",
+    });
+
+    const html = renderMedia(parsed, {
+      resolveImage: () => ({
+        src: "https://example.com/studio.jpg",
+        width: 1600,
+        height: 900,
+      }),
+      resolveGalleryImage: () => ({
+        src: "https://example.com/studio.jpg",
+      }),
+    });
+
+    expect(html).toContain('loading="lazy"');
+    expect(html).toContain('fetchpriority="low"');
+  });
+
   it("rejects unknown fields", () => {
     const result = MediaSchema.safeParse({
       type: "media",


### PR DESCRIPTION
Add optional loading hints to media blocks so individual images can opt into lazy loading and lower fetch priority without changing the default behavior for all other media. The florist image uses this to stay under the hero without hurting the global media defaults.