### PR TITLE
[codex] Allow dev builds to disable analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,16 +8,16 @@ The project is intentionally opinionated. Content authors choose from a fixed se
 
 This repo exists to rebuild existing sites into a cleaner format without opening the door to arbitrary template logic or free-form HTML in content files.
 
-The early issue history shaped that direction:
+The current approach is to keep the authoring surface small and explicit:
 
-- issue `#5` pushed the repo toward real migrations by rebuilding 78th Street Studios as a test site and writing down what worked
-- issue `#9` made themes do more than swap colors, so theme choice materially changes the look and feel
-- issue `#10` added `media` and `prose`, which made visually rich and narrative-heavy pages fit the system better
-- issue `#13` added generated JSON Schema support so editing content in VS Code can stay ergonomic
-- issue `#21` added shared site-level layout with a `page-content` slot for repeated navigation, headers, or footers
-- issue `#22` added a Google Maps component so location-driven sites can keep an embedded map
+- real site migrations are treated as the proving ground, so components need to cover practical brochure-site patterns instead of abstract examples
+- themes control more than color tokens, so changing the theme can materially change spacing, typography, surfaces, and visual rhythm
+- visually rich and narrative-heavy pages are modeled with structured components such as `media`, `image-text`, `gallery`, and `prose`
+- repeated site chrome belongs in shared layout components, with `page-content` marking where each page's own sections render
+- location-driven sites can use first-class contact, hours, store-location-hours, and Google Maps components
+- JSON Schema output keeps editing ergonomic in VS Code while preserving strict validation at build time
 
-The result is a system that aims to be strict, reusable, and reviewable instead of endlessly flexible.
+The goal is a system that stays strict, reusable, and reviewable instead of endlessly flexible.
 
 ## Core approach
 

--- a/src/renderer/render-page.ts
+++ b/src/renderer/render-page.ts
@@ -1,7 +1,8 @@
 import type { PageData, SiteData } from "../schemas/site.schema.js";
 import { escapeHtml } from "./escape-html.js";
 
-const shouldIncludeGoogleAnalytics = (): boolean => process.env.LIGHTHOUSE_CI !== "1";
+const shouldIncludeGoogleAnalytics = (): boolean =>
+  process.env.LIGHTHOUSE_CI !== "1" && process.env.CRUFTLESS_DISABLE_ANALYTICS !== "1";
 
 const renderGoogleAnalyticsTags = (site: SiteData): string => {
   const measurementId = site.googleAnalyticsMeasurementId;

--- a/tests/build-output.test.ts
+++ b/tests/build-output.test.ts
@@ -308,6 +308,29 @@ describe("buildSite output writes", () => {
     }
   });
 
+  it("omits google analytics tags when analytics are disabled for local builds", async () => {
+    const outDir = await mkdtemp(path.join(os.tmpdir(), "cruftless-build-analytics-disabled-"));
+    const previousDisableAnalytics = process.env.CRUFTLESS_DISABLE_ANALYTICS;
+
+    try {
+      process.env.CRUFTLESS_DISABLE_ANALYTICS = "1";
+      await buildSite(createAnalyticsSite(), outDir);
+
+      const html = await readFile(path.join(outDir, "index.html"), "utf8");
+
+      expect(html).not.toContain("googletagmanager.com/gtag/js");
+      expect(html).not.toContain("gtag('config', \"G-TEST1234\");");
+    } finally {
+      if (previousDisableAnalytics === undefined) {
+        delete process.env.CRUFTLESS_DISABLE_ANALYTICS;
+      } else {
+        process.env.CRUFTLESS_DISABLE_ANALYTICS = previousDisableAnalytics;
+      }
+
+      await removeDirectory(outDir);
+    }
+  });
+
   it("optimizes referenced content preview images into assets and removes them when no longer needed", async () => {
     const projectRoot = await mkdtemp(path.join(os.tmpdir(), "cruftless-build-local-assets-"));
     const contentDir = path.join(projectRoot, "content");


### PR DESCRIPTION
## What changed
- Added `CRUFTLESS_DISABLE_ANALYTICS=1` support to the page renderer.
- Covered the analytics suppression path with a build output regression test.
- Updated the README to describe the current Cruftless Site Gen approach instead of historical issue milestones.

## Why
Site by Email local dev needs to generate pages without loading the live Google Analytics script, while production builds should keep analytics enabled. The README should explain the current architecture directly rather than requiring readers to understand the issue history that led there.

## Impact
Consumers can disable analytics for local/dev builds without changing site content. Existing production behavior remains unchanged unless the environment variable is set. The README now describes the current authoring model, theme/component responsibilities, shared layout, location components, and schema-driven editing flow.

## Validation
- `npx vitest run tests/build-output.test.ts`
- `npx vitest run tests/readme-components.test.ts tests/redesign-prompt-docs.test.ts`
- `npm run lint:ts`

## Note
A full `npm test` currently has unrelated pre-existing failures around component class-string expectations and one Baird theme font expectation.