### PR TITLE
Support standalone site target CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,12 @@ npm run validate:strict
 
 `npm run check` is an alias for the same full validation run.
 
+To validate a standalone site folder from this generator checkout, point the CLI at the folder. The target folder only needs `content/site.json`; generated files are written under that same folder's `dist/`.
+
+```bash
+npm run site:validate -- ../my-site
+```
+
 ### 3. Edit content in the browser
 
 ```bash
@@ -164,6 +170,12 @@ You can also point it at one JSON file:
 
 ```bash
 npm run edit -- content/examples/baird-automotive.json
+```
+
+To edit a standalone site folder, use:
+
+```bash
+npm run edit -- --site-dir ../my-site
 ```
 
 ### 4. Build the default site
@@ -195,11 +207,25 @@ Or watch a specific content file and output directory:
 npm run build -- content/examples/78th-street-studios.json dist/78th-street-studios --watch
 ```
 
+To build a standalone target folder without adding a project setup to that folder, run:
+
+```bash
+npm run site:build -- ../my-site
+```
+
+That reads `../my-site/content/site.json` and writes `../my-site/dist/`. If the package is linked or installed as a CLI, the equivalent command is:
+
+```bash
+cruftless-site-gen build ../my-site
+```
+
 ### 5. Build or validate a specific content file
 
 ```bash
 npm run validate -- content/examples/78th-street-studios.json
 npm run build -- content/examples/78th-street-studios.json dist/78th-street-studios
+npm run validate -- --site-dir ../my-site
+npm run build -- --site-dir ../my-site
 ```
 
 ### 5b. Discover likely first-party page images

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,9 @@
         "sharp": "^0.34.4",
         "zod": "^3.23.8"
       },
+      "bin": {
+        "cruftless-site-gen": "scripts/shared-site-gen.mjs"
+      },
       "devDependencies": {
         "@types/node": "^22.10.2",
         "ajv": "^8.18.0",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "0.1.0",
   "private": true,
   "type": "module",
+  "bin": {
+    "cruftless-site-gen": "scripts/shared-site-gen.mjs"
+  },
   "engines": {
     "node": ">=20"
   },
@@ -13,6 +16,9 @@
     "dev": "concurrently -k \"npm:build:watch\" \"npm:build:examples:watch\" \"npm:build:example:78th:watch\" \"npm:build:example:baird:watch\" \"npm:serve:watch\"",
     "build:examples": "tsx src/build/build-examples.ts",
     "build:examples:watch": "tsx src/build/build-examples.ts --watch",
+    "site": "node scripts/shared-site-gen.mjs",
+    "site:build": "node scripts/shared-site-gen.mjs build",
+    "site:validate": "node scripts/shared-site-gen.mjs validate",
     "build:example:baird": "tsx src/build/build.ts content/examples/baird-automotive.json dist/baird-automotive",
     "build:example:baird:watch": "tsx src/build/build.ts content/examples/baird-automotive.json dist/baird-automotive --watch",
     "build:example:78th": "tsx src/build/build.ts content/examples/78th-street-studios.json dist/78th-street-studios",

--- a/scripts/shared-site-gen.mjs
+++ b/scripts/shared-site-gen.mjs
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 import { spawnSync } from "node:child_process";
 import { existsSync } from "node:fs";
 import path from "node:path";
@@ -5,10 +7,68 @@ import { fileURLToPath, pathToFileURL } from "node:url";
 import chokidar from "chokidar";
 
 const generatorDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
-const repoRoot = process.cwd();
-const mainSiteContentPath = path.join(repoRoot, "content", "site.json");
-const composedDistDir = path.join(repoRoot, "dist");
 const tsxCliPath = path.join(generatorDir, "node_modules", "tsx", "dist", "cli.mjs");
+
+const resolveSitePaths = (siteDir = ".") => {
+  const root = path.resolve(process.cwd(), siteDir);
+
+  return {
+    root,
+    contentPath: path.join(root, "content", "site.json"),
+    distDir: path.join(root, "dist"),
+  };
+};
+
+const parseSiteCommandArgs = (args) => {
+  let siteDir = ".";
+  let siteDirWasSet = false;
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+
+    if (arg === "--site-dir" || arg === "--site") {
+      const value = args[index + 1];
+      if (!value) {
+        throw new Error(`Missing path after ${arg}`);
+      }
+
+      siteDir = value;
+      siteDirWasSet = true;
+      index += 1;
+      continue;
+    }
+
+    if (arg.startsWith("--site-dir=")) {
+      siteDir = arg.slice("--site-dir=".length);
+      if (!siteDir) {
+        throw new Error("Missing path after --site-dir");
+      }
+
+      siteDirWasSet = true;
+      continue;
+    }
+
+    if (arg.startsWith("--site=")) {
+      siteDir = arg.slice("--site=".length);
+      if (!siteDir) {
+        throw new Error("Missing path after --site");
+      }
+
+      siteDirWasSet = true;
+      continue;
+    }
+
+    if (!siteDirWasSet && !arg.startsWith("-")) {
+      siteDir = arg;
+      siteDirWasSet = true;
+      continue;
+    }
+  }
+
+  return {
+    sitePaths: resolveSitePaths(siteDir),
+  };
+};
 
 const runInherited = (command, args, cwd, { exitOnError = true } = {}) => {
   const [spawnCommand, spawnArgs] =
@@ -45,39 +105,40 @@ const ensureGeneratorDependenciesAvailable = () => {
   }
 };
 
