### PR TITLE
[codex] refine image scaling and backgrounds

### DIFF
--- a/schemas/site-content.schema.json
+++ b/schemas/site-content.schema.json
@@ -202,6 +202,11 @@
                   "minLength": 1,
                   "maxLength": 400
                 },
+                "--theme-pattern": {
+                  "type": "string",
+                  "minLength": 1,
+                  "maxLength": 400
+                },
                 "--duration": {
                   "type": "string",
                   "minLength": 1,

--- a/src/build/image-pipeline.ts
+++ b/src/build/image-pipeline.ts
@@ -13,7 +13,7 @@ import type {
 } from "../components/render-context.js";
 import type { SiteContentData } from "../schemas/site.schema.js";
 
-const rasterExtensions = new Set([".jpg", ".jpeg", ".png", ".webp", ".avif"]);
+const rasterExtensions = new Set([".jpg", ".jpeg", ".png", ".webp", ".avif", ".gif"]);
 const svgExtension = ".svg";
 const imagePipelineVersion = "v1";
 
@@ -36,20 +36,6 @@ const usageOutputWidths: Record<ComponentImageUsage, number> = {
 const responsiveMediaOutputWidths: Record<"media-content" | "media-wide", number[]> = {
   "media-content": [480, 640, 960, 1024],
   "media-wide": [480, 640, 960, 1152],
-};
-
-const usageMinimumSourceWidths: Partial<Record<ComponentImageUsage, number>> = {
-  "before-after-panel": 960,
-  "feature-grid-inline": 640,
-  "feature-grid-stacked": 960,
-  "gallery-thumb-2": 720,
-  "gallery-thumb-3": 560,
-  "gallery-thumb-4": 420,
-  "image-text": 1200,
-  "media-content": 1024,
-  "media-wide": 1600,
-  "navbar-brand": 320,
-  "testimonial-avatar": 256,
 };
 
 const galleryColumnUsage: Record<"2" | "3" | "4", ComponentImageUsage> = {
@@ -481,7 +467,6 @@ const processLocalImageVariant = async (
 const validateLocalImageUsage = async (
   usageEntry: { path: Array<string | number>; usage: ImageReferenceUsage },
   contentPath: string,
-  accumulatedRequirements: Map<string, number>,
 ): Promise<ImageBuildIssue[]> => {
   const localSource = resolveLocalImageSource(usageEntry.usage.sourceHref, contentPath);
 
@@ -514,21 +499,6 @@ const validateLocalImageUsage = async (
     return issues;
   }
 
-  const requiredWidth = usageMinimumSourceWidths[usageEntry.usage.usage];
-  if (requiredWidth === undefined) {
-    return issues;
-  }
-
-  const previousRequirement = accumulatedRequirements.get(localSource.sourcePath) ?? 0;
-  accumulatedRequirements.set(localSource.sourcePath, Math.max(previousRequirement, requiredWidth));
-
-  if (metadata.isRaster && metadata.width !== undefined && metadata.width < requiredWidth) {
-    issues.push({
-      message: `source image width ${metadata.width}px is smaller than required ${requiredWidth}px for ${usageEntry.usage.usage}`,
-      path: usageEntry.path,
-    });
-  }
-
   return issues;
 };
 
@@ -548,11 +518,8 @@ export const collectImageValidationIssues = async (
   siteContent: SiteContentData,
   contentPath: string,
 ): Promise<ImageBuildIssue[]> => {
-  const requirements = new Map<string, number>();
   const issues = await Promise.all(
-    collectImageUsages(siteContent).map((usageEntry) =>
-      validateLocalImageUsage(usageEntry, contentPath, requirements),
-    ),
+    collectImageUsages(siteContent).map((usageEntry) => validateLocalImageUsage(usageEntry, contentPath)),
   );
 
   return issues.flat();
@@ -686,6 +653,7 @@ export const prepareImagePipeline = async (
           return undefined;
         }
 
+        const seenWidths = new Set<number>();
         const variants = targetWidths
           .flatMap((targetWidth) => {
             const variantKey = createPreparedVariantKey(image.src, usage, targetWidth);
@@ -703,7 +671,18 @@ export const prepareImagePipeline = async (
               },
             ];
           })
-          .filter((variant) => variant.width !== undefined && variant.height !== undefined);
+          .filter((variant) => {
+            if (variant.width === undefined || variant.height === undefined) {
+              return false;
+            }
+
+            if (seenWidths.has(variant.width)) {
+              return false;
+            }
+
+            seenWidths.add(variant.width);
+            return true;
+          });
 
         if (variants.length === 0) {
           return undefined;

--- a/src/components/prose/prose.css
+++ b/src/components/prose/prose.css
@@ -1,5 +1,5 @@
 .c-prose {
-  padding-block: var(--space-xl);
+  padding-block: var(--space-lg);
 }
 
 .c-prose__inner {

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -21,10 +21,7 @@ body {
   min-height: 100vh;
   min-height: 100svh;
   min-height: 100dvh;
-  background-color: var(--bg);
-  background-image: var(--theme-pattern);
-  background-image: var(--site-page-background-image, var(--theme-pattern));
-  background-attachment: fixed;
+  background: var(--site-page-background-image, none) center / cover no-repeat fixed, var(--theme-pattern) fixed var(--bg);
   color: var(--text);
 }
 

--- a/tests/78th-street-studios-example.test.ts
+++ b/tests/78th-street-studios-example.test.ts
@@ -65,7 +65,7 @@ describe("78th Street Studios example", () => {
       expect(js).toContain("resolveNavigationBarMode");
       expect(css).toContain("--site-page-background-image:");
       expect(css).toContain(
-        "background: var(--site-page-background-image, none) left top / cover no-repeat scroll var(--bg);",
+        "background: var(--site-page-background-image, none) center / cover no-repeat fixed, var(--theme-pattern) fixed var(--bg);",
       );
       expect(css).toContain(
         'url("https://78thstreetstudios.com/sites/78thstreetstudios.com/files/styles/adaptive/public/media/images/background/IMG_CFD448348658-1.jpeg?itok=FLmeLmsX")',

--- a/tests/component-css-widths.test.ts
+++ b/tests/component-css-widths.test.ts
@@ -18,7 +18,6 @@ describe("component width tokens", () => {
       componentDefinitions
         .filter(
           (component) =>
-            component.type !== "page-content" &&
             component.type !== "media" &&
             component.type !== "google-maps" &&
             component.type !== "hero",

--- a/tests/image-pipeline.test.ts
+++ b/tests/image-pipeline.test.ts
@@ -136,13 +136,29 @@ const createLocalImageProject = async (
 };
 
 describe("image pipeline", () => {
-  it("rejects local raster images that are smaller than the required component slot", async () => {
+  it("accepts local raster images smaller than the component slot without upscaling them", async () => {
     const fixture = await createLocalImageProject(480, 320);
+    const outDir = path.join(fixture.rootDir, "dist");
 
     try {
-      await expect(loadValidatedSite(fixture.contentPath)).rejects.toThrow(
-        /source image width 480px is smaller than required 560px for gallery-thumb-3/,
+      await buildSiteFromFile(fixture.contentPath, outDir);
+
+      const homeHtml = await readFile(path.join(outDir, "index.html"), "utf8");
+      const outputImagesDir = path.join(outDir, "assets", "images");
+      const outputImageNames = await readdir(outputImagesDir);
+      const thumbOutputName = outputImageNames.find((name) =>
+        name.startsWith("showroom-gallery-thumb-3-"),
       );
+
+      if (!thumbOutputName) {
+        throw new Error(`missing optimized thumbnail output: ${outputImageNames.join(", ")}`);
+      }
+
+      const thumbOutputMetadata = await sharp(path.join(outputImagesDir, thumbOutputName)).metadata();
+
+      expect(thumbOutputMetadata.width).toBe(480);
+      expect(homeHtml).toMatch(/srcset="[^"]+ 480w"/u);
+      expect(homeHtml).not.toMatch(/srcset="[^"]+ 640w/u);
     } finally {
       await removeDirectory(fixture.rootDir);
     }


### PR DESCRIPTION
﻿## Summary

- Allow local raster images that are smaller than a target slot to build without upscaling, while deduplicating responsive `srcset` widths.
- Add GIF as a supported raster input format for the image pipeline.
- Compose site background images with the theme pattern background and tighten prose section spacing.
- Update generated schema artifacts and regression tests for the image and background behavior.

## Why

The image pipeline was rejecting smaller-but-valid local images before build output could use the source dimensions. The renderer can safely emit the available size without inventing larger variants, so validation should not block that case.

## Notes

Separate `feature-list` and `link-list` component types were removed from this changeset. That functionality stays on the existing `feature-grid` surface.

## Validation

- `npm run schema:check`
- `npm run lint:ts`
- `npm run lint:css`
- `npx vitest run tests/build-watch.test.ts tests/image-pipeline.test.ts tests/site-json-schema.test.ts tests/theme-examples.test.ts tests/78th-street-studios-example.test.ts tests/component-css-widths.test.ts`
- `npm run test`
