### PR TITLE
[codex] Fix image-text mobile overflow

### DIFF
--- a/src/components/image-text/image-text.css
+++ b/src/components/image-text/image-text.css
@@ -17,6 +17,7 @@
 .c-image-text__copy,
 .c-image-text__content,
 .c-image-text__media {
+  min-width: 0;
   display: grid;
   gap: var(--space-md);
 }
@@ -61,6 +62,7 @@
 .c-image-text__image {
   display: block;
   width: 100%;
+  max-width: 100%;
   height: auto;
   border-radius: var(--radius);
   box-shadow: var(--shadow);

--- a/tests/image-rich-components.browser.ts
+++ b/tests/image-rich-components.browser.ts
@@ -147,7 +147,10 @@ const runBrowserRegression = async (): Promise<void> => {
       });
 
       const mobileMetrics = await mobilePage.evaluate(() => {
+        const documentElement = document.documentElement;
         const imageTextInner = document.querySelector(".c-image-text__inner");
+        const imageTextMedia = document.querySelector(".c-image-text__media");
+        const imageTextImage = document.querySelector(".c-image-text__image");
         const beforeAfterItems = Array.from(document.querySelectorAll(".c-before-after__item"));
         const galleryItems = Array.from(document.querySelectorAll(".c-gallery__item"));
         const testimonialItems = Array.from(document.querySelectorAll(".c-testimonials__item"));
@@ -156,9 +159,15 @@ const runBrowserRegression = async (): Promise<void> => {
           throw new Error("Expected image-text section to be present.");
         }
 
+        if (!(imageTextMedia instanceof HTMLElement) || !(imageTextImage instanceof HTMLElement)) {
+          throw new Error("Expected image-text media and image to be present.");
+        }
+
         const beforeAfterFirstTop = beforeAfterItems[0]?.getBoundingClientRect().top;
         const galleryFirstTop = galleryItems[0]?.getBoundingClientRect().top;
         const testimonialFirstTop = testimonialItems[0]?.getBoundingClientRect().top;
+        const mediaRect = imageTextMedia.getBoundingClientRect();
+        const imageRect = imageTextImage.getBoundingClientRect();
 
         if (
           beforeAfterFirstTop === undefined ||
@@ -169,6 +178,8 @@ const runBrowserRegression = async (): Promise<void> => {
         }
 
         return {
+          documentOverflow: documentElement.scrollWidth - documentElement.clientWidth,
+          imageFitsMedia: imageRect.width <= mediaRect.width + 1,
           imageTextColumns: getComputedStyle(imageTextInner).gridTemplateColumns.split(" ").length,
           beforeAfterRowCount: beforeAfterItems.filter(
             (item) => Math.abs(item.getBoundingClientRect().top - beforeAfterFirstTop) < 1,
@@ -182,6 +193,8 @@ const runBrowserRegression = async (): Promise<void> => {
         };
       });
 
+      assert.ok(mobileMetrics.documentOverflow <= 1);
+      assert.equal(mobileMetrics.imageFitsMedia, true);
       assert.equal(mobileMetrics.imageTextColumns, 1);
       assert.equal(mobileMetrics.beforeAfterRowCount, 1);
       assert.equal(mobileMetrics.galleryRowCount, 1);


### PR DESCRIPTION
## Summary
- Allow image-text grid items to shrink below intrinsic image width on mobile.
- Add an explicit `max-width: 100%` guard to image-text images.
- Extend the image-rich browser regression to assert no mobile document overflow and that the image fits its media box.

## Root Cause
The generated `width` attribute can contribute to the image's intrinsic/min-content size. Without `min-width: 0` on the grid item, the media column can force the page wider than the mobile viewport even though the image has `width: 100%`.

## Validation
- `npm run lint:css`
- `npm run lint:ts`
- `npx tsx tests/image-rich-components.browser.ts`
- Rebuilt `F:\Refreshes\collinscooling-com` with `npm run build:site`
- Local 430px browser measurement showed `scrollWidth: 430`, `clientWidth: 430`, `overflow: 0`