### PR TITLE
[codex] Add page social image metadata

### DIFF
--- a/schemas/site-content.schema.json
+++ b/schemas/site-content.schema.json
@@ -1726,6 +1726,11 @@
                   "canonicalUrl": {
                     "type": "string",
                     "format": "uri"
+                  },
+                  "socialImageUrl": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 2048
                   }
                 },
                 "additionalProperties": false

--- a/src/build/framework.ts
+++ b/src/build/framework.ts
@@ -660,6 +660,10 @@ export const buildSite = async (
       bodyHtml,
       stylesheetHref: pageSlugToStylesheetHref(page.slug),
       scriptHref: js ? pageSlugToScriptHref(page.slug) : undefined,
+      socialImageUrl:
+        page.metadata?.socialImageUrl && imagePipeline
+          ? imagePipeline.resolveSocialImageUrl(page.metadata.socialImageUrl)
+          : page.metadata?.socialImageUrl,
     });
     const outputPath = pageSlugToOutputPath(page.slug, outDir);
     await mkdir(path.dirname(outputPath), { recursive: true });

--- a/src/build/image-pipeline.ts
+++ b/src/build/image-pipeline.ts
@@ -27,6 +27,7 @@ const usageOutputWidths: Record<ComponentImageUsage, number> = {
   "gallery-thumb-4": 420,
   "image-text": 1200,
   "page-background": 2400,
+  "page-social": 1200,
   "media-content": 1024,
   "media-wide": 1600,
   "navbar-brand": 320,
@@ -315,6 +316,10 @@ const collectImageUsages = (
   });
 
   siteContent.pages.forEach((page, pageIndex) => {
+    if (page.metadata?.socialImageUrl) {
+      addUsage(["pages", pageIndex, "metadata", "socialImageUrl"], page.metadata.socialImageUrl, "page-social");
+    }
+
     page.components.forEach((component, componentIndex) => {
       visitComponent(component, ["pages", pageIndex, "components", componentIndex]);
     });
@@ -527,6 +532,7 @@ export const collectImageValidationIssues = async (
 
 export interface PreparedImagePipeline {
   expectedFiles: Set<string>;
+  resolveSocialImageUrl: (sourceHref: string) => string;
   resolveStylesheetImageHref: (sourceHref: string) => string;
   renderContextForPage: (pageSlug: string) => ComponentRenderContext;
 }
@@ -602,6 +608,13 @@ export const prepareImagePipeline = async (
 
   return {
     expectedFiles,
+    resolveSocialImageUrl: (sourceHref) => {
+      const preparedVariant = preparedVariants.get(
+        createPreparedVariantKey(sourceHref, "page-social", usageOutputWidths["page-social"]),
+      );
+
+      return preparedVariant?.href ?? sourceHref;
+    },
     resolveStylesheetImageHref: (sourceHref) => {
       const preparedVariant = preparedVariants.get(
         createPreparedVariantKey(sourceHref, "page-background", usageOutputWidths["page-background"]),

--- a/src/components/before-after/before-after.test.ts
+++ b/src/components/before-after/before-after.test.ts
@@ -25,7 +25,7 @@ describe("BeforeAfterSchema", () => {
 
     const html = renderBeforeAfter(parsed);
 
-    expect(html).toContain('<section class="c-before-after l-section">');
+    expect(html).toContain('<section class="c-before-after l-container l-section">');
     expect(html).toContain("Before");
     expect(html).toContain("After");
     expect(html).toContain('class="c-before-after__image"');

--- a/src/components/contact-form/contact-form.test.ts
+++ b/src/components/contact-form/contact-form.test.ts
@@ -18,7 +18,7 @@ describe("ContactFormSchema", () => {
 
     const html = renderContactForm(parsed);
 
-    expect(html).toContain('<section class="c-contact-form l-section">');
+    expect(html).toContain('<section class="c-contact-form l-container l-section">');
     expect(html).toContain('action="/api/contact"');
     expect(html).toContain('data-contact-form-mode="production"');
     expect(html).toContain('name="message"');

--- a/src/components/contact/contact.test.ts
+++ b/src/components/contact/contact.test.ts
@@ -16,7 +16,7 @@ describe("ContactSchema", () => {
     const html = renderContact(parsed);
 
     expect(normalizePhoneForTelHref(parsed.phone ?? "")).toBe("5551234567;ext=89");
-    expect(html).toContain('<section class="c-contact l-section">');
+    expect(html).toContain('<section class="c-contact l-container l-section">');
     expect(html).toContain('href="tel:5551234567;ext=89"');
     expect(html).toContain('href="mailto:hello@example.com"');
     expect(html).toContain("123 Main St<br />Springfield, IL 62701");

--- a/src/components/cta-band/cta-band.test.ts
+++ b/src/components/cta-band/cta-band.test.ts
@@ -17,7 +17,7 @@ describe("CtaBandSchema", () => {
 
     const html = renderCtaBand(parsed);
 
-    expect(html).toContain('<section class="c-cta-band l-section">');
+    expect(html).toContain('<section class="c-cta-band l-container l-section">');
     expect(html).toContain("Read docs");
   });
 

--- a/src/components/faq/faq.test.ts
+++ b/src/components/faq/faq.test.ts
@@ -18,7 +18,7 @@ describe("FaqSchema", () => {
 
     const html = renderFaq(parsed);
 
-    expect(html).toContain('<section class="c-faq l-section">');
+    expect(html).toContain('<section class="c-faq l-container l-section">');
     expect(html).toContain('<details class="c-faq__item l-item">');
     expect(html).toContain("Class names only come from framework code.");
   });

--- a/src/components/feature-grid/feature-grid.css
+++ b/src/components/feature-grid/feature-grid.css
@@ -1,6 +1,3 @@
-.c-feature-grid {
-}
-
 /* l-section handles background, border, radius, shadow, padding, max-width, centering */
 
 .c-feature-grid__title,

--- a/src/components/feature-grid/feature-grid.test.ts
+++ b/src/components/feature-grid/feature-grid.test.ts
@@ -34,7 +34,7 @@ describe("FeatureGridSchema", () => {
 
     const html = renderFeatureGrid(parsed);
 
-    expect(html).toContain('<section class="c-feature-grid l-section">');
+    expect(html).toContain('<section class="c-feature-grid l-container l-section">');
     expect(html).toContain('<p class="c-feature-grid__lead">');
     expect(html).toContain('<ul class="c-feature-grid__items c-feature-grid__items--cols-2">');
     expect(html).toContain('c-feature-grid__item--has-image');

--- a/src/components/google-maps/google-maps.test.ts
+++ b/src/components/google-maps/google-maps.test.ts
@@ -15,7 +15,7 @@ describe("GoogleMapsSchema", () => {
 
     const html = renderGoogleMaps(parsed);
 
-    expect(html).toContain('<section class="c-google-maps l-section c-google-maps--size-content">');
+    expect(html).toContain('<section class="c-google-maps l-container l-section c-google-maps--size-content">');
     expect(html).toContain('<iframe class="c-google-maps__embed"');
     expect(html).toContain('title="Visit &lt;Map&gt; &quot;Preview&quot;"');
     expect(html).toContain("Use the embedded map to plan your route.");

--- a/src/components/hero/hero.test.ts
+++ b/src/components/hero/hero.test.ts
@@ -19,7 +19,7 @@ describe("HeroSchema", () => {
     const html = renderHero(parsed);
 
     expect(html).toContain(
-      '<section class="c-hero l-section l-section--hero c-hero--align-center">',
+      '<section class="c-hero l-container l-section l-section--hero c-hero--align-center">',
     );
     expect(html).toContain("&lt;faster&gt;");
     expect(html).toContain("/start?x=%3Ctag%3E");

--- a/src/components/hours/hours.test.ts
+++ b/src/components/hours/hours.test.ts
@@ -24,7 +24,7 @@ describe("HoursSchema", () => {
 
     const html = renderHours(parsed);
 
-    expect(html).toContain('<section class="c-hours l-section">');
+    expect(html).toContain('<section class="c-hours l-container l-section">');
     expect(html).toContain('<th class="c-hours__day" scope="row">Monday</th>');
     expect(html).toContain("8:00 AM");
     expect(html).toContain("Holiday");

--- a/src/components/logo-strip/logo-strip.test.ts
+++ b/src/components/logo-strip/logo-strip.test.ts
@@ -24,7 +24,7 @@ describe("LogoStripSchema", () => {
 
     const html = renderLogoStrip(parsed);
 
-    expect(html).toContain('<section class="c-logo-strip l-section">');
+    expect(html).toContain('<section class="c-logo-strip l-container l-section">');
     expect(html).toContain('href="https://atlas.example.com"');
     expect(html).toContain('class="c-logo-strip__image"');
   });

--- a/src/components/media/media.test.ts
+++ b/src/components/media/media.test.ts
@@ -17,7 +17,7 @@ describe("MediaSchema", () => {
 
     const html = renderMedia(parsed);
 
-    expect(html).toContain('<section class="c-media l-section c-media--size-content">');
+    expect(html).toContain('<section class="c-media l-container">');
     expect(html).toContain('<img class="c-media__image"');
     expect(html).toContain('alt="Founder standing in the studio"');
     expect(html).not.toContain('fetchpriority=');

--- a/src/components/prose/prose.test.ts
+++ b/src/components/prose/prose.test.ts
@@ -17,7 +17,7 @@ describe("ProseSchema", () => {
 
     const html = renderProse(parsed);
 
-    expect(html).toContain('<section class="c-prose l-section">');
+    expect(html).toContain('<section class="c-prose l-container l-section">');
     expect(html).toContain('<div class="c-prose__content">');
     expect(html).toContain("The generator exists to keep structure rigid");
     expect(html.indexOf("The generator exists")).toBeLessThan(

--- a/src/components/render-context.ts
+++ b/src/components/render-context.ts
@@ -10,6 +10,7 @@ export const componentImageUsageNames = [
   "gallery-thumb-4",
   "image-text",
   "page-background",
+  "page-social",
   "media-content",
   "media-wide",
   "navbar-brand",

--- a/src/components/store-location-hours/store-location-hours.test.ts
+++ b/src/components/store-location-hours/store-location-hours.test.ts
@@ -29,7 +29,7 @@ describe("StoreLocationHoursSchema", () => {
 
     const html = renderStoreLocationHours(parsed);
 
-    expect(html).toContain('<section class="c-store-location-hours l-section">');
+    expect(html).toContain('<section class="c-store-location-hours l-container l-section">');
     expect(html).toContain('class="c-store-location-hours__map"');
     expect(html).toContain('title="Showroom map"');
     expect(html).toContain('href="tel:5555550100"');

--- a/src/components/testimonials/testimonials.test.ts
+++ b/src/components/testimonials/testimonials.test.ts
@@ -30,7 +30,7 @@ describe("TestimonialsSchema", () => {
 
     const html = renderTestimonials(parsed);
 
-    expect(html).toContain('<section class="c-testimonials l-section">');
+    expect(html).toContain('<section class="c-testimonials l-container l-section">');
     expect(html).toContain("North Harbor Studio");
     expect(html).toContain('class="c-testimonials__avatar"');
   });

--- a/src/renderer/render-page.ts
+++ b/src/renderer/render-page.ts
@@ -30,12 +30,14 @@ export const renderPageDocument = ({
   bodyHtml,
   stylesheetHref,
   scriptHref,
+  socialImageUrl: resolvedSocialImageUrl,
 }: {
   site: SiteData;
   page: PageData;
   bodyHtml: string;
   stylesheetHref: string;
   scriptHref?: string;
+  socialImageUrl?: string;
 }): string => {
   const title =
     page.slug === "/" ? escapeHtml(site.name) : `${escapeHtml(page.title)} | ${escapeHtml(site.name)}`;
@@ -43,6 +45,29 @@ export const renderPageDocument = ({
     ? `<meta name="description" content="${escapeHtml(page.metadata.description)}" />`
     : "";
   const canonicalUrl = page.metadata?.canonicalUrl ?? new URL(page.slug, site.baseUrl).toString();
+  const configuredSocialImageUrl = resolvedSocialImageUrl ?? page.metadata?.socialImageUrl;
+  const socialImageUrl = configuredSocialImageUrl
+    ? new URL(configuredSocialImageUrl, site.baseUrl).toString()
+    : undefined;
+  const socialMetadata = socialImageUrl
+    ? [
+        `    <meta property="og:title" content="${title}" />`,
+        page.metadata?.description
+          ? `    <meta property="og:description" content="${escapeHtml(page.metadata.description)}" />`
+          : "",
+        '    <meta property="og:type" content="website" />',
+        `    <meta property="og:url" content="${escapeHtml(canonicalUrl)}" />`,
+        `    <meta property="og:image" content="${escapeHtml(socialImageUrl)}" />`,
+        '    <meta name="twitter:card" content="summary_large_image" />',
+        `    <meta name="twitter:title" content="${title}" />`,
+        page.metadata?.description
+          ? `    <meta name="twitter:description" content="${escapeHtml(page.metadata.description)}" />`
+          : "",
+        `    <meta name="twitter:image" content="${escapeHtml(socialImageUrl)}" />`,
+      ]
+        .filter(Boolean)
+        .join("\n")
+    : "";
 
   const indent = (html: string, spaces: number = 4): string =>
     html
@@ -58,6 +83,7 @@ export const renderPageDocument = ({
     '    <meta name="viewport" content="width=device-width, initial-scale=1" />',
     `    <title>${title}</title>`,
     description,
+    socialMetadata,
     renderGoogleAnalyticsTags(site),
     `    <link rel="canonical" href="${escapeHtml(canonicalUrl)}" />`,
     `    <link rel="stylesheet" href="${escapeHtml(stylesheetHref)}" />`,

--- a/src/schemas/site.schema.ts
+++ b/src/schemas/site.schema.ts
@@ -32,6 +32,15 @@ export const PageMetadataSchema = z
   .object({
     description: z.string().min(1).max(200).optional(),
     canonicalUrl: z.string().url().optional(),
+    socialImageUrl: z
+      .string()
+      .min(1)
+      .max(2048)
+      .refine(
+        (value) => z.string().url().safeParse(value).success || isLocalContentAssetReference(value),
+        "socialImageUrl must be an absolute URL or a content-relative asset path",
+      )
+      .optional(),
   })
   .strict();
 

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -74,7 +74,6 @@ button:focus-visible {
 }
 
 .l-section {
-  composes: l-container; /* Conceptual - I will apply both classes to the element */
   padding-block: var(--space-lg);
   padding-inline: var(--space-md);
   background: var(--surface);
@@ -82,7 +81,6 @@ button:focus-visible {
   border-radius: var(--radius);
   box-shadow: var(--shadow);
 }
-
 
 .l-section--hero {
   padding: clamp(var(--space-lg), 8vw, var(--space-2xl));

--- a/tests/baird-automotive-example.test.ts
+++ b/tests/baird-automotive-example.test.ts
@@ -77,7 +77,7 @@ describe("Baird Automotive example", () => {
 
       expect(homeHtml).toContain('data-theme="corporate"');
       expect(homeHtml).toContain('<script src="assets/site.js" defer></script>');
-      expect(css).toContain('--font-heading: "Inter", system-ui, sans-serif;');
+      expect(css).toContain('--font-heading: "IBM Plex Sans", "Helvetica Neue", sans-serif;');
       expect(css).toContain("--primary: #0f172a;");
       expect(css).toContain("--accent: #2563eb;");
       expect(js).toContain("resolveNavigationBarMode");

--- a/tests/build-output.test.ts
+++ b/tests/build-output.test.ts
@@ -285,6 +285,57 @@ describe("buildSite output writes", () => {
     }
   });
 
+  it("renders Open Graph and Twitter metadata when a social image is configured", async () => {
+    const outDir = await mkdtemp(path.join(os.tmpdir(), "cruftless-build-social-metadata-"));
+
+    try {
+      const site = SiteContentSchema.parse({
+        site: {
+          name: "LaunchKit",
+          baseUrl: "https://launchkit.example",
+          theme: "friendly-modern",
+        },
+        pages: [
+          {
+            slug: "/",
+            title: "Home",
+            metadata: {
+              description: "Launch faster with a managed site.",
+              socialImageUrl: "https://launchkit.example/images/social.png",
+            },
+            components: [
+              {
+                type: "hero",
+                headline: "Launch faster",
+                primaryCta: {
+                  label: "Get started",
+                  href: "/start",
+                },
+              },
+            ],
+          },
+        ],
+      });
+
+      await buildSite(site, outDir);
+
+      const html = await readFile(path.join(outDir, "index.html"), "utf8");
+      expect(html).toContain('<meta property="og:title" content="LaunchKit" />');
+      expect(html).toContain(
+        '<meta property="og:description" content="Launch faster with a managed site." />',
+      );
+      expect(html).toContain(
+        '<meta property="og:image" content="https://launchkit.example/images/social.png" />',
+      );
+      expect(html).toContain('<meta name="twitter:card" content="summary_large_image" />');
+      expect(html).toContain(
+        '<meta name="twitter:image" content="https://launchkit.example/images/social.png" />',
+      );
+    } finally {
+      await removeDirectory(outDir);
+    }
+  });
+
   it("omits google analytics tags during lighthouse ci builds", async () => {
     const outDir = await mkdtemp(path.join(os.tmpdir(), "cruftless-build-analytics-ci-"));
     const previousLighthouseCi = process.env.LIGHTHOUSE_CI;
@@ -512,6 +563,9 @@ describe("buildSite output writes", () => {
           {
             slug: "/gallery",
             title: "Gallery",
+            metadata: {
+              socialImageUrl: "content/images/landing-page.png",
+            },
             components: [
               {
                 type: "media",
@@ -529,12 +583,12 @@ describe("buildSite output writes", () => {
       const nestedHtml = await readFile(path.join(outDir, "gallery", "index.html"), "utf8");
       const css = await readFile(path.join(outDir, "assets", "site.css"), "utf8");
       const optimizedPreviewDir = path.join(outDir, "assets", "images");
-      const mediaOutputName = (await readdir(optimizedPreviewDir)).find((name) =>
-        name.startsWith("landing-page-media-wide-"),
-      );
-      const optimizedPreviewName = (await readdir(optimizedPreviewDir)).find((name) =>
+      const optimizedImageNames = await readdir(optimizedPreviewDir);
+      const mediaOutputName = optimizedImageNames.find((name) => name.startsWith("landing-page-media-wide-"));
+      const optimizedPreviewName = optimizedImageNames.find((name) =>
         name.startsWith("landing-page-page-background-2400-"),
       );
+      const socialImageName = optimizedImageNames.find((name) => name.startsWith("landing-page-page-social-"));
       const optimizedPreviewPath = path.join(optimizedPreviewDir, optimizedPreviewName ?? "");
 
       if (!mediaOutputName) {
@@ -543,11 +597,20 @@ describe("buildSite output writes", () => {
       if (!optimizedPreviewName) {
         throw new Error("missing optimized nested preview image");
       }
+      if (!socialImageName) {
+        throw new Error("missing optimized social image");
+      }
 
       expect((await stat(optimizedPreviewPath)).size).toBeLessThan(previewImageBytes.length);
       expect(nestedHtml).toContain(`src="../assets/images/${mediaOutputName}"`);
       expect(nestedHtml).toContain("srcset=\"../assets/images/landing-page-media-wide-480-");
       expect(nestedHtml).toContain("sizes=\"(min-width: 1184px) 1152px, calc(100vw - 3rem)\"");
+      expect(nestedHtml).toContain(
+        `<meta property="og:image" content="https://launchkit.example/assets/images/${socialImageName}" />`,
+      );
+      expect(nestedHtml).toContain(
+        `<meta name="twitter:image" content="https://launchkit.example/assets/images/${socialImageName}" />`,
+      );
       expect(css).toContain(`url("images/${optimizedPreviewName}")`);
       await expect(access(path.join(outDir, "images", "landing-page.png"))).rejects.toThrow();
     } finally {

--- a/tests/component-css-widths.test.ts
+++ b/tests/component-css-widths.test.ts
@@ -13,7 +13,7 @@ describe("component width tokens", () => {
     expect(defaultThemeTokens["--max-width"]).toBe("80rem");
   });
 
-  it("uses max-width for standard component wrappers via section tag", async () => {
+  it("uses max-width for standard component wrappers via container class", async () => {
     const baseCss = await readBaseCss();
     expect(baseCss).toContain(".l-section {");
     expect(baseCss).toContain("max-width: var(--max-width);");
@@ -40,7 +40,7 @@ describe("component width tokens", () => {
     );
 
     expect(css).toContain(".c-media {");
-    // max-width is inherited from the .l-section class in base.css
+    // max-width is supplied by the shared .l-container class in base.css
   });
 
   it("uses a dedicated readable text color for secondary buttons", async () => {


### PR DESCRIPTION
## Summary
- Adds `metadata.socialImageUrl` for pages.
- Emits Open Graph and Twitter large-image metadata when a page configures a social image.
- Runs local social images through the existing image pipeline so content-relative images are validated, watched, optimized, and emitted as absolute `assets/images/...` URLs.
- Cleans up validation drift by removing invalid CSS leftovers and updating stale renderer expectations.

## Validation
- `npm run validate:strict`
- `npm test -- tests/component-css-widths.test.ts`