### PR TITLE
[codex] tighten panel spacing

### DIFF
--- a/src/components/cta-band/cta-band.css
+++ b/src/components/cta-band/cta-band.css
@@ -1,11 +1,11 @@
 .c-cta-band {
-  padding-block: var(--space-7);
+  padding-block: var(--space-6);
 }
 
 .c-cta-band__inner {
   width: min(calc(100% - (2 * var(--space-5))), var(--content-max));
   margin-inline: auto;
-  padding: var(--space-6);
+  padding: var(--space-5);
   display: grid;
   gap: var(--space-4);
   border: var(--border-width-2) solid var(--color-border);

--- a/src/components/feature-grid/feature-grid.css
+++ b/src/components/feature-grid/feature-grid.css
@@ -1,5 +1,5 @@
 .c-feature-grid {
-  padding-block: var(--space-7);
+  padding-block: var(--space-6);
 }
 
 .c-feature-grid__inner {
@@ -64,7 +64,7 @@
 }
 
 .c-feature-grid__item {
-  padding: var(--space-5);
+  padding: var(--space-4);
   display: grid;
   gap: var(--space-4);
   border: var(--border-width-1) solid var(--color-border);

--- a/src/components/media/media.css
+++ b/src/components/media/media.css
@@ -1,6 +1,6 @@
 .c-media {
   margin: 0;
-  padding-block: var(--space-7);
+  padding-block: var(--space-6);
 }
 
 .c-media--size-content {


### PR DESCRIPTION
Tighten the shared panel density by reducing the vertical padding inside the most common section components:

- `media` sections now use a smaller section pad
- `feature-grid` sections and cards use a tighter padding scale
- `cta-band` uses a smaller outer/inner padding combination

This keeps the hero readable while reducing the amount of whitespace stacked inside the supporting panels.

Validation:
- `npm test`
- `npm run lint:ts`