### PR TITLE
Keep lazy media loading simple

### DIFF
--- a/src/components/media/media.render.ts
+++ b/src/components/media/media.render.ts
@@ -47,7 +47,7 @@ export const renderMedia = (
 
   return [
     `<figure class="c-media c-media--size-${escapeHtml(data.size)}">`,
-    `  <img class="c-media__image" src="${escapeHtml(resolvedImage.src)}" alt="${escapeHtml(altText)}"${intrinsicDimensions}${srcsetAttribute}${sizesAttribute}${styleAttribute}${loadingAttribute} fetchpriority="high" decoding="async" />`,
+    `  <img class="c-media__image" src="${escapeHtml(resolvedImage.src)}" alt="${escapeHtml(altText)}"${intrinsicDimensions}${srcsetAttribute}${sizesAttribute}${styleAttribute}${loadingAttribute} decoding="async" />`,
     data.caption ? `  <figcaption class="c-media__caption">${escapeHtml(data.caption)}</figcaption>` : "",
     "</figure>",
   ]

--- a/src/components/media/media.render.ts
+++ b/src/components/media/media.render.ts
@@ -44,12 +44,10 @@ export const renderMedia = (
   const sizesAttribute =
     responsiveImage?.sizes ? ` sizes="${escapeHtml(responsiveImage.sizes)}"` : "";
   const loadingAttribute = data.loading ? ` loading="${escapeHtml(data.loading)}"` : "";
-  const fetchPriorityAttribute =
-    data.loading === "lazy" ? ' fetchpriority="low"' : ' fetchpriority="high"';
 
   return [
     `<figure class="c-media c-media--size-${escapeHtml(data.size)}">`,
-    `  <img class="c-media__image" src="${escapeHtml(resolvedImage.src)}" alt="${escapeHtml(altText)}"${intrinsicDimensions}${srcsetAttribute}${sizesAttribute}${styleAttribute}${loadingAttribute}${fetchPriorityAttribute} decoding="async" />`,
+    `  <img class="c-media__image" src="${escapeHtml(resolvedImage.src)}" alt="${escapeHtml(altText)}"${intrinsicDimensions}${srcsetAttribute}${sizesAttribute}${styleAttribute}${loadingAttribute} fetchpriority="high" decoding="async" />`,
     data.caption ? `  <figcaption class="c-media__caption">${escapeHtml(data.caption)}</figcaption>` : "",
     "</figure>",
   ]

--- a/src/components/media/media.test.ts
+++ b/src/components/media/media.test.ts
@@ -72,7 +72,7 @@ describe("MediaSchema", () => {
     });
 
     expect(html).toContain('loading="lazy"');
-    expect(html).toContain('fetchpriority="low"');
+    expect(html).toContain('fetchpriority="high"');
   });
 
   it("rejects unknown fields", () => {

--- a/src/components/media/media.test.ts
+++ b/src/components/media/media.test.ts
@@ -20,7 +20,7 @@ describe("MediaSchema", () => {
     expect(html).toContain('<figure class="c-media c-media--size-content">');
     expect(html).toContain('<img class="c-media__image"');
     expect(html).toContain('alt="Founder standing in the studio"');
-    expect(html).toContain('fetchpriority="high"');
+    expect(html).not.toContain('fetchpriority=');
     expect(html).toContain('decoding="async"');
     expect(html).toContain('style="width: 1600px; height: 900px;"');
     expect(html).not.toContain('width="1600" height="900"');
@@ -48,7 +48,7 @@ describe("MediaSchema", () => {
 
     expect(html).toContain('width="1600" height="900"');
     expect(html).not.toContain('style="width:');
-    expect(html).toContain('fetchpriority="high"');
+    expect(html).not.toContain('fetchpriority=');
   });
 
   it("supports lazy loading media blocks with lower fetch priority", () => {
@@ -72,7 +72,7 @@ describe("MediaSchema", () => {
     });
 
     expect(html).toContain('loading="lazy"');
-    expect(html).toContain('fetchpriority="high"');
+    expect(html).not.toContain('fetchpriority=');
   });
 
   it("rejects unknown fields", () => {


### PR DESCRIPTION
Keep the lazy-loading support for media blocks, but remove the extra fetch-priority branching. The florist image uses lazy loading plus explicit sizing to stay under the hero without introducing extra behavior.