-const runGeneratorEntryPoint = (entryPoint, args, inheritedOptions) => {
+const runGeneratorEntryPoint = (entryPoint, args, cwd, inheritedOptions) => {
   const entryPath = path.join(generatorDir, "src", "build", `${entryPoint}.ts`);
-  runInherited(process.execPath, [tsxCliPath, entryPath, ...args], repoRoot, inheritedOptions);
+  runInherited(process.execPath, [tsxCliPath, entryPath, ...args], cwd, inheritedOptions);
 };
 
-const validateSite = (contentPath = mainSiteContentPath, inheritedOptions) => {
-  runGeneratorEntryPoint("validate", [contentPath], inheritedOptions);
+const validateSite = (sitePaths, contentPath = sitePaths.contentPath, inheritedOptions) => {
+  runGeneratorEntryPoint("validate", [contentPath], sitePaths.root, inheritedOptions);
 };
 
 const discoverPageImages = (args, inheritedOptions) => {
-  runGeneratorEntryPoint("discover-page-images", args, inheritedOptions);
+  runGeneratorEntryPoint("discover-page-images", args, process.cwd(), inheritedOptions);
 };
 
-const lighthouseCi = (inheritedOptions) => {
-  runGeneratorEntryPoint("lighthouse-ci", [], inheritedOptions);
+const lighthouseCi = (sitePaths, inheritedOptions) => {
+  runGeneratorEntryPoint("lighthouse-ci", [], sitePaths.root, inheritedOptions);
 };
 
 const localizeLandingImage = (args, inheritedOptions) => {
-  runGeneratorEntryPoint("localize-landing-image", args, inheritedOptions);
+  runGeneratorEntryPoint("localize-landing-image", args, process.cwd(), inheritedOptions);
 };
 
 const buildSite = (
-  contentPath = mainSiteContentPath,
-  outDir = composedDistDir,
+  sitePaths,
+  contentPath = sitePaths.contentPath,
+  outDir = sitePaths.distDir,
   inheritedOptions,
 ) => {
-  validateSite(contentPath, inheritedOptions);
-  runGeneratorEntryPoint("build", [contentPath, outDir], inheritedOptions);
+  validateSite(sitePaths, contentPath, inheritedOptions);
+  runGeneratorEntryPoint("build", [contentPath, outDir], sitePaths.root, inheritedOptions);
 };
 
-const watchSiteBuild = async ({ skipInitialBuild = false } = {}) => {
+const watchSiteBuild = async (sitePaths, { skipInitialBuild = false } = {}) => {
   const watchRoots = [
-    path.join(repoRoot, "content"),
+    path.join(sitePaths.root, "content"),
     path.join(generatorDir, "src"),
   ];
   const watchers = [];
@@ -94,7 +155,7 @@ const watchSiteBuild = async ({ skipInitialBuild = false } = {}) => {
     buildInProgress = true;
 
     try {
-      buildSite(mainSiteContentPath, composedDistDir, { exitOnError: false });
+      buildSite(sitePaths, sitePaths.contentPath, sitePaths.distDir, { exitOnError: false });
       process.exitCode = 0;
     } catch (error) {
       if (error instanceof Error) {
@@ -134,7 +195,7 @@ const watchSiteBuild = async ({ skipInitialBuild = false } = {}) => {
     });
 
     watcher.on("all", (_eventName, changedPath) => {
-      const relativePath = path.relative(repoRoot, changedPath);
+      const relativePath = path.relative(sitePaths.root, changedPath);
       console.log(`Detected change in ${relativePath}. Rebuilding site...`);
       queueBuild();
     });
@@ -143,7 +204,7 @@ const watchSiteBuild = async ({ skipInitialBuild = false } = {}) => {
   }
 
   console.log(
-    `Watching ${watchRoots.map((root) => path.relative(repoRoot, root)).join(", ")} for changes...`,
+    `Watching ${watchRoots.map((root) => path.relative(sitePaths.root, root)).join(", ")} for changes...`,
   );
 
   if (!skipInitialBuild) {
@@ -185,24 +246,33 @@ if (isDirectExecution) {
     ensureGeneratorDependenciesAvailable();
 
     if (command === "validate") {
-      console.log(`Validating with shared generator at ${generatorDir}.`);
-      validateSite();
+      const { sitePaths } = parseSiteCommandArgs(commandArgs);
+      console.log(
+        `Validating ${path.relative(process.cwd(), sitePaths.root) || "."} with shared generator at ${generatorDir}.`,
+      );
+      validateSite(sitePaths);
       process.exit(0);
     }
 
-    if (command === "build:site") {
-      console.log(`Building with shared generator at ${generatorDir}.`);
+    if (command === "build" || command === "build:site") {
+      const { sitePaths } = parseSiteCommandArgs(commandArgs);
+      console.log(
+        `Building ${path.relative(process.cwd(), sitePaths.root) || "."} with shared generator at ${generatorDir}.`,
+      );
       if (watchMode) {
-        await watchSiteBuild({ skipInitialBuild });
+        await watchSiteBuild(sitePaths, { skipInitialBuild });
       } else {
-        buildSite();
+        buildSite(sitePaths);
       }
       process.exit(0);
     }
 
-    if (command === "dev:prepare") {
-      console.log(`Preparing local dev build with shared generator at ${generatorDir}.`);
-      buildSite();
+    if (command === "dev:prepare" || command === "prepare") {
+      const { sitePaths } = parseSiteCommandArgs(commandArgs);
+      console.log(
+        `Preparing ${path.relative(process.cwd(), sitePaths.root) || "."} with shared generator at ${generatorDir}.`,
+      );
+      buildSite(sitePaths);
       process.exit(0);
     }
 
@@ -213,8 +283,11 @@ if (isDirectExecution) {
     }
 
     if (command === "lighthouse:ci") {
-      console.log(`Running Lighthouse CI with shared generator at ${generatorDir}.`);
-      lighthouseCi();
+      const { sitePaths } = parseSiteCommandArgs(commandArgs);
+      console.log(
+        `Running Lighthouse CI for ${path.relative(process.cwd(), sitePaths.root) || "."} with shared generator at ${generatorDir}.`,
+      );
+      lighthouseCi(sitePaths);
       process.exit(0);
     }
 
@@ -225,7 +298,7 @@ if (isDirectExecution) {
     }
 
     throw new Error(
-      "Usage: node scripts/shared-site-gen.mjs <validate|build:site|dev:prepare|discover:images|lighthouse:ci|localize:landing-image>",
+      "Usage: cruftless-site-gen <validate|build|build:site|prepare|dev:prepare|discover:images|lighthouse:ci|localize:landing-image> [site-dir]",
     );
   } catch (error) {
     if (error instanceof Error) {

--- a/src/build/build.ts
+++ b/src/build/build.ts
@@ -11,9 +11,11 @@ import {
   loadValidatedSite,
 } from "./framework.js";
 import { collectWatchableLocalImagePaths } from "./image-pipeline.js";
+import { resolveSiteTargetPaths } from "./site-target.js";
 
 const args = process.argv.slice(2);
 let watchMode = false;
+let siteDirArg: string | undefined;
 const preserveArgs: string[] = [];
 const positionalArgs: string[] = [];
 
@@ -22,6 +24,37 @@ for (let index = 0; index < args.length; index += 1) {
 
   if (arg === "--watch" || arg === "-w") {
     watchMode = true;
+    continue;
+  }
+
+  if (arg === "--site-dir" || arg === "--site") {
+    const sitePath = args[index + 1];
+    if (!sitePath) {
+      throw new Error(`Missing path after ${arg}`);
+    }
+
+    siteDirArg = sitePath;
+    index += 1;
+    continue;
+  }
+
+  if (arg.startsWith("--site-dir=")) {
+    const sitePath = arg.slice("--site-dir=".length);
+    if (!sitePath) {
+      throw new Error("Missing path after --site-dir");
+    }
+
+    siteDirArg = sitePath;
+    continue;
+  }
+
+  if (arg.startsWith("--site=")) {
+    const sitePath = arg.slice("--site=".length);
+    if (!sitePath) {
+      throw new Error("Missing path after --site");
+    }
+
+    siteDirArg = sitePath;
     continue;
   }
 
@@ -44,15 +77,17 @@ for (let index = 0; index < args.length; index += 1) {
   positionalArgs.push(arg);
 }
 
-if (positionalArgs.length > 2) {
+if (positionalArgs.length > 2 || (siteDirArg && positionalArgs.length > 0)) {
   throw new Error(
-    "Usage: tsx src/build/build.ts [content-path] [out-dir] [--watch] [--preserve output-path]",
+    "Usage: tsx src/build/build.ts [content-path] [out-dir] [--watch] [--preserve output-path] or tsx src/build/build.ts --site-dir site-directory [--watch]",
   );
 }
 
 const [contentArg, outArg] = positionalArgs;
-const contentPath = contentArg ? path.resolve(process.cwd(), contentArg) : defaultContentPath;
-const outDir = outArg ? path.resolve(process.cwd(), outArg) : defaultOutDir;
+const siteTarget = siteDirArg ? resolveSiteTargetPaths(siteDirArg) : undefined;
+const contentPath =
+  siteTarget?.contentPath ?? (contentArg ? path.resolve(process.cwd(), contentArg) : defaultContentPath);
+const outDir = siteTarget?.outDir ?? (outArg ? path.resolve(process.cwd(), outArg) : defaultOutDir);
 const preservePaths = preserveArgs.map((preserveArg) =>
   path.resolve(path.isAbsolute(preserveArg) ? preserveArg : path.join(outDir, preserveArg)),
 );

--- a/src/build/site-target.ts
+++ b/src/build/site-target.ts
@@ -1,0 +1,19 @@
+import path from "node:path";
+
+export interface SiteTargetPaths {
+  root: string;
+  contentRoot: string;
+  contentPath: string;
+  outDir: string;
+}
+
+export const resolveSiteTargetPaths = (siteDir: string): SiteTargetPaths => {
+  const root = path.resolve(process.cwd(), siteDir);
+
+  return {
+    root,
+    contentRoot: path.join(root, "content"),
+    contentPath: path.join(root, "content", "site.json"),
+    outDir: path.join(root, "dist"),
+  };
+};

--- a/src/build/validate.ts
+++ b/src/build/validate.ts
@@ -1,9 +1,57 @@
 import path from "node:path";
 
 import { ValidationFailure, defaultContentPath, loadValidatedSite } from "./framework.js";
+import { resolveSiteTargetPaths } from "./site-target.js";
 
-const [, , contentArg] = process.argv;
-const contentPath = contentArg ? path.resolve(process.cwd(), contentArg) : defaultContentPath;
+const args = process.argv.slice(2);
+let siteDirArg: string | undefined;
+const positionalArgs: string[] = [];
+
+for (let index = 0; index < args.length; index += 1) {
+  const arg = args[index];
+
+  if (arg === "--site-dir" || arg === "--site") {
+    const sitePath = args[index + 1];
+    if (!sitePath) {
+      throw new Error(`Missing path after ${arg}`);
+    }
+
+    siteDirArg = sitePath;
+    index += 1;
+    continue;
+  }
+
+  if (arg.startsWith("--site-dir=")) {
+    const sitePath = arg.slice("--site-dir=".length);
+    if (!sitePath) {
+      throw new Error("Missing path after --site-dir");
+    }
+
+    siteDirArg = sitePath;
+    continue;
+  }
+
+  if (arg.startsWith("--site=")) {
+    const sitePath = arg.slice("--site=".length);
+    if (!sitePath) {
+      throw new Error("Missing path after --site");
+    }
+
+    siteDirArg = sitePath;
+    continue;
+  }
+
+  positionalArgs.push(arg);
+}
+
+if (positionalArgs.length > 1 || (siteDirArg && positionalArgs.length > 0)) {
+  throw new Error("Usage: tsx src/build/validate.ts [content-path] or tsx src/build/validate.ts --site-dir site-directory");
+}
+
+const [contentArg] = positionalArgs;
+const siteTarget = siteDirArg ? resolveSiteTargetPaths(siteDirArg) : undefined;
+const contentPath =
+  siteTarget?.contentPath ?? (contentArg ? path.resolve(process.cwd(), contentArg) : defaultContentPath);
 
 try {
   const siteContent = await loadValidatedSite(contentPath);
@@ -18,4 +66,3 @@ try {
     throw error;
   }
 }
-

--- a/src/editor/edit.ts
+++ b/src/editor/edit.ts
@@ -1,14 +1,47 @@
 import path from "node:path";
 
+import { resolveSiteTargetPaths } from "../build/site-target.js";
 import { createSiteEditorServer } from "./site-editor-server.js";
 
 const args = process.argv.slice(2);
 const positionalArgs: string[] = [];
 let host = "127.0.0.1";
 let port: number | undefined;
+let siteDirArg: string | undefined;
 
 for (let index = 0; index < args.length; index += 1) {
   const arg = args[index];
+
+  if (arg === "--site-dir" || arg === "--site") {
+    const sitePath = args[index + 1];
+    if (!sitePath) {
+      throw new Error(`Missing value after ${arg}`);
+    }
+
+    siteDirArg = sitePath;
+    index += 1;
+    continue;
+  }
+
+  if (arg.startsWith("--site-dir=")) {
+    const sitePath = arg.slice("--site-dir=".length);
+    if (!sitePath) {
+      throw new Error("Missing value after --site-dir");
+    }
+
+    siteDirArg = sitePath;
+    continue;
+  }
+
+  if (arg.startsWith("--site=")) {
+    const sitePath = arg.slice("--site=".length);
+    if (!sitePath) {
+      throw new Error("Missing value after --site");
+    }
+
+    siteDirArg = sitePath;
+    continue;
+  }
 
   if (arg === "--host") {
     const value = args[index + 1];
@@ -45,11 +78,19 @@ for (let index = 0; index < args.length; index += 1) {
   positionalArgs.push(arg);
 }
 
-if (positionalArgs.length > 1 || (port !== undefined && (!Number.isInteger(port) || port <= 0))) {
-  throw new Error("Usage: tsx src/editor/edit.ts [content-directory-or-json-file] [--host host] [--port port]");
+if (
+  positionalArgs.length > 1 ||
+  (siteDirArg && positionalArgs.length > 0) ||
+  (port !== undefined && (!Number.isInteger(port) || port <= 0))
+) {
+  throw new Error(
+    "Usage: tsx src/editor/edit.ts [content-directory-or-json-file] [--host host] [--port port] or tsx src/editor/edit.ts --site-dir site-directory [--host host] [--port port]",
+  );
 }
 
-const contentPath = path.resolve(process.cwd(), positionalArgs[0] ?? "content");
+const siteTarget = siteDirArg ? resolveSiteTargetPaths(siteDirArg) : undefined;
+const contentPath =
+  siteTarget?.contentRoot ?? path.resolve(process.cwd(), positionalArgs[0] ?? "content");
 const server = await createSiteEditorServer({
   contentPath,
   host,

--- a/tests/site-target-cli.test.ts
+++ b/tests/site-target-cli.test.ts
@@ -1,0 +1,93 @@
+import { spawnSync } from "node:child_process";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const repoRoot = path.resolve(import.meta.dirname, "..");
+const tsxCliPath = path.join(repoRoot, "node_modules", "tsx", "dist", "cli.mjs");
+
+const siteContent = {
+  site: {
+    name: "LaunchKit",
+    baseUrl: "https://launchkit.example",
+    theme: "friendly-modern",
+  },
+  pages: [
+    {
+      slug: "/",
+      title: "Home",
+      components: [
+        {
+          type: "hero",
+          headline: "Launch faster",
+          primaryCta: {
+            label: "Get started",
+            href: "/start",
+          },
+        },
+      ],
+    },
+  ],
+};
+
+const createStandaloneSite = async (): Promise<string> => {
+  const siteDir = await mkdtemp(path.join(os.tmpdir(), "cruftless-target-site-"));
+  await mkdir(path.join(siteDir, "content"), { recursive: true });
+  await writeFile(
+    path.join(siteDir, "content", "site.json"),
+    `${JSON.stringify(siteContent, null, 2)}\n`,
+    "utf8",
+  );
+  return siteDir;
+};
+
+const runCli = (args: string[]) => {
+  const result = spawnSync(process.execPath, args, {
+    cwd: repoRoot,
+    encoding: "utf8",
+  });
+
+  if (result.status !== 0) {
+    throw new Error(
+      `Command failed: node ${args.join(" ")}\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`,
+    );
+  }
+
+  return result;
+};
+
+describe("target site directory CLI", () => {
+  it("builds a site directory into its own dist folder", async () => {
+    const siteDir = await createStandaloneSite();
+
+    try {
+      const result = runCli([tsxCliPath, "src/build/build.ts", "--site-dir", siteDir]);
+
+      expect(result.stdout).toContain("Built 1 page(s)");
+      expect(result.stdout).toContain("dist");
+      await expect(readFile(path.join(siteDir, "dist", "index.html"), "utf8")).resolves.toContain(
+        "Launch faster",
+      );
+    } finally {
+      await rm(siteDir, { recursive: true, force: true });
+    }
+  });
+
+  it("runs the shared generator from this repo against a standalone target folder", async () => {
+    const siteDir = await createStandaloneSite();
+
+    try {
+      const result = runCli(["scripts/shared-site-gen.mjs", "build", siteDir]);
+
+      expect(result.stdout).toContain("Building");
+      expect(result.stdout).toContain("Validated 1 page(s)");
+      await expect(readFile(path.join(siteDir, "dist", "index.html"), "utf8")).resolves.toContain(
+        "Launch faster",
+      );
+    } finally {
+      await rm(siteDir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Add site-directory resolution so build, validate, and edit can target a folder that contains `content/site.json` and writes to its own `dist/`.
- Turn `scripts/shared-site-gen.mjs` into a runnable CLI/bin with `build` and `validate` commands that accept a target site folder.
- Document the standalone target-folder workflow and cover it with CLI tests.

Closes #119.

## Validation

- `npm run validate:strict`
