### PR TITLE
[codex] support feature grid CTA link targets

### DIFF
--- a/schemas/site-content.schema.json
+++ b/schemas/site-content.schema.json
@@ -694,6 +694,13 @@
                                     "minLength": 1,
                                     "maxLength": 2048,
                                     "pattern": "^(?:(?:https?|ftp):\\/\\/[^/?#\\s<>\"`]+(?:[/?#][^\\s<>\"`]*)?|mailto:[^\\s<>\"`?#]+(?:\\?[^\\s<>\"`]*)?|tel:\\+?[0-9A-Za-z().-]+(?:;[A-Za-z0-9-]+=[^;\\s<>\"`]*)*|sms:\\+?[0-9A-Za-z().-]+(?:\\?[^\\s<>\"`]*)?|(?!(?:(?:https?|ftp|mailto|tel|sms|javascript|data|vbscript):))[a-z][a-z0-9+.-]*:[^\\s<>\"`]+|\\/\\/[^/?#\\s<>\"`]+(?:[/?#][^\\s<>\"`]*)?|\\/(?!\\/)[^\\s<>\"`]*|\\.{1,2}\\/[^\\s<>\"`]*|[#?][^\\s<>\"`]*)$"
+                                  },
+                                  "target": {
+                                    "type": "string",
+                                    "enum": [
+                                      "_self",
+                                      "_blank"
+                                    ]
                                   }
                                 },
                                 "required": [
@@ -1133,13 +1140,6 @@
                                 "type": "integer",
                                 "exclusiveMinimum": 0,
                                 "maximum": 10000
-                              },
-                              "loading": {
-                                "type": "string",
-                                "enum": [
-                                  "eager",
-                                  "lazy"
-                                ]
                               },
                               "size": {
                                 "type": "string",

--- a/src/components/feature-grid/feature-grid.render.ts
+++ b/src/components/feature-grid/feature-grid.render.ts
@@ -94,7 +94,15 @@ export const renderFeatureGrid = (
             ? '          <p class="c-feature-grid__item-status" aria-current="page">Current selection</p>'
             : "",
           item.cta
-            ? `          <a class="c-feature-grid__item-cta c-button c-button--secondary" href="${escapeHtml(item.cta.href)}">${escapeHtml(item.cta.label)}</a>`
+            ? (() => {
+                const targetAttribute = item.cta.target
+                  ? ` target="${escapeHtml(item.cta.target)}"`
+                  : "";
+                const relAttribute =
+                  item.cta.target === "_blank" ? ' rel="noopener noreferrer"' : "";
+
+                return `          <a class="c-feature-grid__item-cta c-button c-button--secondary" href="${escapeHtml(item.cta.href)}"${targetAttribute}${relAttribute}>${escapeHtml(item.cta.label)}</a>`;
+              })()
             : "",
           "        </div>",
           "      </li>",

--- a/src/components/feature-grid/feature-grid.test.ts
+++ b/src/components/feature-grid/feature-grid.test.ts
@@ -26,6 +26,7 @@ describe("FeatureGridSchema", () => {
           cta: {
             label: "See examples",
             href: "/examples",
+            target: "_blank",
           },
         },
       ],
@@ -45,6 +46,8 @@ describe("FeatureGridSchema", () => {
     expect(html).toContain("Strict validation");
     expect(html).toContain('class="c-feature-grid__item-cta c-button c-button--secondary"');
     expect(html).toContain('href="/examples"');
+    expect(html).toContain('target="_blank"');
+    expect(html).toContain('rel="noopener noreferrer"');
     expect(html).toContain("See examples");
   });
 
@@ -163,5 +166,24 @@ describe("FeatureGridSchema", () => {
           String(issue.path.join(".")) === "items.0.cta",
       ),
     ).toBe(true);
+  });
+
+  it("accepts supported CTA targets", () => {
+    const result = FeatureGridSchema.safeParse({
+      type: "feature-grid",
+      title: "Why it works",
+      items: [
+        {
+          title: "Strict validation",
+          cta: {
+            label: "Open",
+            href: "/examples",
+            target: "_blank",
+          },
+        },
+      ],
+    });
+
+    expect(result.success).toBe(true);
   });
 });

--- a/src/schemas/shared.ts
+++ b/src/schemas/shared.ts
@@ -97,6 +97,7 @@ export const LinkSchema = z
   .object({
     label: z.string().min(1),
     href: HrefSchema,
+    target: z.enum(["_self", "_blank"]).optional(),
   })
   .strict();
 


### PR DESCRIPTION
## Summary
- add optional link target support to the shared link schema
- render feature-grid CTA links with target and safe rel attributes when requested
- refresh the shared content schema and feature-grid tests

## Verification
- npm run test -- src/components/feature-grid/feature-grid.test.ts
- npm run lint:ts
- npm run schema:generate