### PR TITLE
[codex] Fix media-wide image rendering

### DIFF
--- a/src/components/contact/contact.css
+++ b/src/components/contact/contact.css
@@ -33,11 +33,11 @@
   display: grid;
   gap: var(--space-xs);
   text-decoration: none;
-  transition: transform var(--duration) var(--ease), background-color var(--duration) var(--ease);
+  transition: transform var(--duration) var(--ease), background var(--duration) var(--ease);
 }
 
 .c-contact__item--link:hover {
-  background-color: var(--surface);
+  background: var(--surface);
   transform: translateY(-2px);
 }
 

--- a/src/components/media/media.css
+++ b/src/components/media/media.css
@@ -10,6 +10,7 @@
   height: auto;
   margin-inline: auto;
   border-radius: var(--radius);
+
   /* shadow handled by section card if this is the root */
 }
 

--- a/src/components/media/media.render.ts
+++ b/src/components/media/media.render.ts
@@ -15,8 +15,9 @@ export const renderMedia = (
   data: MediaData,
   renderContext: ComponentRenderContext = defaultComponentRenderContext,
 ): string => {
-  const resolvedImage = renderContext.resolveImage(data, "media-content");
-  const responsiveImage = renderContext.resolveResponsiveImage?.(data, "media-content");
+  const imageUsage = data.size === "content" ? "media-content" : "media-wide";
+  const resolvedImage = renderContext.resolveImage(data, imageUsage);
+  const responsiveImage = renderContext.resolveResponsiveImage?.(data, imageUsage);
   const altText = data.alt ?? "";
   const intrinsicWidth = data.width ?? resolvedImage.width;
   const intrinsicHeight = data.height ?? resolvedImage.height;
@@ -31,7 +32,7 @@ export const renderMedia = (
   const loadingAttribute = data.loading ? ` loading="${escapeHtml(data.loading)}"` : "";
 
   return [
-    '<section class="c-media l-section">',
+    `<section class="c-media l-section c-media--size-${escapeHtml(data.size)}">`,
     `  <img class="c-media__image" src="${escapeHtml(resolvedImage.src)}" alt="${escapeHtml(altText)}"${intrinsicDimensions}${srcsetAttribute}${sizesAttribute}${loadingAttribute} decoding="async" />`,
     data.caption ? `  <p class="c-media__caption">${escapeHtml(data.caption)}</p>` : "",
     "</section>",


### PR DESCRIPTION
## Summary

Fixes media components so wide media blocks resolve image pipeline assets using the `media-wide` usage instead of always using `media-content`.

## Root Cause

The image pipeline collected wide media references under the `media-wide` usage, but `renderMedia` always asked the render context for `media-content`. That mismatch left generated pages pointing at the original `/content/images/landing-page.*` path even though optimized `landing-page-media-wide-*` assets were emitted.

## Changes

- Resolve media image usage from `data.size` in `renderMedia`.
- Restore the size modifier class on the media section markup.
- Clean up CSS lint issues in contact and media component styles.

## Validation

- `npm run validate:strict` in `F:\cruftless-site-gen`
- `SITEBYEMAIL_ALLOW_UNREADY_GENERATOR=1 npm run validate:strict` in `F:\sitebyemail.com`
- `.\validate-refreshes.ps1` in `F:\Refreshes` checked 100 sites with 0 errors and 0 warnings