### PR TITLE
[codex] add lighthouse failure summaries

### DIFF
--- a/src/build/lighthouse-ci.ts
+++ b/src/build/lighthouse-ci.ts
@@ -5,6 +5,7 @@ import os from "node:os";
 import path from "node:path";
 
 import { createStaticServer } from "./static-server.js";
+import { formatFailedCategoryDetails, type LighthouseReport } from "./lighthouse-report.js";
 
 const repoRoot = process.cwd();
 const distDir = path.join(repoRoot, "dist");
@@ -96,10 +97,7 @@ const main = async (): Promise<void> => {
   try {
     await runLighthouse(`${server.origin}/`, reportPath);
 
-    const report = JSON.parse(await readFile(reportPath, "utf8")) as {
-      categories?: Record<string, { score?: number | null }>;
-      audits?: Record<string, { numericValue?: number | null }>;
-    };
+    const report = JSON.parse(await readFile(reportPath, "utf8")) as LighthouseReport;
 
     const categoryScores = categoryThresholds.map(({ key, label }) => {
       const score = report.categories?.[key]?.score;
@@ -141,13 +139,14 @@ const main = async (): Promise<void> => {
 
     if (failedCategories.length > 0 || failedMetrics.length > 0) {
       const messages = [
-        ...failedCategories.map(
-          ({ label, score }) => `${label} score ${formatPercent(score)} is below ${minCategoryScore}`,
-        ),
-        ...failedMetrics.map(
-          ({ label, value, maxValue, format }) =>
-            `${label} ${format(value)} exceeds ${format(maxValue)}`,
-        ),
+        ...failedCategories.flatMap(({ key, label, score }) => [
+          `${label} score ${formatPercent(score)} is below ${minCategoryScore}`,
+          ...formatFailedCategoryDetails(report, key),
+        ]),
+        ...failedMetrics.map(({ label, value, maxValue, format }) => {
+          const formattedValue = format(value);
+          return `${label} ${formattedValue} exceeds ${format(maxValue)}`;
+        }),
       ];
 
       throw new Error(`Lighthouse thresholds failed:\n- ${messages.join("\n- ")}`);

--- a/src/build/lighthouse-report.ts
+++ b/src/build/lighthouse-report.ts
@@ -1,0 +1,127 @@
+export type LighthouseAuditDetails = {
+  overallSavingsBytes?: number | null;
+  overallSavingsMs?: number | null;
+  type?: string;
+};
+
+export type LighthouseAudit = {
+  details?: LighthouseAuditDetails;
+  displayValue?: string | null;
+  id?: string;
+  numericValue?: number | null;
+  score?: number | null;
+  title?: string | null;
+};
+
+export type LighthouseAuditRef = {
+  id: string;
+  weight?: number;
+};
+
+export type LighthouseCategory = {
+  auditRefs?: LighthouseAuditRef[];
+  score?: number | null;
+};
+
+export type LighthouseReport = {
+  audits?: Record<string, LighthouseAudit>;
+  categories?: Record<string, LighthouseCategory>;
+};
+
+const formatPercent = (score: number): string => `${Math.round(score * 100)}`;
+
+const formatBytes = (value: number): string => {
+  const absolute = Math.abs(value);
+
+  if (absolute < 1024) {
+    return `${Math.round(value)}B`;
+  }
+
+  const kib = value / 1024;
+
+  if (Math.abs(kib) < 1024) {
+    return `${kib.toFixed(Math.abs(kib) < 10 ? 1 : 0)} KiB`;
+  }
+
+  const mib = kib / 1024;
+  return `${mib.toFixed(Math.abs(mib) < 10 ? 1 : 0)} MiB`;
+};
+
+const formatAuditValue = (audit: LighthouseAudit): string | undefined => {
+  if (audit.displayValue) {
+    return audit.displayValue;
+  }
+
+  if (typeof audit.numericValue === "number") {
+    return `${Math.round(audit.numericValue)}`;
+  }
+
+  return undefined;
+};
+
+const formatAuditDetails = (audit: LighthouseAudit): string | undefined => {
+  if (audit.details?.type === "opportunity") {
+    if (typeof audit.details.overallSavingsMs === "number" && audit.details.overallSavingsMs > 0) {
+      return `estimated savings ${Math.round(audit.details.overallSavingsMs)}ms`;
+    }
+
+    if (
+      typeof audit.details.overallSavingsBytes === "number" &&
+      audit.details.overallSavingsBytes > 0
+    ) {
+      return `estimated savings ${formatBytes(audit.details.overallSavingsBytes)}`;
+    }
+  }
+
+  const displayValue = formatAuditValue(audit);
+  return displayValue ? `value ${displayValue}` : undefined;
+};
+
+export const collectCategoryAuditDetails = (
+  report: LighthouseReport,
+  categoryKey: string,
+  maxItems = 5,
+): string[] => {
+  const category = report.categories?.[categoryKey];
+  const auditRefs = category?.auditRefs ?? [];
+
+  return auditRefs
+    .map((ref) => {
+      const audit = report.audits?.[ref.id];
+
+      if (!audit || typeof audit.score !== "number") {
+        return undefined;
+      }
+
+      const weight = ref.weight ?? 0;
+      const score = audit.score;
+      const impact = weight * (1 - score);
+
+      return {
+        audit,
+        impact,
+      };
+    })
+    .filter(
+      (entry): entry is { audit: LighthouseAudit; impact: number } =>
+        entry !== undefined && entry.impact > 0,
+    )
+    .sort((left, right) => right.impact - left.impact)
+    .slice(0, maxItems)
+    .map(({ audit }) => {
+      const score = typeof audit.score === "number" ? ` (${formatPercent(audit.score)})` : "";
+      const detail = formatAuditDetails(audit);
+
+      return `- ${audit.title ?? audit.id ?? "Unnamed audit"}${score}${detail ? `: ${detail}` : ""}`;
+    });
+};
+
+export const formatFailedCategoryDetails = (report: LighthouseReport, categoryKey: string): string[] => {
+  const details = collectCategoryAuditDetails(report, categoryKey);
+
+  if (details.length === 0) {
+    return [];
+  }
+
+  return ["  Top related audits:", ...details.map((detail) => `    ${detail}`)];
+};

--- a/tests/lighthouse-report.test.ts
+++ b/tests/lighthouse-report.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+
+import { formatFailedCategoryDetails, type LighthouseReport } from "../src/build/lighthouse-report.js";
+
+describe("Lighthouse report summaries", () => {
+  it("lists the most impactful failing audits first", () => {
+    const report: LighthouseReport = {
+      categories: {
+        performance: {
+          auditRefs: [
+            { id: "unused-javascript", weight: 3 },
+            { id: "render-blocking-resources", weight: 2 },
+            { id: "uses-long-cache-ttl", weight: 1 },
+          ],
+        },
+      },
+      audits: {
+        "unused-javascript": {
+          title: "Reduce unused JavaScript",
+          score: 0,
+          details: {
+            type: "opportunity",
+            overallSavingsBytes: 512000,
+          },
+        },
+        "render-blocking-resources": {
+          title: "Eliminate render-blocking resources",
+          score: 0.5,
+          details: {
+            type: "opportunity",
+            overallSavingsMs: 240,
+          },
+        },
+        "uses-long-cache-ttl": {
+          title: "Serve static assets with an efficient cache policy",
+          score: 1,
+          details: {
+            type: "opportunity",
+            overallSavingsBytes: 1000,
+          },
+        },
+      },
+    };
+
+    const details = formatFailedCategoryDetails(report, "performance");
+
+    expect(details).toEqual([
+      "  Top related audits:",
+      "    - Reduce unused JavaScript (0): estimated savings 500 KiB",
+      "    - Eliminate render-blocking resources (50): estimated savings 240ms",
+    ]);
+  });
+
+  it("returns no detail block when the category has no failing audits", () => {
+    const report: LighthouseReport = {
+      categories: {
+        accessibility: {
+          auditRefs: [{ id: "color-contrast", weight: 1 }],
+        },
+      },
+      audits: {
+        "color-contrast": {
+          title: "Contrast",
+          score: 1,
+        },
+      },
+    };
+
+    expect(formatFailedCategoryDetails(report, "accessibility")).toEqual([]);
+  });
+});


### PR DESCRIPTION
Improve Lighthouse CI failure output so category threshold misses are easier to debug in GitHub Actions logs.

When a category falls below the threshold, the script now prints the most impactful audits for that category, including scores and estimated savings or values where available. The helpers live in a pure module and are covered by unit tests.

Validation:
- `npm test`
- `npm run lint:ts`