### PR TITLE
Add global transition CSS

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -97,6 +97,7 @@
       "overflow": [
         "visible",
         "hidden",
+        "clip",
         "auto",
         "scroll"
       ]
@@ -119,6 +120,7 @@
       "aspect-ratio",
       "box-sizing",
       "color-scheme",
+      "interpolate-size",
       "flex-grow",
       "flex-shrink",
       "flex-basis",
@@ -172,6 +174,10 @@
       "padding-inline-end",
       "padding-block-start",
       "transition",
+      "transition-property",
+      "transition-duration",
+      "transition-timing-function",
+      "transition-behavior",
       "transform"
     ],
     "selector-class-pattern": [

--- a/src/components/navigation-bar/navigation-bar.css
+++ b/src/components/navigation-bar/navigation-bar.css
@@ -132,6 +132,20 @@
   background: var(--surface);
   box-shadow: var(--shadow);
   border: 1px solid var(--border);
+  overflow: clip;
+  opacity: 1;
+  transform: translateY(0);
+  transition-property: opacity, transform, height, display;
+  transition-duration: var(--duration);
+  transition-timing-function: var(--ease);
+  transition-behavior: allow-discrete;
+}
+
+.c-navbar__panel[hidden] {
+  display: none;
+  height: 0;
+  opacity: 0;
+  transform: translateY(calc(var(--space-xs) * -1));
 }
 
 .c-navbar__panel .c-navbar__list {
@@ -172,5 +186,19 @@
 
   .c-navbar__menu-button {
     display: inline-flex;
+  }
+}
+
+@supports (interpolate-size: allow-keywords) {
+  .c-navbar__panel {
+    height: auto;
+  }
+
+  @starting-style {
+    .c-navbar__panel:not([hidden]) {
+      height: 0;
+      opacity: 0;
+      transform: translateY(calc(var(--space-xs) * -1));
+    }
   }
 }

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -2,10 +2,20 @@
   color-scheme: var(--color-scheme);
 }
 
+@supports (interpolate-size: allow-keywords) {
+  :root {
+    interpolate-size: allow-keywords;
+  }
+}
+
 *,
 *::before,
 *::after {
   box-sizing: border-box;
+  transition-property: all;
+  transition-duration: var(--duration);
+  transition-timing-function: var(--ease);
+  transition-behavior: allow-discrete;
 }
 
 html {

--- a/src/themes/brutalism.ts
+++ b/src/themes/brutalism.ts
@@ -35,7 +35,7 @@ export const brutalismTheme = createThemeDefinition(
     "--space-2xl": "5rem",
     "--radius": "0rem",
     "--theme-pattern": "url(\"data:image/svg+xml,%3Csvg width='40' height='40' viewBox='0 0 40 40' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cpath d='M0 40h40M40 0v40' stroke='%23000000' stroke-opacity='0.15' stroke-width='1'/%3E%3C/g%3E%3C/svg%3E\")",
-    "--duration": "0.1s",
+    "--duration": "0.5s",
     "--ease": "linear",
   },
   `
@@ -54,7 +54,7 @@ export const brutalismTheme = createThemeDefinition(
     .c-image-text__image {
       border: 2px solid var(--border);
       box-shadow: var(--shadow);
-      transition: transform 0.1s ease, box-shadow 0.1s ease;
+      transition: transform var(--duration) var(--ease), box-shadow var(--duration) var(--ease);
     }
 
     .l-section:hover,

--- a/src/themes/tokens.ts
+++ b/src/themes/tokens.ts
@@ -40,7 +40,7 @@ const canonicalThemeTokens = {
 
   "--theme-pattern": "none",
 
-  "--duration": "200ms",
+  "--duration": "0.5s",
   "--ease": "cubic-bezier(0.4, 0, 0.2, 1)",
 } as const;
 

--- a/tests/component-css-widths.test.ts
+++ b/tests/component-css-widths.test.ts
@@ -63,6 +63,30 @@ describe("component width tokens", () => {
     expect(css).toContain(".l-page {");
   });
 
+  it("enables default interpolated transitions for site elements", async () => {
+    const css = await readBaseCss();
+
+    expect(defaultThemeTokens["--duration"]).toBe("0.5s");
+    expect(css).toContain("@supports (interpolate-size: allow-keywords) {");
+    expect(css).toContain("interpolate-size: allow-keywords;");
+    expect(css).toContain("transition-property: all;");
+    expect(css).toContain("transition-duration: var(--duration);");
+    expect(css).toContain("transition-behavior: allow-discrete;");
+  });
+
+  it("allows navigation menu display and auto-height transitions", async () => {
+    const css = await readFile(
+      componentDefinitions.find((component) => component.type === "navigation-bar")!.cssPath,
+      "utf8",
+    );
+
+    expect(css).toContain("transition-property: opacity, transform, height, display;");
+    expect(css).toContain("transition-behavior: allow-discrete;");
+    expect(css).toContain("@supports (interpolate-size: allow-keywords) {");
+    expect(css).toContain("height: auto;");
+    expect(css).toContain("@starting-style");
+  });
+
   it("keeps google maps width modes split between content and container tokens", async () => {
     const css = await readFile(
       componentDefinitions.find((component) => component.type === "google-maps")!.cssPath,


### PR DESCRIPTION
## Summary

- Add root `interpolate-size: allow-keywords` behind `@supports` for generated site CSS.
- Set the default transition duration to `0.5s` and apply default transitions to site elements.
- Add the first discrete/auto-size transition use to the navigation menu panel.
- Tighten CSS lint allow-lists and add focused tests for the new CSS behavior.

Addresses #120.

## Validation

- `npm run check`

The generated files in `dist/assets/site.css` and `dist/78th-street-studios/assets/site.css` include the requested CSS after the build.
