### PR TITLE
Skip analytics during Lighthouse CI

### DIFF
--- a/src/renderer/render-page.ts
+++ b/src/renderer/render-page.ts
@@ -1,10 +1,12 @@
 import type { PageData, SiteData } from "../schemas/site.schema.js";
 import { escapeHtml } from "./escape-html.js";
 
+const shouldIncludeGoogleAnalytics = (): boolean => process.env.LIGHTHOUSE_CI !== "1";
+
 const renderGoogleAnalyticsTags = (site: SiteData): string => {
   const measurementId = site.googleAnalyticsMeasurementId;
 
-  if (!measurementId) {
+  if (!measurementId || !shouldIncludeGoogleAnalytics()) {
     return "";
   }
 

--- a/tests/build-output.test.ts
+++ b/tests/build-output.test.ts
@@ -262,6 +262,29 @@ describe("buildSite output writes", () => {
     }
   });
 
+  it("omits google analytics tags during lighthouse ci builds", async () => {
+    const outDir = await mkdtemp(path.join(os.tmpdir(), "cruftless-build-analytics-ci-"));
+    const previousLighthouseCi = process.env.LIGHTHOUSE_CI;
+
+    try {
+      process.env.LIGHTHOUSE_CI = "1";
+      await buildSite(createAnalyticsSite(), outDir);
+
+      const html = await readFile(path.join(outDir, "index.html"), "utf8");
+
+      expect(html).not.toContain("googletagmanager.com/gtag/js");
+      expect(html).not.toContain("gtag('config', \"G-TEST1234\");");
+    } finally {
+      if (previousLighthouseCi === undefined) {
+        delete process.env.LIGHTHOUSE_CI;
+      } else {
+        process.env.LIGHTHOUSE_CI = previousLighthouseCi;
+      }
+
+      await removeDirectory(outDir);
+    }
+  });
+
   it("optimizes referenced content preview images into assets and removes them when no longer needed", async () => {
     const projectRoot = await mkdtemp(path.join(os.tmpdir(), "cruftless-build-local-assets-"));
     const contentDir = path.join(projectRoot, "content");


### PR DESCRIPTION
Omit Google Analytics tags when LIGHTHOUSE_CI=1 so the Lighthouse audit build matches the no-analytics CI path and avoids performance noise from GA.