### PR TITLE
Add schema-bound site editor with media picker and inline validation

### DIFF
--- a/src/editor-dsl/editor-for.ts
+++ b/src/editor-dsl/editor-for.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import type {
   CheckboxFieldDef,
   FieldDef,
+  MediaFieldDef,
   NumberFieldDef,
   ObjectFieldDef,
   ObjectListFieldDef,
@@ -45,6 +46,8 @@ export type EditorFor<
   readonly<TKey extends AllKeys<TSchema>>(key: TKey): ReadonlyFieldDef<TKey>;
 
   text<TKey extends StringKeys<TSchema>>(key: TKey, label: string): TextFieldDef<TKey>;
+
+  media<TKey extends StringKeys<TSchema>>(key: TKey, label: string): MediaFieldDef<TKey>;
 
   textarea<TKey extends StringKeys<TSchema>>(key: TKey, label: string): TextAreaFieldDef<TKey>;
 
@@ -113,6 +116,15 @@ export function editorFor<
     text(key, label) {
       return {
         kind: "text",
+        key,
+        label,
+        ...optionalFlag(schema, key),
+      };
+    },
+
+    media(key, label) {
+      return {
+        kind: "media",
         key,
         label,
         ...optionalFlag(schema, key),

--- a/src/editor-dsl/field-defs.ts
+++ b/src/editor-dsl/field-defs.ts
@@ -10,6 +10,13 @@ export type TextFieldDef<TKey extends string> = {
   optional?: boolean;
 };
 
+export type MediaFieldDef<TKey extends string> = {
+  kind: "media";
+  key: TKey;
+  label: string;
+  optional?: boolean;
+};
+
 export type TextAreaFieldDef<TKey extends string> = {
   kind: "textarea";
   key: TKey;
@@ -79,6 +86,7 @@ export type ObjectListFieldDef<TKey extends string> = {
 export type FieldDef<TKey extends string> =
   | ReadonlyFieldDef<TKey>
   | TextFieldDef<TKey>
+  | MediaFieldDef<TKey>
   | TextAreaFieldDef<TKey>
   | NumberFieldDef<TKey>
   | CheckboxFieldDef<TKey>

--- a/src/editor-dsl/index.ts
+++ b/src/editor-dsl/index.ts
@@ -3,6 +3,7 @@ export { defineEditorRegistry, type EditorRegistryForUnion } from "./registry.js
 export type {
   CheckboxFieldDef,
   FieldDef,
+  MediaFieldDef,
   NumberFieldDef,
   ObjectFieldDef,
   ObjectListFieldDef,

--- a/src/editor/site-editor-server.ts
+++ b/src/editor/site-editor-server.ts
@@ -15,6 +15,11 @@ export interface SiteEditorServerOptions {
   port?: number;
 }
 
+export interface EditorValidationIssue {
+  message: string;
+  path: (string | number)[];
+}
+
 export interface EditableFileSummary {
   name: string;
   path: string;
@@ -39,6 +44,19 @@ export interface EditorFileBrowserListing {
   selectedFile: string;
 }
 
+export interface EditableMediaFile {
+  href: string;
+  kind: "audio" | "image" | "video";
+  path: string;
+  relativePath: string;
+}
+
+export interface EditorMediaBrowserListing {
+  contentRoot: string;
+  directory: string;
+  files: EditableMediaFile[];
+}
+
 export interface SiteEditorServer {
   close: () => Promise<void>;
   contentRoot: string;
@@ -51,6 +69,7 @@ class EditorHttpError extends Error {
   constructor(
     readonly statusCode: number,
     message: string,
+    readonly issues?: readonly EditorValidationIssue[],
   ) {
     super(message);
     this.name = "EditorHttpError";
@@ -64,6 +83,7 @@ const editorFilesPath = "/__editor/files";
 const editorConfigPath = "/__editor/config";
 const editorOpenDirectoryPath = "/__editor/open-directory";
 const editorOpenPath = "/__editor/open";
+const editorMediaPath = "/__editor/media";
 const editorSavePath = "/__editor/save";
 const previewPagePath = "/__preview/page";
 const previewStylesheetPath = "/__preview/assets/site.css";
@@ -74,6 +94,19 @@ const previewSavePath = "/__preview/save";
 const contentAssetPrefix = "/content/";
 const contentDirectoryName = "content";
 const maxContentRootSearchDepth = 3;
+const mediaFileExtensions = new Map<string, "audio" | "image" | "video">([
+  [".avif", "image"],
+  [".gif", "image"],
+  [".jpeg", "image"],
+  [".jpg", "image"],
+  [".mp3", "audio"],
+  [".mp4", "video"],
+  [".png", "image"],
+  [".svg", "image"],
+  [".wav", "audio"],
+  [".webm", "video"],
+  [".webp", "image"],
+]);
 const skippedContentSearchDirectories = new Set([
   ".git",
   ".next",
@@ -145,11 +178,21 @@ const formatSiteContentIssues = (issues: readonly ZodIssue[]): string =>
     })
     .join("; ");
 
+const serializeValidationIssues = (issues: readonly ZodIssue[]): EditorValidationIssue[] =>
+  issues.map((issue) => ({
+    message: issue.message,
+    path: [...issue.path],
+  }));
+
 const parseSiteContent = (value: unknown): SiteContentData => {
   const parsed = SiteContentSchema.safeParse(value);
 
   if (!parsed.success) {
-    throw new EditorHttpError(400, `Invalid site content: ${formatSiteContentIssues(parsed.error.issues)}`);
+    throw new EditorHttpError(
+      400,
+      `Invalid site content: ${formatSiteContentIssues(parsed.error.issues)}`,
+      serializeValidationIssues(parsed.error.issues),
+    );
   }
 
   return parsed.data;
@@ -259,6 +302,20 @@ const resolveBrowserFilePath = (
   return path.resolve(browseDirectory, normalized);
 };
 
+const resolveDirectoryWithinRoot = (rootPath: string, requestedPath: string): string => {
+  const resolvedRootPath = path.resolve(rootPath);
+  const resolvedRequestedPath = path.resolve(requestedPath);
+  const rootWithSeparator = resolvedRootPath.endsWith(path.sep)
+    ? resolvedRootPath
+    : `${resolvedRootPath}${path.sep}`;
+
+  if (resolvedRequestedPath !== resolvedRootPath && !resolvedRequestedPath.startsWith(rootWithSeparator)) {
+    throw new EditorHttpError(400, "Directory is outside the editor root.");
+  }
+
+  return resolvedRequestedPath;
+};
+
 const collectJsonFiles = async (directoryPath: string): Promise<string[]> => {
   const entries = await readdir(directoryPath, { withFileTypes: true });
   const nestedFiles = await Promise.all(
@@ -270,6 +327,25 @@ const collectJsonFiles = async (directoryPath: string): Promise<string[]> => {
       }
 
       return entry.isFile() && entry.name.endsWith(".json") ? [entryPath] : [];
+    }),
+  );
+
+  return nestedFiles.flat().sort();
+};
+
+const collectMediaFiles = async (directoryPath: string): Promise<string[]> => {
+  const entries = await readdir(directoryPath, { withFileTypes: true });
+  const nestedFiles = await Promise.all(
+    entries.map(async (entry) => {
+      const entryPath = path.join(directoryPath, entry.name);
+
+      if (entry.isDirectory()) {
+        return collectMediaFiles(entryPath);
+      }
+
+      return entry.isFile() && mediaFileExtensions.has(path.extname(entry.name).toLowerCase())
+        ? [entryPath]
+        : [];
     }),
   );
 
@@ -379,6 +455,53 @@ const findNestedContentDirectory = async (
   }
 
   return undefined;
+};
+
+const findUniqueNestedContentDirectory = async (
+  directoryPath: string,
+  maxDepth: number = maxContentRootSearchDepth,
+): Promise<string | undefined> => {
+  const resolvedPath = path.resolve(directoryPath);
+  const directContentDirectory = await findDirectContentDirectory(resolvedPath);
+
+  if (directContentDirectory) {
+    return directContentDirectory;
+  }
+
+  if (maxDepth <= 0) {
+    return undefined;
+  }
+
+  let entries;
+
+  try {
+    entries = await readdir(resolvedPath, { withFileTypes: true });
+  } catch {
+    return undefined;
+  }
+
+  const directories = entries
+    .filter((entry) => entry.isDirectory() && isContentSearchableDirectory(entry.name))
+    .map((entry) => path.join(resolvedPath, entry.name))
+    .sort((left, right) => left.localeCompare(right));
+
+  let candidate: string | undefined;
+
+  for (const childDirectory of directories) {
+    const nestedContentDirectory = await findUniqueNestedContentDirectory(childDirectory, maxDepth - 1);
+
+    if (!nestedContentDirectory) {
+      continue;
+    }
+
+    if (candidate && candidate !== nestedContentDirectory) {
+      return undefined;
+    }
+
+    candidate = nestedContentDirectory;
+  }
+
+  return candidate;
 };
 
 const isInsideContentRoot = (contentRoot: string, directoryPath: string): boolean => {
@@ -696,15 +819,15 @@ export const createSiteEditorServer = async (
       : (await Promise.all(
         candidateDirectories.map(async (entry) => ({
           ...entry,
-          snapToContent: true,
           targetPath: await findNestedContentDirectory(entry.path),
+          uniqueTargetPath: await findUniqueNestedContentDirectory(entry.path),
         })),
       ))
         .filter((entry) => entry.targetPath)
-        .map(({ name, path: directoryPath, snapToContent }) => ({
+        .map(({ name, path: directoryPath, uniqueTargetPath }) => ({
           name,
           path: directoryPath,
-          snapToContent,
+          snapToContent: Boolean(uniqueTargetPath),
         }))
         .sort((left, right) => left.name.localeCompare(right.name));
     const files = await Promise.all(
@@ -721,6 +844,30 @@ export const createSiteEditorServer = async (
       files: files.sort((left, right) => left.name.localeCompare(right.name)),
       parentDirectory: parentDirectory === browseDirectory ? undefined : parentDirectory,
       selectedFile: selectedFileAbsolutePath(),
+    };
+  };
+
+  const listMediaDirectory = async (requestedDirectory?: string): Promise<EditorMediaBrowserListing> => {
+    const directoryPath = requestedDirectory
+      ? resolveDirectoryWithinRoot(contentRoot, requestedDirectory)
+      : browseDirectory;
+    const resolvedDirectoryPath = isInsideContentRoot(contentRoot, directoryPath) ? directoryPath : contentRoot;
+    const mediaFiles = await collectMediaFiles(resolvedDirectoryPath);
+
+    return {
+      contentRoot,
+      directory: resolvedDirectoryPath,
+      files: mediaFiles.map((filePath) => {
+        const extension = path.extname(filePath).toLowerCase();
+        const relativePath = path.relative(contentRoot, filePath).replaceAll("\\", "/");
+
+        return {
+          href: `${contentAssetPrefix}${relativePath}`,
+          kind: mediaFileExtensions.get(extension) ?? "image",
+          path: filePath,
+          relativePath,
+        };
+      }),
     };
   };
 
@@ -765,6 +912,11 @@ export const createSiteEditorServer = async (
 
       if (request.method === "GET" && requestUrl.pathname === editorFilesPath) {
         sendJson(response, 200, await listBrowserDirectory());
+        return;
+      }
+
+      if (request.method === "GET" && requestUrl.pathname === editorMediaPath) {
+        sendJson(response, 200, await listMediaDirectory(requestUrl.searchParams.get("directory") ?? undefined));
         return;
       }
 
@@ -883,7 +1035,10 @@ export const createSiteEditorServer = async (
       send(response, 404, "text/plain; charset=utf-8", "Not found");
     } catch (error) {
       if (error instanceof EditorHttpError) {
-        sendJson(response, error.statusCode, { error: error.message });
+        sendJson(response, error.statusCode, {
+          error: error.message,
+          issues: error.issues,
+        });
         return;
       }
 

--- a/src/editor/site-editor-server.ts
+++ b/src/editor/site-editor-server.ts
@@ -27,6 +27,7 @@ export interface EditableFileSummary {
 export interface EditableDirectorySummary {
   name: string;
   path: string;
+  snapToContent: boolean;
 }
 
 export interface EditorFileBrowserListing {
@@ -71,6 +72,17 @@ const previewDraftPath = "/__preview/draft";
 const previewEventsPath = "/__preview/events";
 const previewSavePath = "/__preview/save";
 const contentAssetPrefix = "/content/";
+const contentDirectoryName = "content";
+const maxContentRootSearchDepth = 3;
+const skippedContentSearchDirectories = new Set([
+  ".git",
+  ".next",
+  ".turbo",
+  "coverage",
+  "dist",
+  "node_modules",
+  "reports",
+]);
 
 const send = (
   response: ServerResponse,
@@ -303,7 +315,86 @@ const summarizeEditableFile = async (
   }
 };
 
-const resolveBrowseDirectory = async (directoryPath: string): Promise<string> => {
+const isContentSearchableDirectory = (directoryName: string): boolean =>
+  !directoryName.startsWith(".")
+  && !skippedContentSearchDirectories.has(directoryName.toLowerCase());
+
+const findDirectContentDirectory = async (directoryPath: string): Promise<string | undefined> => {
+  const resolvedPath = path.resolve(directoryPath);
+
+  if (path.basename(resolvedPath).toLowerCase() === contentDirectoryName) {
+    return resolvedPath;
+  }
+
+  const candidatePath = path.join(resolvedPath, contentDirectoryName);
+
+  try {
+    const candidateStat = await stat(candidatePath);
+
+    if (candidateStat.isDirectory()) {
+      return candidatePath;
+    }
+  } catch {
+    return undefined;
+  }
+
+  return undefined;
+};
+
+const findNestedContentDirectory = async (
+  directoryPath: string,
+  maxDepth: number = maxContentRootSearchDepth,
+): Promise<string | undefined> => {
+  const resolvedPath = path.resolve(directoryPath);
+
+  const directContentDirectory = await findDirectContentDirectory(resolvedPath);
+
+  if (directContentDirectory) {
+    return directContentDirectory;
+  }
+
+  if (maxDepth <= 0) {
+    return undefined;
+  }
+
+  let entries;
+
+  try {
+    entries = await readdir(resolvedPath, { withFileTypes: true });
+  } catch {
+    return undefined;
+  }
+
+  const directories = entries
+    .filter((entry) => entry.isDirectory() && isContentSearchableDirectory(entry.name))
+    .map((entry) => path.join(resolvedPath, entry.name))
+    .sort((left, right) => left.localeCompare(right));
+
+  for (const childDirectory of directories) {
+    const nestedContentDirectory = await findNestedContentDirectory(childDirectory, maxDepth - 1);
+
+    if (nestedContentDirectory) {
+      return nestedContentDirectory;
+    }
+  }
+
+  return undefined;
+};
+
+const isInsideContentRoot = (contentRoot: string, directoryPath: string): boolean => {
+  const resolvedContentRoot = path.resolve(contentRoot);
+  const resolvedDirectoryPath = path.resolve(directoryPath);
+  const contentRootPrefix = resolvedContentRoot.endsWith(path.sep)
+    ? resolvedContentRoot
+    : `${resolvedContentRoot}${path.sep}`;
+
+  return resolvedDirectoryPath === resolvedContentRoot || resolvedDirectoryPath.startsWith(contentRootPrefix);
+};
+
+const resolveBrowseDirectory = async (
+  directoryPath: string,
+  options?: { snapToContent?: "none" | "direct" | "nested" },
+): Promise<string> => {
   if (!directoryPath.trim()) {
     throw new EditorHttpError(400, "Browser path is required.");
   }
@@ -315,7 +406,15 @@ const resolveBrowseDirectory = async (directoryPath: string): Promise<string> =>
     throw new EditorHttpError(400, "Browser path must be a directory.");
   }
 
-  return resolvedPath;
+  if (!options?.snapToContent || options.snapToContent === "none") {
+    return resolvedPath;
+  }
+
+  if (options.snapToContent === "direct") {
+    return (await findDirectContentDirectory(resolvedPath)) ?? resolvedPath;
+  }
+
+  return (await findNestedContentDirectory(resolvedPath)) ?? resolvedPath;
 };
 
 const renderEditorHtml = (): string => `<!doctype html>
@@ -580,13 +679,34 @@ export const createSiteEditorServer = async (
 
   const listBrowserDirectory = async (): Promise<EditorFileBrowserListing> => {
     const entries = await readdir(browseDirectory, { withFileTypes: true });
-    const directories = entries
+    const inContentTree = isInsideContentRoot(contentRoot, browseDirectory);
+    const candidateDirectories = entries
       .filter((entry) => entry.isDirectory())
       .map((entry) => ({
         name: entry.name,
         path: path.join(browseDirectory, entry.name),
-      }))
-      .sort((left, right) => left.name.localeCompare(right.name));
+      }));
+    const directories = inContentTree
+      ? candidateDirectories
+        .map((entry) => ({
+          ...entry,
+          snapToContent: false,
+        }))
+        .sort((left, right) => left.name.localeCompare(right.name))
+      : (await Promise.all(
+        candidateDirectories.map(async (entry) => ({
+          ...entry,
+          snapToContent: true,
+          targetPath: await findNestedContentDirectory(entry.path),
+        })),
+      ))
+        .filter((entry) => entry.targetPath)
+        .map(({ name, path: directoryPath, snapToContent }) => ({
+          name,
+          path: directoryPath,
+          snapToContent,
+        }))
+        .sort((left, right) => left.name.localeCompare(right.name));
     const files = await Promise.all(
       entries
         .filter((entry) => entry.isFile() && path.extname(entry.name).toLowerCase() === ".json")
@@ -654,8 +774,14 @@ export const createSiteEditorServer = async (
           typeof payload === "object" && payload !== null && "path" in payload
             ? String((payload as { path: unknown }).path)
             : "";
+        const rawSnapToContent =
+          typeof payload === "object" && payload !== null && "snapToContent" in payload
+            ? String((payload as { snapToContent: unknown }).snapToContent)
+            : "none";
+        const snapToContent =
+          rawSnapToContent === "direct" || rawSnapToContent === "nested" ? rawSnapToContent : "none";
 
-        browseDirectory = await resolveBrowseDirectory(nextDirectoryPath);
+        browseDirectory = await resolveBrowseDirectory(nextDirectoryPath, { snapToContent });
         sendJson(response, 200, await listBrowserDirectory());
         return;
       }

--- a/src/editor/site-editor-server.ts
+++ b/src/editor/site-editor-server.ts
@@ -117,6 +117,13 @@ const skippedContentSearchDirectories = new Set([
   "reports",
 ]);
 
+const toContentAssetHref = (relativePath: string): string =>
+  `${contentAssetPrefix}${relativePath
+    .split("/")
+    .filter(Boolean)
+    .map((segment) => encodeURIComponent(segment))
+    .join("/")}`;
+
 const send = (
   response: ServerResponse,
   statusCode: number,
@@ -862,7 +869,7 @@ export const createSiteEditorServer = async (
         const relativePath = path.relative(contentRoot, filePath).replaceAll("\\", "/");
 
         return {
-          href: `${contentAssetPrefix}${relativePath}`,
+          href: toContentAssetHref(relativePath),
           kind: mediaFileExtensions.get(extension) ?? "image",
           path: filePath,
           relativePath,

--- a/src/editor/static/app.css
+++ b/src/editor/static/app.css
@@ -170,6 +170,20 @@ button:focus {
   align-items: stretch;
 }
 
+.picker-summary {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.picker-summary-title {
+  overflow: hidden;
+  color: #334155;
+  font-size: 0.9rem;
+  font-weight: 650;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .folder-path {
   flex: 1 1 auto;
   min-width: 0;
@@ -210,6 +224,7 @@ button:focus {
 .hint {
   color: var(--muted);
   font-size: 0.86rem;
+  overflow-wrap: anywhere;
 }
 
 .card,
@@ -303,6 +318,17 @@ button:focus {
   gap: 0.75rem;
 }
 
+.component-add-row {
+  display: grid;
+  grid-template-columns: minmax(10rem, 1fr) auto;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.component-add-row .grow {
+  min-width: 0;
+}
+
 .list-item {
   padding: 0.75rem;
 }
@@ -341,6 +367,12 @@ button:focus {
   font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
   font-size: 0.86rem;
   line-height: 1.45;
+}
+
+@media (width <= 820px) {
+  .component-add-row {
+    grid-template-columns: 1fr;
+  }
 }
 
 .empty-state {

--- a/src/editor/static/app.css
+++ b/src/editor/static/app.css
@@ -280,6 +280,11 @@ button:focus {
   font-weight: 650;
 }
 
+.field-error {
+  color: var(--danger);
+  font-size: 0.82rem;
+}
+
 .field-inline {
   display: flex;
   gap: 0.5rem;
@@ -296,6 +301,77 @@ button:focus {
 
 .field-group + .field-group {
   margin-top: 0.75rem;
+}
+
+.media-preview-card,
+.media-picker {
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--panel-2);
+  padding: 0.65rem;
+}
+
+.media-preview-card {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.media-preview-image {
+  width: 100%;
+  max-height: 180px;
+  object-fit: contain;
+  border-radius: 4px;
+  background: #ffffff;
+}
+
+.media-picker {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.media-picker-list {
+  display: grid;
+  gap: 0.5rem;
+  max-height: 320px;
+  overflow: auto;
+}
+
+.media-picker-item {
+  display: grid;
+  grid-template-columns: 72px minmax(0, 1fr);
+  gap: 0.65rem;
+  align-items: center;
+  width: 100%;
+  text-align: left;
+}
+
+.media-picker-thumb {
+  width: 72px;
+  height: 72px;
+  border-radius: 4px;
+  object-fit: cover;
+  background: #ffffff;
+}
+
+.media-picker-thumb-placeholder {
+  display: grid;
+  place-items: center;
+  border: 1px solid var(--border);
+  color: var(--muted);
+  font-size: 0.8rem;
+  text-transform: uppercase;
+}
+
+.media-picker-meta {
+  min-width: 0;
+}
+
+.media-picker-name {
+  overflow: hidden;
+  font-size: 0.9rem;
+  font-weight: 600;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .row {

--- a/src/editor/static/app.jsx
+++ b/src/editor/static/app.jsx
@@ -34,6 +34,29 @@ const moveItem = (items, fromIndex, toIndex) => {
   return nextItems;
 };
 
+class HttpError extends Error {
+  constructor(message, issues = []) {
+    super(message);
+    this.name = "HttpError";
+    this.issues = Array.isArray(issues) ? issues : [];
+  }
+}
+
+const pathKey = (path) => JSON.stringify(path);
+
+const issuesToMap = (issues) => {
+  const map = new Map();
+
+  for (const issue of Array.isArray(issues) ? issues : []) {
+    const key = pathKey(issue.path ?? []);
+    const nextIssues = map.get(key) ?? [];
+    nextIssues.push(issue.message);
+    map.set(key, nextIssues);
+  }
+
+  return map;
+};
+
 const postJson = async (url, body) => {
   const response = await fetch(url, {
     method: "POST",
@@ -44,14 +67,17 @@ const postJson = async (url, body) => {
   if (!response.ok) {
     const text = await response.text();
     let message = text;
+    let issues = [];
 
     try {
-      message = JSON.parse(text).error ?? text;
+      const payload = JSON.parse(text);
+      message = payload.error ?? text;
+      issues = payload.issues ?? [];
     } catch {
       message = text;
     }
 
-    throw new Error(message || `${response.status} ${response.statusText}`);
+    throw new HttpError(message || `${response.status} ${response.statusText}`, issues);
   }
 
   if (response.status === 204) {
@@ -71,8 +97,155 @@ const normalizeFieldValue = (field, value) => {
   return value;
 };
 
-const FieldRenderer = ({ draft, field, path, setDraft, refreshPreview }) => {
+const imageExtensions = new Set([".avif", ".gif", ".jpeg", ".jpg", ".png", ".svg", ".webp"]);
+
+const toContentAssetHref = (value) => {
+  const trimmedValue = String(value ?? "").trim();
+
+  if (!trimmedValue) {
+    return "";
+  }
+
+  if (/^https?:\/\//iu.test(trimmedValue) || trimmedValue.startsWith("//")) {
+    return trimmedValue;
+  }
+
+  const normalizedValue = trimmedValue.replaceAll("\\", "/");
+
+  if (normalizedValue.startsWith("/content/")) {
+    return normalizedValue;
+  }
+
+  if (normalizedValue.startsWith("content/")) {
+    return `/${normalizedValue}`;
+  }
+
+  if (normalizedValue.startsWith("/")) {
+    return normalizedValue;
+  }
+
+  return `/content/${normalizedValue.replace(/^\/+/u, "")}`;
+};
+
+const isPreviewableImageHref = (value) => {
+  const href = toContentAssetHref(value);
+
+  if (!href || /^data:/iu.test(href)) {
+    return false;
+  }
+
+  const pathname = href.startsWith("http")
+    ? new URL(href).pathname
+    : href.split("?")[0] ?? href;
+  const extensionIndex = pathname.lastIndexOf(".");
+
+  if (extensionIndex < 0) {
+    return false;
+  }
+
+  return imageExtensions.has(pathname.slice(extensionIndex).toLowerCase());
+};
+
+const MediaSourceField = ({ browser, errors, field, update, value }) => {
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const [mediaFiles, setMediaFiles] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [loadError, setLoadError] = useState("");
+  const previewHref = isPreviewableImageHref(value) ? toContentAssetHref(value) : "";
+
+  const loadMediaFiles = async () => {
+    setLoading(true);
+    setLoadError("");
+
+    try {
+      const params = new URLSearchParams({ directory: browser.directory });
+      const payload = await fetch(`/__editor/media?${params.toString()}`);
+
+      if (!payload.ok) {
+        throw new Error(await payload.text());
+      }
+
+      const nextListing = await payload.json();
+      setMediaFiles(nextListing.files ?? []);
+    } catch (error) {
+      setLoadError(error instanceof Error ? error.message : String(error));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    if (!pickerOpen) {
+      return;
+    }
+
+    void loadMediaFiles();
+  }, [pickerOpen, browser.directory]);
+
+  return (
+    <div className="field">
+      <label>{fieldLabel(field)}</label>
+      <input
+        data-testid={`field-${field.key}`}
+        type="text"
+        value={value ?? ""}
+        onChange={(event) => update(event.currentTarget.value)}
+      />
+      {errors.map((error) => (
+        <div className="field-error" key={error}>{error}</div>
+      ))}
+      <div className="row">
+        <button type="button" onClick={() => setPickerOpen((open) => !open)}>
+          {pickerOpen ? "Hide media" : "Pick media"}
+        </button>
+      </div>
+      {previewHref ? (
+        <div className="media-preview-card">
+          <img alt="" className="media-preview-image" src={previewHref} />
+          <div className="hint">{previewHref}</div>
+        </div>
+      ) : null}
+      {pickerOpen ? (
+        <div className="media-picker">
+          {loading ? <div className="hint">Loading media…</div> : null}
+          {loadError ? <div className="hint">{loadError}</div> : null}
+          {!loading && !loadError && mediaFiles.length === 0 ? (
+            <div className="hint">No media files found in this folder or its subdirectories.</div>
+          ) : null}
+          {!loading && !loadError ? (
+            <div className="media-picker-list">
+              {mediaFiles.map((file) => (
+                <button
+                  key={file.path}
+                  className="media-picker-item"
+                  type="button"
+                  onClick={() => {
+                    update(file.href);
+                    setPickerOpen(false);
+                  }}
+                >
+                  {file.kind === "image" ? (
+                    <img alt="" className="media-picker-thumb" src={file.href} />
+                  ) : (
+                    <div className="media-picker-thumb media-picker-thumb-placeholder">{file.kind}</div>
+                  )}
+                  <div className="media-picker-meta">
+                    <div className="media-picker-name">{file.relativePath}</div>
+                    <div className="hint">{file.href}</div>
+                  </div>
+                </button>
+              ))}
+            </div>
+          ) : null}
+        </div>
+      ) : null}
+    </div>
+  );
+};
+
+const FieldRenderer = ({ browser, draft, field, path, setDraft, refreshPreview, validationErrors }) => {
   const value = getAtPath(draft, path);
+  const fieldErrors = validationErrors.get(pathKey(path)) ?? [];
 
   const update = (nextValue) => {
     setDraft((currentDraft) =>
@@ -83,6 +256,18 @@ const FieldRenderer = ({ draft, field, path, setDraft, refreshPreview }) => {
 
   if (field.kind === "readonly") {
     return null;
+  }
+
+  if (field.kind === "media") {
+    return (
+      <MediaSourceField
+        browser={browser}
+        errors={fieldErrors}
+        field={field}
+        update={update}
+        value={value}
+      />
+    );
   }
 
   if (field.kind === "text" || field.kind === "number") {
@@ -101,6 +286,9 @@ const FieldRenderer = ({ draft, field, path, setDraft, refreshPreview }) => {
             update(nextValue);
           }}
         />
+        {fieldErrors.map((error) => (
+          <div className="field-error" key={error}>{error}</div>
+        ))}
       </div>
     );
   }
@@ -114,20 +302,28 @@ const FieldRenderer = ({ draft, field, path, setDraft, refreshPreview }) => {
           value={value ?? ""}
           onChange={(event) => update(event.currentTarget.value)}
         />
+        {fieldErrors.map((error) => (
+          <div className="field-error" key={error}>{error}</div>
+        ))}
       </div>
     );
   }
 
   if (field.kind === "checkbox") {
     return (
-      <label className="field-inline">
-        <input
-          type="checkbox"
-          checked={Boolean(value)}
-          onChange={(event) => update(field.optional && !event.currentTarget.checked ? undefined : event.currentTarget.checked)}
-        />
-        <span>{fieldLabel(field)}</span>
-      </label>
+      <div className="field">
+        <label className="field-inline">
+          <input
+            type="checkbox"
+            checked={Boolean(value)}
+            onChange={(event) => update(field.optional && !event.currentTarget.checked ? undefined : event.currentTarget.checked)}
+          />
+          <span>{fieldLabel(field)}</span>
+        </label>
+        {fieldErrors.map((error) => (
+          <div className="field-error" key={error}>{error}</div>
+        ))}
+      </div>
     );
   }
 
@@ -151,6 +347,9 @@ const FieldRenderer = ({ draft, field, path, setDraft, refreshPreview }) => {
             );
           })}
         </select>
+        {fieldErrors.map((error) => (
+          <div className="field-error" key={error}>{error}</div>
+        ))}
       </div>
     );
   }
@@ -203,12 +402,14 @@ const FieldRenderer = ({ draft, field, path, setDraft, refreshPreview }) => {
         <div className="form-grid">
           {field.fields.map((childField) => (
             <FieldRenderer
+              browser={browser}
               key={childField.key}
               draft={draft}
               field={childField}
               path={[...path, childField.key]}
               setDraft={setDraft}
               refreshPreview={refreshPreview}
+              validationErrors={validationErrors}
             />
           ))}
         </div>
@@ -233,12 +434,14 @@ const FieldRenderer = ({ draft, field, path, setDraft, refreshPreview }) => {
           <div className="form-grid">
             {field.fields.map((childField) => (
               <FieldRenderer
+                browser={browser}
                 key={childField.key}
                 draft={draft}
                 field={childField}
                 path={[...path, childField.key]}
                 setDraft={setDraft}
                 refreshPreview={refreshPreview}
+                validationErrors={validationErrors}
               />
             ))}
           </div>
@@ -292,12 +495,14 @@ const FieldRenderer = ({ draft, field, path, setDraft, refreshPreview }) => {
               <div className="form-grid">
                 {field.fields.map((childField) => (
                   <FieldRenderer
+                    browser={browser}
                     key={childField.key}
                     draft={draft}
                     field={childField}
                     path={[...path, index, childField.key]}
                     setDraft={setDraft}
                     refreshPreview={refreshPreview}
+                    validationErrors={validationErrors}
                   />
                 ))}
               </div>
@@ -311,25 +516,35 @@ const FieldRenderer = ({ draft, field, path, setDraft, refreshPreview }) => {
   return <div className="empty-state">Unsupported field {field.kind}</div>;
 };
 
-const SectionRenderer = ({ draft, section, basePath, setDraft, refreshPreview }) => (
+const SectionRenderer = ({
+  basePath,
+  browser,
+  draft,
+  refreshPreview,
+  section,
+  setDraft,
+  validationErrors,
+}) => (
   <div className="field-group">
     <h3>{section.title}</h3>
     <div className="form-grid">
       {section.fields.map((field) => (
         <FieldRenderer
+          browser={browser}
           key={field.key}
           draft={draft}
           field={field}
           path={[...basePath, field.key]}
           setDraft={setDraft}
           refreshPreview={refreshPreview}
+          validationErrors={validationErrors}
         />
       ))}
     </div>
   </div>
 );
 
-const SiteEditor = ({ config, draft, setDraft, refreshPreview }) => {
+const SiteEditor = ({ browser, config, draft, refreshPreview, setDraft, validationErrors }) => {
   const sitePath = ["site"];
   const updateSiteField = (key, value) => {
     setDraft((currentDraft) => setAtPath(currentDraft, [...sitePath, key], value || undefined));
@@ -351,18 +566,22 @@ const SiteEditor = ({ config, draft, setDraft, refreshPreview }) => {
         <h2>Site</h2>
         <div className="form-grid">
           <FieldRenderer
+            browser={browser}
             draft={draft}
             field={{ kind: "text", key: "name", label: "Name" }}
             path={[...sitePath, "name"]}
             setDraft={setDraft}
             refreshPreview={refreshPreview}
+            validationErrors={validationErrors}
           />
           <FieldRenderer
+            browser={browser}
             draft={draft}
             field={{ kind: "text", key: "baseUrl", label: "Base URL" }}
             path={[...sitePath, "baseUrl"]}
             setDraft={setDraft}
             refreshPreview={refreshPreview}
+            validationErrors={validationErrors}
           />
           <div className="field">
             <label>Theme</label>
@@ -379,9 +598,10 @@ const SiteEditor = ({ config, draft, setDraft, refreshPreview }) => {
             </select>
           </div>
           <FieldRenderer
+            browser={browser}
             draft={draft}
             field={{
-              kind: "text",
+              kind: "media",
               key: "pageBackgroundImageUrl",
               label: "Page background image",
               optional: true,
@@ -389,8 +609,10 @@ const SiteEditor = ({ config, draft, setDraft, refreshPreview }) => {
             path={[...sitePath, "pageBackgroundImageUrl"]}
             setDraft={setDraft}
             refreshPreview={refreshPreview}
+            validationErrors={validationErrors}
           />
           <FieldRenderer
+            browser={browser}
             draft={draft}
             field={{
               kind: "text",
@@ -401,11 +623,13 @@ const SiteEditor = ({ config, draft, setDraft, refreshPreview }) => {
             path={[...sitePath, "googleAnalyticsMeasurementId"]}
             setDraft={setDraft}
             refreshPreview={refreshPreview}
+            validationErrors={validationErrors}
           />
         </div>
       </div>
       {draft.site.layout?.components ? (
         <ComponentListEditor
+          browser={browser}
           config={config}
           draft={draft}
           components={draft.site.layout.components}
@@ -414,6 +638,7 @@ const SiteEditor = ({ config, draft, setDraft, refreshPreview }) => {
           setDraft={setDraft}
           refreshPreview={refreshPreview}
           title="Shared Layout Components"
+          validationErrors={validationErrors}
         />
       ) : (
         <div className="card">
@@ -431,9 +656,11 @@ const SiteEditor = ({ config, draft, setDraft, refreshPreview }) => {
 };
 
 const PageEditor = ({
+  browser,
   draft,
   page,
   pageIndex,
+  validationErrors,
   setDraft,
   setSelectedPageIndex,
   refreshPreview,
@@ -492,28 +719,33 @@ const PageEditor = ({
       </div>
       <div className="form-grid">
         <FieldRenderer
+          browser={browser}
           draft={draft}
           field={{ kind: "text", key: "slug", label: "Slug" }}
           path={["pages", pageIndex, "slug"]}
           setDraft={setDraft}
           refreshPreview={refreshPreview}
+          validationErrors={validationErrors}
         />
         <FieldRenderer
+          browser={browser}
           draft={draft}
           field={{ kind: "text", key: "title", label: "Title" }}
           path={["pages", pageIndex, "title"]}
           setDraft={setDraft}
           refreshPreview={refreshPreview}
+          validationErrors={validationErrors}
         />
         <div className="field-group">
           <h3>Metadata</h3>
           <div className="form-grid">
             {["description", "canonicalUrl", "socialImageUrl"].map((key) => (
               <FieldRenderer
+                browser={browser}
                 key={key}
                 draft={draft}
                 field={{
-                  kind: key === "description" ? "textarea" : "text",
+                  kind: key === "description" ? "textarea" : key === "socialImageUrl" ? "media" : "text",
                   key,
                   label: key,
                   optional: true,
@@ -521,6 +753,7 @@ const PageEditor = ({
                 path={["pages", pageIndex, "metadata", key]}
                 setDraft={setDraft}
                 refreshPreview={refreshPreview}
+                validationErrors={validationErrors}
               />
             ))}
           </div>
@@ -531,6 +764,7 @@ const PageEditor = ({
 };
 
 const ComponentEditor = ({
+  browser,
   config,
   draft,
   component,
@@ -540,6 +774,7 @@ const ComponentEditor = ({
   mode,
   setDraft,
   refreshPreview,
+  validationErrors,
 }) => {
   const editor = config.componentSpecs[component.type];
 
@@ -659,12 +894,14 @@ const ComponentEditor = ({
       {editor ? (
         editor.fields.map((section) => (
           <SectionRenderer
+            browser={browser}
             key={section.title}
             draft={draft}
             section={section}
             basePath={[...componentsPath, componentIndex]}
             setDraft={setDraft}
             refreshPreview={refreshPreview}
+            validationErrors={validationErrors}
           />
         ))
       ) : (
@@ -675,6 +912,7 @@ const ComponentEditor = ({
 };
 
 const ComponentListEditor = ({
+  browser,
   config,
   draft,
   components,
@@ -683,6 +921,7 @@ const ComponentListEditor = ({
   setDraft,
   refreshPreview,
   title,
+  validationErrors,
 }) => {
   const componentTypeRef = useRef(null);
   const componentTypeOptions =
@@ -727,6 +966,7 @@ const ComponentListEditor = ({
       <div className="list-stack">
         {components.map((component, componentIndex) => (
           <ComponentEditor
+            browser={browser}
             key={`${component.type}-${componentIndex}`}
             config={config}
             draft={draft}
@@ -737,6 +977,7 @@ const ComponentListEditor = ({
             mode={mode}
             setDraft={setDraft}
             refreshPreview={refreshPreview}
+            validationErrors={validationErrors}
           />
         ))}
       </div>
@@ -745,6 +986,7 @@ const ComponentListEditor = ({
 };
 
 const PageScopeEditor = ({
+  browser,
   config,
   draft,
   page,
@@ -752,6 +994,7 @@ const PageScopeEditor = ({
   setDraft,
   setSelectedScope,
   refreshPreview,
+  validationErrors,
 }) => {
   const addPage = () => {
     const slugs = new Set(draft.pages.map((candidate) => candidate.slug));
@@ -779,9 +1022,11 @@ const PageScopeEditor = ({
   return (
     <>
       <PageEditor
+        browser={browser}
         draft={draft}
         page={page}
         pageIndex={pageIndex}
+        validationErrors={validationErrors}
         setDraft={setDraft}
         setSelectedPageIndex={(nextPageIndex) =>
           setSelectedScope({ type: "page", pageIndex: nextPageIndex })
@@ -789,6 +1034,7 @@ const PageScopeEditor = ({
         refreshPreview={refreshPreview}
       />
       <ComponentListEditor
+        browser={browser}
         config={config}
         draft={draft}
         components={page.components}
@@ -797,6 +1043,7 @@ const PageScopeEditor = ({
         setDraft={setDraft}
         refreshPreview={refreshPreview}
         title="Components"
+        validationErrors={validationErrors}
       />
       <div className="card">
         <div className="list-item-header">
@@ -992,6 +1239,7 @@ const App = () => {
   const [selectedScope, setSelectedScope] = useState({ type: "site" });
   const [dirty, setDirty] = useState(false);
   const [rawOpen, setRawOpen] = useState(false);
+  const [validationErrors, setValidationErrors] = useState(() => new Map());
   const [status, setStatus] = useState("Loading editor...");
   const [statusKind, setStatusKind] = useState("info");
   const [previewVersion, setPreviewVersion] = useState(0);
@@ -1037,6 +1285,7 @@ const App = () => {
     setBrowser(payload.browser);
     setSelectedScope({ type: "site" });
     setDirty(false);
+    setValidationErrors(new Map());
     setStatusMessage(`Opened ${payload.name}.`);
     setPreviewVersion(Date.now());
   };
@@ -1063,9 +1312,11 @@ const App = () => {
     try {
       await postJson("/__editor/save", draft);
       setDirty(false);
+      setValidationErrors(new Map());
       setStatusMessage(`Saved ${selectedFile}.`);
       await refreshBrowser();
     } catch (error) {
+      setValidationErrors(issuesToMap(error.issues));
       setStatusMessage(error instanceof Error ? error.message : String(error), "error");
     }
   };
@@ -1118,8 +1369,10 @@ const App = () => {
     updateTimer.current = window.setTimeout(async () => {
       try {
         await postJson("/__preview/draft", draft);
+        setValidationErrors(new Map());
         setStatusMessage("Draft preview updated.");
       } catch (error) {
+        setValidationErrors(issuesToMap(error.issues));
         setStatusMessage(error instanceof Error ? error.message : String(error), "error");
       }
     }, 100);
@@ -1163,14 +1416,17 @@ const App = () => {
         </div>
         {selectedScope.type === "site" ? (
           <SiteEditor
+            browser={browser}
             config={config}
             draft={draft}
             setDraft={setDraft}
             refreshPreview={refreshPreview}
+            validationErrors={validationErrors}
           />
         ) : null}
         {selectedScope.type === "page" && selectedPage ? (
           <PageScopeEditor
+            browser={browser}
             config={config}
             draft={draft}
             page={selectedPage}
@@ -1178,6 +1434,7 @@ const App = () => {
             setDraft={setDraft}
             setSelectedScope={setSelectedScope}
             refreshPreview={refreshPreview}
+            validationErrors={validationErrors}
           />
         ) : null}
         {rawOpen ? <RawEditor draft={draft} setDraft={setDraft} refreshPreview={refreshPreview} /> : null}

--- a/src/editor/static/app.jsx
+++ b/src/editor/static/app.jsx
@@ -99,6 +99,19 @@ const normalizeFieldValue = (field, value) => {
 
 const imageExtensions = new Set([".avif", ".gif", ".jpeg", ".jpg", ".png", ".svg", ".webp"]);
 
+const encodeContentAssetPath = (value) =>
+  value
+    .split("/")
+    .filter(Boolean)
+    .map((segment) => {
+      try {
+        return encodeURIComponent(decodeURIComponent(segment));
+      } catch {
+        return encodeURIComponent(segment);
+      }
+    })
+    .join("/");
+
 const toContentAssetHref = (value) => {
   const trimmedValue = String(value ?? "").trim();
 
@@ -113,18 +126,18 @@ const toContentAssetHref = (value) => {
   const normalizedValue = trimmedValue.replaceAll("\\", "/");
 
   if (normalizedValue.startsWith("/content/")) {
-    return normalizedValue;
+    return `/content/${encodeContentAssetPath(normalizedValue.slice("/content/".length))}`;
   }
 
   if (normalizedValue.startsWith("content/")) {
-    return `/${normalizedValue}`;
+    return `/content/${encodeContentAssetPath(normalizedValue.slice("content/".length))}`;
   }
 
   if (normalizedValue.startsWith("/")) {
     return normalizedValue;
   }
 
-  return `/content/${normalizedValue.replace(/^\/+/u, "")}`;
+  return `/content/${encodeContentAssetPath(normalizedValue.replace(/^\/+/u, ""))}`;
 };
 
 const isPreviewableImageHref = (value) => {

--- a/src/editor/static/app.jsx
+++ b/src/editor/static/app.jsx
@@ -707,7 +707,7 @@ const ComponentListEditor = ({
     <div className="component-scope">
       <div className="list-item-header">
         <h2>{title}</h2>
-        <div className="row">
+        <div className="component-add-row">
           <div className="grow">
             <select ref={componentTypeRef} defaultValue={mode === "layout" ? "page-content" : "prose"}>
               {componentTypeOptions.map((componentType) => (
@@ -822,6 +822,8 @@ const Sidebar = ({
   showScope,
 }) => {
   const [folderPath, setFolderPath] = useState(browser.directory);
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const currentFileLabel = selectedFile.split(/[/\\]/u).pop() || selectedFile;
 
   useEffect(() => {
     setFolderPath(browser.directory);
@@ -830,71 +832,85 @@ const Sidebar = ({
   return (
     <aside className="sidebar">
       <div className="brand">Cruftless Editor</div>
-      <div className="section-title">Folder</div>
-      <form
-        className="path-picker"
-        onSubmit={(event) => {
-          event.preventDefault();
-          void openDirectory(folderPath);
-        }}
-      >
-        <input
-          aria-label="Folder path"
-          className="folder-path"
-          value={folderPath}
-          onChange={(event) => setFolderPath(event.currentTarget.value)}
-        />
-        <button type="submit">Go</button>
-      </form>
-      <div className="nav-list">
-        <button
-          type="button"
-          className="nav-item"
-          disabled={!browser.parentDirectory}
-          onClick={() => {
-            if (browser.parentDirectory) {
-              void openDirectory(browser.parentDirectory);
-            }
-          }}
-        >
-          Up one folder
+      <div className="section-title">Site File</div>
+      <div className="picker-summary">
+        <div className="picker-summary-title" title={selectedFile}>
+          {currentFileLabel}
+        </div>
+        <div className="hint" title={browser.directory}>
+          {browser.directory}
+        </div>
+        <button type="button" onClick={() => setPickerOpen((open) => !open)}>
+          {pickerOpen ? "Hide picker" : "Change site"}
         </button>
-        {browser.directories.map((directory) => (
-          <button
-            key={directory.path}
-            type="button"
-            className="nav-item"
-            onClick={() => void openDirectory(directory.path)}
-          >
-            [dir] {directory.name}
-          </button>
-        ))}
       </div>
-      <div className="section-title">JSON Files</div>
-      <div className="nav-list">
-        {browser.files.length === 0 ? <div className="hint">No JSON files in this folder.</div> : null}
-        {browser.files.map((file) => (
-          <button
-            key={file.path}
-            type="button"
-            className={`nav-item ${selectedFile === file.path ? "active" : ""} ${file.valid ? "" : "invalid"}`}
-            onClick={() => {
-              if (!file.valid) {
-                window.alert(file.error ?? "This JSON file is not valid site content.");
-                return;
-              }
-              if (dirty && !window.confirm("Discard unsaved draft changes?")) {
-                return;
-              }
-              void openFile(file.path);
+      {pickerOpen ? (
+        <>
+          <div className="section-title">Folder</div>
+          <form
+            className="path-picker"
+            onSubmit={(event) => {
+              event.preventDefault();
+              void openDirectory(folderPath, "direct");
             }}
-            title={file.path}
           >
-            {file.siteName ?? file.name}
-            {file.valid ? "" : " (invalid)"}
-          </button>
-        ))}
-      </div>
+            <input
+              aria-label="Project or content path"
+              className="folder-path"
+              value={folderPath}
+              onChange={(event) => setFolderPath(event.currentTarget.value)}
+            />
+            <button type="submit">Go</button>
+          </form>
+          <div className="nav-list">
+            {browser.parentDirectory ? (
+              <button
+                type="button"
+                className="nav-item"
+                onClick={() => void openDirectory(browser.parentDirectory, "none")}
+              >
+                Up one folder
+              </button>
+            ) : null}
+            {browser.directories.map((directory) => (
+              <button
+                key={directory.path}
+                type="button"
+                className="nav-item"
+                onClick={() => void openDirectory(directory.path, directory.snapToContent ? "nested" : "none")}
+              >
+                [dir] {directory.name}
+              </button>
+            ))}
+          </div>
+          <div className="section-title">JSON Files</div>
+          <div className="nav-list">
+            {browser.files.length === 0 ? <div className="hint">No JSON files in this folder.</div> : null}
+            {browser.files.map((file) => (
+              <button
+                key={file.path}
+                type="button"
+                className={`nav-item ${selectedFile === file.path ? "active" : ""} ${file.valid ? "" : "invalid"}`}
+                onClick={async () => {
+                  if (!file.valid) {
+                    window.alert(file.error ?? "This JSON file is not valid site content.");
+                    return;
+                  }
+                  if (dirty && !window.confirm("Discard unsaved draft changes?")) {
+                    return;
+                  }
+                  await openFile(file.path);
+                  setPickerOpen(false);
+                }}
+                title={file.path}
+              >
+                {file.siteName ?? file.name}
+                {file.valid ? "" : " (invalid)"}
+              </button>
+            ))}
+          </div>
+        </>
+      ) : null}
       <div className="section-title">Edit</div>
       <div className="nav-list">
         <button
@@ -1025,11 +1041,14 @@ const App = () => {
     setPreviewVersion(Date.now());
   };
 
-  const openDirectory = async (directoryPath) => {
+  const openDirectory = async (directoryPath, snapToContent = "none") => {
     setStatusMessage(`Browsing ${directoryPath}...`);
 
     try {
-      const payload = await postJson("/__editor/open-directory", { path: directoryPath });
+      const payload = await postJson("/__editor/open-directory", {
+        path: directoryPath,
+        snapToContent,
+      });
       setBrowser(payload);
       setStatusMessage(`Browsing ${payload.directory}.`);
     } catch (error) {

--- a/src/editors/component-editors.ts
+++ b/src/editors/component-editors.ts
@@ -47,7 +47,7 @@ const linkFields = [
 ] as const satisfies readonly FieldDef<string>[];
 
 const imageFields = [
-  { kind: "text", key: "src", label: "Source" },
+  { kind: "media", key: "src", label: "Source" },
   { kind: "text", key: "alt", label: "Alt text" },
   { kind: "textarea", key: "caption", label: "Caption", optional: true },
   { kind: "number", key: "width", label: "Width", optional: true },
@@ -392,7 +392,7 @@ export const logoStripEditor = logoStrip.object({
         "Logos",
         { src: "/content/logo.svg", alt: "Logo" },
         [
-          { kind: "text", key: "src", label: "Source" },
+          { kind: "media", key: "src", label: "Source" },
           { kind: "text", key: "alt", label: "Alt text" },
           { kind: "text", key: "href", label: "Href", optional: true },
           { kind: "number", key: "width", label: "Width", optional: true },
@@ -416,7 +416,7 @@ export const mediaEditor = media.object({
   fields: [
     media.section("Main", [
       media.readonly("type"),
-      media.text("src", "Source"),
+      media.media("src", "Source"),
       media.text("alt", "Alt text"),
       media.textarea("caption", "Caption"),
       media.select("loading", "Loading", [
@@ -446,7 +446,7 @@ export const navigationBarEditor = navigationBar.object({
       navigationBar.readonly("type"),
       navigationBar.text("brandText", "Brand text"),
       navigationBar.optionalObject("brandImage", "Brand image", emptyImage, [
-        { kind: "text", key: "src", label: "Source" },
+        { kind: "media", key: "src", label: "Source" },
         { kind: "text", key: "alt", label: "Alt text" },
       ]),
       navigationBar.objectList("links", "Links", emptyLink, linkFields, {

--- a/tests/site-editor-flow.browser.ts
+++ b/tests/site-editor-flow.browser.ts
@@ -129,6 +129,13 @@ const runBrowserRegression = async (): Promise<void> => {
       .frameLocator("[data-testid='preview-frame']")
       .locator("text=SiblingKit Nav")
       .waitFor();
+    await page.locator("[data-testid='field-name']").fill("S".repeat(81));
+    await page.locator(".field-error").filter({ hasText: "String must contain at most 80 character(s)" }).waitFor();
+    await page.locator("[data-testid='field-name']").fill("SiblingKit");
+    await page
+      .frameLocator("[data-testid='preview-frame']")
+      .locator("text=SiblingKit Nav")
+      .waitFor();
 
     await page.locator("button", { hasText: "2. About" }).click();
     await page.locator("h2", { hasText: /^Page$/u }).waitFor();

--- a/tests/site-editor-flow.browser.ts
+++ b/tests/site-editor-flow.browser.ts
@@ -94,6 +94,12 @@ const runBrowserRegression = async (): Promise<void> => {
   const siblingContentPath = path.join(siblingContentDir, "site.json");
   await writeJson(firstContentPath, createDraft("About FirstKit", "FirstKit"));
   await writeJson(siblingContentPath, createDraft("About SiblingKit", "SiblingKit"));
+  await mkdir(path.join(siblingContentDir, "images"), { recursive: true });
+  await writeFile(
+    path.join(siblingContentDir, "images", "hero image.svg"),
+    '<svg xmlns="http://www.w3.org/2000/svg" width="40" height="20"><rect width="40" height="20" fill="#0f766e"/></svg>\n',
+    "utf8",
+  );
   const server = await createSiteEditorServer({ contentPath: firstContentDir });
   const browser = await chromium.launch();
 
@@ -124,6 +130,21 @@ const runBrowserRegression = async (): Promise<void> => {
       return field instanceof HTMLInputElement && field.value === "SiblingKit";
     });
     assert.equal(await page.locator("[data-testid='field-name']").inputValue(), "SiblingKit");
+    await page.locator("[data-testid='field-pageBackgroundImageUrl']").scrollIntoViewIfNeeded();
+    await page.locator("[data-testid='field-pageBackgroundImageUrl']").fill("images/hero image.svg");
+    await page.waitForFunction(() => {
+      const image = document.querySelector(".media-preview-image");
+      return image instanceof HTMLImageElement && image.currentSrc.includes("hero%20image.svg");
+    });
+    await page.locator("button", { hasText: "Pick media" }).first().click();
+    await page.locator(".media-picker-item", { hasText: "images/hero image.svg" }).click();
+    await page.waitForFunction(() => {
+      const image = document.querySelector(".media-preview-image");
+
+      return image instanceof HTMLImageElement
+        && image.currentSrc.includes("hero%20image.svg")
+        && image.naturalWidth > 0;
+    });
     await page.locator("[data-testid='field-brandText']").fill("SiblingKit Nav");
     await page
       .frameLocator("[data-testid='preview-frame']")

--- a/tests/site-editor-flow.browser.ts
+++ b/tests/site-editor-flow.browser.ts
@@ -88,13 +88,13 @@ const writeJson = async (filePath: string, value: unknown): Promise<void> => {
 
 const runBrowserRegression = async (): Promise<void> => {
   const tempDir = await mkdtemp(path.join(os.tmpdir(), "cruftless-site-editor-browser-"));
-  const firstDir = path.join(tempDir, "first");
-  const siblingDir = path.join(tempDir, "sibling");
-  const firstContentPath = path.join(firstDir, "site.json");
-  const siblingContentPath = path.join(siblingDir, "site.json");
+  const firstContentDir = path.join(tempDir, "first", "content");
+  const siblingContentDir = path.join(tempDir, "sibling", "nested", "content");
+  const firstContentPath = path.join(firstContentDir, "site.json");
+  const siblingContentPath = path.join(siblingContentDir, "site.json");
   await writeJson(firstContentPath, createDraft("About FirstKit", "FirstKit"));
   await writeJson(siblingContentPath, createDraft("About SiblingKit", "SiblingKit"));
-  const server = await createSiteEditorServer({ contentPath: firstDir });
+  const server = await createSiteEditorServer({ contentPath: firstContentDir });
   const browser = await chromium.launch();
 
   try {
@@ -110,9 +110,15 @@ const runBrowserRegression = async (): Promise<void> => {
     await page.goto(server.origin, { waitUntil: "domcontentloaded" });
     await page.locator("button", { hasText: "Site details" }).waitFor();
     assert.equal(await page.locator("h2").first().textContent(), "Site");
+    assert.equal(await page.locator("button", { hasText: "Change site" }).count(), 1);
+    assert.equal(await page.locator("button", { hasText: "Up one folder" }).count(), 0);
+    await page.locator("button", { hasText: "Change site" }).click();
+    await page.locator("button", { hasText: "Up one folder" }).click();
     await page.locator("button", { hasText: "Up one folder" }).click();
     await page.locator("button", { hasText: "[dir] sibling" }).click();
     await page.locator("button", { hasText: "SiblingKit" }).click();
+    await page.locator("button", { hasText: "Change site" }).waitFor();
+    assert.equal(await page.locator("button", { hasText: "Up one folder" }).count(), 0);
     await page.waitForFunction(() => {
       const field = document.querySelector("[data-testid='field-name']");
       return field instanceof HTMLInputElement && field.value === "SiblingKit";

--- a/tests/site-editor-server.test.ts
+++ b/tests/site-editor-server.test.ts
@@ -246,7 +246,7 @@ describe("createSiteEditorServer", () => {
 
   it("lists media files from the current content folder and nested subdirectories", async () => {
     const tempDir = await mkdtemp(path.join(os.tmpdir(), "cruftless-site-editor-"));
-    const imagePath = path.join(tempDir, "images", "hero.jpg");
+    const imagePath = path.join(tempDir, "images", "hero image.jpg");
     const logoPath = path.join(tempDir, "logos", "mark.svg");
     const videoPath = path.join(tempDir, "videos", "intro.mp4");
     await writeJson(path.join(tempDir, "site.json"), createDraft("LaunchKit"));
@@ -272,9 +272,9 @@ describe("createSiteEditorServer", () => {
     expect(payload.files).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
-          href: "/content/images/hero.jpg",
+          href: "/content/images/hero%20image.jpg",
           kind: "image",
-          relativePath: "images/hero.jpg",
+          relativePath: "images/hero image.jpg",
         }),
         expect.objectContaining({
           href: "/content/logos/mark.svg",

--- a/tests/site-editor-server.test.ts
+++ b/tests/site-editor-server.test.ts
@@ -108,30 +108,45 @@ describe("createSiteEditorServer", () => {
     expect(filesPayload.selectedFile).toBe(path.join(tempDir, "site.json"));
   });
 
-  it("moves up to a parent directory, browses into a sibling folder, and opens a site JSON there", async () => {
+  it("lets you browse above the current content root, filters sibling project directories, and snaps into nested content", async () => {
     const tempDir = await mkdtemp(path.join(os.tmpdir(), "cruftless-site-editor-"));
-    const firstDir = path.join(tempDir, "first");
-    const siblingDir = path.join(tempDir, "sibling");
-    const siblingPath = path.join(siblingDir, "site.json");
-    await writeJson(path.join(firstDir, "site.json"), createDraft("First"));
+    const firstProjectDir = path.join(tempDir, "first");
+    const firstContentDir = path.join(firstProjectDir, "content");
+    const siblingProjectDir = path.join(tempDir, "sibling");
+    const siblingContentDir = path.join(siblingProjectDir, "nested", "content");
+    const unrelatedDir = path.join(tempDir, "notes-only");
+    const siblingPath = path.join(siblingContentDir, "site.json");
+    await writeJson(path.join(firstContentDir, "site.json"), createDraft("First"));
     await writeJson(siblingPath, createDraft("Sibling"));
-    const server = await createServer(firstDir);
+    await mkdir(unrelatedDir, { recursive: true });
+    const server = await createServer(firstContentDir);
 
+    const projectResponse = await fetch(`${server.origin}/__editor/open-directory`, {
+      body: JSON.stringify({ path: firstProjectDir, snapToContent: false }),
+      headers: { "content-type": "application/json" },
+      method: "POST",
+    });
+    const projectPayload = await projectResponse.json() as {
+      directory: string;
+      directories: { name: string; path: string; snapToContent: boolean }[];
+      parentDirectory?: string;
+    };
     const parentResponse = await fetch(`${server.origin}/__editor/open-directory`, {
-      body: JSON.stringify({ path: tempDir }),
+      body: JSON.stringify({ path: tempDir, snapToContent: false }),
       headers: { "content-type": "application/json" },
       method: "POST",
     });
     const parentPayload = await parentResponse.json() as {
-      directories: { name: string; path: string }[];
-      files: { name: string }[];
+      directory: string;
+      directories: { name: string; path: string; snapToContent: boolean }[];
     };
     const siblingResponse = await fetch(`${server.origin}/__editor/open-directory`, {
-      body: JSON.stringify({ path: siblingDir }),
+      body: JSON.stringify({ path: siblingProjectDir, snapToContent: "nested" }),
       headers: { "content-type": "application/json" },
       method: "POST",
     });
     const siblingPayload = await siblingResponse.json() as {
+      directory: string;
       files: { name: string; valid: boolean; siteName?: string }[];
     };
     const openResponse = await fetch(`${server.origin}/__editor/open`, {
@@ -144,15 +159,37 @@ describe("createSiteEditorServer", () => {
       path: string;
     };
 
+    expect(projectResponse.status).toBe(200);
+    expect(projectPayload.directory).toBe(firstProjectDir);
+    expect(projectPayload.parentDirectory).toBe(tempDir);
+    expect(projectPayload.directories).toEqual([
+      expect.objectContaining({
+        name: "content",
+        path: firstContentDir,
+        snapToContent: true,
+      }),
+    ]);
     expect(parentResponse.status).toBe(200);
-    expect(parentPayload.directories).toEqual(
+    expect(parentPayload.directory).toBe(tempDir);
+    expect(parentPayload.directories).toEqual([
+      expect.objectContaining({
+        name: "first",
+        path: firstProjectDir,
+        snapToContent: true,
+      }),
+      expect.objectContaining({
+        name: "sibling",
+        path: siblingProjectDir,
+        snapToContent: true,
+      }),
+    ]);
+    expect(parentPayload.directories).not.toEqual(
       expect.arrayContaining([
-        expect.objectContaining({ name: "first" }),
-        expect.objectContaining({ name: "sibling" }),
+        expect.objectContaining({ name: path.basename(unrelatedDir) }),
       ]),
     );
-    expect(parentPayload.files).toEqual([]);
     expect(siblingResponse.status).toBe(200);
+    expect(siblingPayload.directory).toBe(siblingContentDir);
     expect(siblingPayload.files).toEqual([
       expect.objectContaining({ name: "site.json", valid: true, siteName: "Sibling" }),
     ]);
@@ -160,6 +197,34 @@ describe("createSiteEditorServer", () => {
     expect(openPayload.draft.site.name).toBe("Sibling");
     expect(openPayload.path).toBe(siblingPath);
     expect(server.getSelectedFilePath()).toBe(siblingPath);
+  });
+
+  it("does not jump into the first nested content tree when a broad directory is opened directly", async () => {
+    const tempDir = await mkdtemp(path.join(os.tmpdir(), "cruftless-site-editor-"));
+    const firstContentDir = path.join(tempDir, "first", "content");
+    const siblingContentDir = path.join(tempDir, "sibling", "nested", "content");
+    await writeJson(path.join(firstContentDir, "site.json"), createDraft("First"));
+    await writeJson(path.join(siblingContentDir, "site.json"), createDraft("Sibling"));
+    const server = await createServer(firstContentDir);
+
+    const response = await fetch(`${server.origin}/__editor/open-directory`, {
+      body: JSON.stringify({ path: tempDir, snapToContent: "direct" }),
+      headers: { "content-type": "application/json" },
+      method: "POST",
+    });
+    const payload = await response.json() as {
+      directory: string;
+      directories: { name: string; path: string; snapToContent: boolean }[];
+    };
+
+    expect(response.status).toBe(200);
+    expect(payload.directory).toBe(tempDir);
+    expect(payload.directories).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: "first", snapToContent: true }),
+        expect.objectContaining({ name: "sibling", snapToContent: true }),
+      ]),
+    );
   });
 
   it("opens, previews, drafts, and saves a selected JSON file", async () => {

--- a/tests/site-editor-server.test.ts
+++ b/tests/site-editor-server.test.ts
@@ -201,8 +201,9 @@ describe("createSiteEditorServer", () => {
 
   it("does not jump into the first nested content tree when a broad directory is opened directly", async () => {
     const tempDir = await mkdtemp(path.join(os.tmpdir(), "cruftless-site-editor-"));
-    const firstContentDir = path.join(tempDir, "first", "content");
-    const siblingContentDir = path.join(tempDir, "sibling", "nested", "content");
+    const broadDir = path.join(tempDir, "refreshes");
+    const firstContentDir = path.join(broadDir, "first", "content");
+    const siblingContentDir = path.join(broadDir, "sibling", "nested", "content");
     await writeJson(path.join(firstContentDir, "site.json"), createDraft("First"));
     await writeJson(path.join(siblingContentDir, "site.json"), createDraft("Sibling"));
     const server = await createServer(firstContentDir);
@@ -216,13 +217,108 @@ describe("createSiteEditorServer", () => {
       directory: string;
       directories: { name: string; path: string; snapToContent: boolean }[];
     };
+    const broadResponse = await fetch(`${server.origin}/__editor/open-directory`, {
+      body: JSON.stringify({ path: broadDir, snapToContent: "none" }),
+      headers: { "content-type": "application/json" },
+      method: "POST",
+    });
+    const broadPayload = await broadResponse.json() as {
+      directory: string;
+      directories: { name: string; path: string; snapToContent: boolean }[];
+    };
 
     expect(response.status).toBe(200);
     expect(payload.directory).toBe(tempDir);
     expect(payload.directories).toEqual(
       expect.arrayContaining([
+        expect.objectContaining({ name: "refreshes", snapToContent: false }),
+      ]),
+    );
+    expect(broadResponse.status).toBe(200);
+    expect(broadPayload.directory).toBe(broadDir);
+    expect(broadPayload.directories).toEqual(
+      expect.arrayContaining([
         expect.objectContaining({ name: "first", snapToContent: true }),
         expect.objectContaining({ name: "sibling", snapToContent: true }),
+      ]),
+    );
+  });
+
+  it("lists media files from the current content folder and nested subdirectories", async () => {
+    const tempDir = await mkdtemp(path.join(os.tmpdir(), "cruftless-site-editor-"));
+    const imagePath = path.join(tempDir, "images", "hero.jpg");
+    const logoPath = path.join(tempDir, "logos", "mark.svg");
+    const videoPath = path.join(tempDir, "videos", "intro.mp4");
+    await writeJson(path.join(tempDir, "site.json"), createDraft("LaunchKit"));
+    await mkdir(path.dirname(imagePath), { recursive: true });
+    await mkdir(path.dirname(logoPath), { recursive: true });
+    await mkdir(path.dirname(videoPath), { recursive: true });
+    await writeFile(imagePath, "jpg\n", "utf8");
+    await writeFile(logoPath, "<svg />\n", "utf8");
+    await writeFile(videoPath, "mp4\n", "utf8");
+    await writeFile(path.join(tempDir, "notes.txt"), "ignore\n", "utf8");
+    const server = await createServer(tempDir);
+
+    const response = await fetch(
+      `${server.origin}/__editor/media?directory=${encodeURIComponent(tempDir)}`,
+    );
+    const payload = await response.json() as {
+      directory: string;
+      files: { href: string; kind: string; relativePath: string }[];
+    };
+
+    expect(response.status).toBe(200);
+    expect(payload.directory).toBe(tempDir);
+    expect(payload.files).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          href: "/content/images/hero.jpg",
+          kind: "image",
+          relativePath: "images/hero.jpg",
+        }),
+        expect.objectContaining({
+          href: "/content/logos/mark.svg",
+          kind: "image",
+          relativePath: "logos/mark.svg",
+        }),
+        expect.objectContaining({
+          href: "/content/videos/intro.mp4",
+          kind: "video",
+          relativePath: "videos/intro.mp4",
+        }),
+      ]),
+    );
+    expect(payload.files).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ relativePath: "notes.txt" }),
+      ]),
+    );
+  });
+
+  it("returns structured validation issues for invalid draft updates", async () => {
+    const tempDir = await mkdtemp(path.join(os.tmpdir(), "cruftless-site-editor-"));
+    await writeJson(path.join(tempDir, "site.json"), createDraft("LaunchKit"));
+    const server = await createServer(tempDir);
+    const invalidDraft = createDraft("LaunchKit");
+    invalidDraft.site.name = "L".repeat(81);
+
+    const response = await fetch(`${server.origin}/__preview/draft`, {
+      body: JSON.stringify(invalidDraft),
+      headers: { "content-type": "application/json" },
+      method: "POST",
+    });
+    const payload = await response.json() as {
+      error: string;
+      issues?: { message: string; path: (string | number)[] }[];
+    };
+
+    expect(response.status).toBe(400);
+    expect(payload.error).toContain("Invalid site content");
+    expect(payload.issues).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          path: ["site", "name"],
+        }),
       ]),
     );
   });


### PR DESCRIPTION
## Summary
- add the schema-bound JSON site editor UI with page/site scope editing, component editing, reordering, and live preview wiring
- add explicit media field support with recursive media picking and inline image previews
- return structured validation issues from the editor server and show matching inline field errors in the UI
- add browser/server coverage for the editor flows, preview updates, folder navigation, save shortcut, and validation behavior

## Validation
- npm run lint:ts
- npm run lint:css
- npm test -- --run tests/site-editor-server.test.ts
- node_modules\\.bin\\tsx tests\\site-editor-flow.browser.ts