### PR TITLE
Add cache-busting query hashes to generated assets

### DIFF
--- a/src/build/asset-version.ts
+++ b/src/build/asset-version.ts
@@ -1,0 +1,20 @@
+import { createHash } from "node:crypto";
+
+export const createContentVersion = (contents: string | Uint8Array): string =>
+  createHash("sha1").update(contents).digest("hex").slice(0, 12);
+
+export const appendVersionQuery = (
+  href: string,
+  version: string | undefined,
+): string => {
+  if (!version) {
+    return href;
+  }
+
+  const hashIndex = href.indexOf("#");
+  const hrefWithoutHash = hashIndex >= 0 ? href.slice(0, hashIndex) : href;
+  const hashSuffix = hashIndex >= 0 ? href.slice(hashIndex) : "";
+  const queryDelimiter = hrefWithoutHash.includes("?") ? "&" : "?";
+
+  return `${hrefWithoutHash}${queryDelimiter}v=${encodeURIComponent(version)}${hashSuffix}`;
+};

--- a/src/build/framework.ts
+++ b/src/build/framework.ts
@@ -39,6 +39,7 @@ import {
   validateCssTokenUsage,
   validateThemeDefinition,
 } from "../validation/theme-validation.js";
+import { appendVersionQuery, createContentVersion } from "./asset-version.js";
 
 export const defaultContentPath = path.resolve(process.cwd(), "content/site.json");
 export const defaultOutDir = path.resolve(process.cwd(), "dist");
@@ -286,14 +287,20 @@ const pageSlugToOutputPath = (slug: string, outDir: string): string => {
   return path.join(outDir, slug.replace(/^\//, ""), "index.html");
 };
 
-const pageSlugToStylesheetHref = (slug: string): string => {
+const pageSlugToStylesheetHref = (slug: string, version: string): string => {
   const pagePath = slug === "/" ? "/index.html" : path.posix.join(slug, "index.html");
-  return path.posix.relative(path.posix.dirname(pagePath), "/assets/site.css");
+  return appendVersionQuery(
+    path.posix.relative(path.posix.dirname(pagePath), "/assets/site.css"),
+    version,
+  );
 };
 
-const pageSlugToScriptHref = (slug: string): string => {
+const pageSlugToScriptHref = (slug: string, version: string): string => {
   const pagePath = slug === "/" ? "/index.html" : path.posix.join(slug, "index.html");
-  return path.posix.relative(path.posix.dirname(pagePath), "/assets/site.js");
+  return appendVersionQuery(
+    path.posix.relative(path.posix.dirname(pagePath), "/assets/site.js"),
+    version,
+  );
 };
 
 const escapeCssString = (value: string): string =>
@@ -702,6 +709,8 @@ export const buildSite = async (
     : undefined;
   const css = await renderSiteCss(siteContent, imagePipeline);
   const js = renderSiteJs(siteContent);
+  const cssVersion = createContentVersion(css);
+  const jsVersion = js ? createContentVersion(js) : undefined;
   const expectedFiles = new Set<string>();
   let filesCreated = 0;
   let filesUpdated = 0;
@@ -743,8 +752,8 @@ export const buildSite = async (
       siteContent,
       page,
       renderContext,
-      stylesheetHref: pageSlugToStylesheetHref(page.slug),
-      scriptHref: js ? pageSlugToScriptHref(page.slug) : undefined,
+      stylesheetHref: pageSlugToStylesheetHref(page.slug, cssVersion),
+      scriptHref: jsVersion ? pageSlugToScriptHref(page.slug, jsVersion) : undefined,
       socialImageUrl:
         page.metadata?.socialImageUrl && imagePipeline
           ? imagePipeline.resolveSocialImageUrl(page.metadata.socialImageUrl)

--- a/src/build/image-pipeline.ts
+++ b/src/build/image-pipeline.ts
@@ -1,4 +1,4 @@
-import { access, copyFile, mkdir, readFile, stat, writeFile } from "node:fs/promises";
+import { mkdir, readFile, stat, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { createHash } from "node:crypto";
 
@@ -12,7 +12,7 @@ import type {
   ResponsiveImageData,
 } from "../components/render-context.js";
 import type { SiteContentData } from "../schemas/site.schema.js";
-import { appendVersionQuery } from "./asset-version.js";
+import { appendVersionQuery, createContentVersion } from "./asset-version.js";
 
 const rasterExtensions = new Set([".jpg", ".jpeg", ".png", ".webp", ".avif", ".gif"]);
 const svgExtension = ".svg";
@@ -344,25 +344,22 @@ const resolveOutputExtension = (extension: string, usage: ComponentImageUsage): 
 
 const createOutputRelativePath = (
   source: LocalImageSource,
-  sourceMtimeMs: number,
+  sourceVersion: string,
   usage: ComponentImageUsage,
   targetWidth: number,
   extension: string,
-): { relativePath: string; version: string } => {
+): string => {
   const fileHash = createHash("sha1")
     .update(imagePipelineVersion)
     .update(source.sourceProjectRelativePath)
-    .update(String(sourceMtimeMs))
+    .update(sourceVersion)
     .update(usage)
     .update(String(targetWidth))
     .digest("hex")
     .slice(0, 12);
   const fileName = `${path.basename(source.sourceProjectRelativePath, path.extname(source.sourceProjectRelativePath))}-${usage}-${targetWidth}-${fileHash}${resolveOutputExtension(extension, usage)}`;
 
-  return {
-    relativePath: path.posix.join("assets", "images", fileName),
-    version: fileHash,
-  };
+  return path.posix.join("assets", "images", fileName);
 };
 
 const createOutputHref = (pageSlug: string, outputRelativePath: string): string => {
@@ -372,6 +369,18 @@ const createOutputHref = (pageSlug: string, outputRelativePath: string): string 
 
 const createStylesheetHref = (outputRelativePath: string): string =>
   path.posix.relative("/assets", `/${outputRelativePath}`);
+
+const readOutputVersionIfExists = async (outputPath: string): Promise<string | undefined> => {
+  try {
+    return createContentVersion(await readFile(outputPath));
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return undefined;
+    }
+
+    throw error;
+  }
+};
 
 const resolveVariantDimensions = (
   sourceWidth: number | undefined,
@@ -398,30 +407,27 @@ const processLocalImageVariant = async (
   targetWidth: number,
   outDir: string,
 ): Promise<PreparedVariant> => {
-  const sourceStats = await stat(source.sourcePath);
-  const outputAsset = createOutputRelativePath(
+  const sourceBytes = await readFile(source.sourcePath);
+  const outputRelativePath = createOutputRelativePath(
     source,
-    sourceStats.mtimeMs,
+    createContentVersion(sourceBytes),
     usage,
     targetWidth,
     metadata.extension,
   );
-  const outputPath = path.join(outDir, ...outputAsset.relativePath.split("/"));
+  const outputPath = path.join(outDir, ...outputRelativePath.split("/"));
+  const existingOutputVersion = await readOutputVersionIfExists(outputPath);
+  let version = existingOutputVersion;
 
-  try {
-    await access(outputPath);
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
-      throw error;
-    }
-
+  if (version === undefined) {
     await mkdir(path.dirname(outputPath), { recursive: true });
 
+    let outputBytes: Buffer;
     if (metadata.isSvg) {
-      await copyFile(source.sourcePath, outputPath);
+      outputBytes = sourceBytes;
     } else if (metadata.isRaster) {
-      const transformer = sharp(source.sourcePath).rotate();
-      const resized = await (usage === "page-background"
+      const transformer = sharp(sourceBytes).rotate();
+      outputBytes = await (usage === "page-background"
         ? transformer
             .resize({
               fit: "inside",
@@ -452,10 +458,12 @@ const processLocalImageVariant = async (
               withoutEnlargement: true,
             })
             .toBuffer());
-      await writeBufferIfChanged(outputPath, resized);
     } else {
-      await copyFile(source.sourcePath, outputPath);
+      outputBytes = sourceBytes;
     }
+
+    await writeBufferIfChanged(outputPath, outputBytes);
+    version = createContentVersion(outputBytes);
   }
 
   const variantDimensions =
@@ -468,9 +476,9 @@ const processLocalImageVariant = async (
 
   return {
     height: variantDimensions.height,
-    href: outputAsset.relativePath,
+    href: outputRelativePath,
     outputPath,
-    version: outputAsset.version,
+    version,
     width: variantDimensions.width,
   };
 };

--- a/src/build/image-pipeline.ts
+++ b/src/build/image-pipeline.ts
@@ -12,6 +12,7 @@ import type {
   ResponsiveImageData,
 } from "../components/render-context.js";
 import type { SiteContentData } from "../schemas/site.schema.js";
+import { appendVersionQuery } from "./asset-version.js";
 
 const rasterExtensions = new Set([".jpg", ".jpeg", ".png", ".webp", ".avif", ".gif"]);
 const svgExtension = ".svg";
@@ -78,6 +79,7 @@ interface PreparedVariant {
   height?: number;
   href: string;
   outputPath: string;
+  version: string;
   width?: number;
 }
 
@@ -346,7 +348,7 @@ const createOutputRelativePath = (
   usage: ComponentImageUsage,
   targetWidth: number,
   extension: string,
-): string => {
+): { relativePath: string; version: string } => {
   const fileHash = createHash("sha1")
     .update(imagePipelineVersion)
     .update(source.sourceProjectRelativePath)
@@ -357,7 +359,10 @@ const createOutputRelativePath = (
     .slice(0, 12);
   const fileName = `${path.basename(source.sourceProjectRelativePath, path.extname(source.sourceProjectRelativePath))}-${usage}-${targetWidth}-${fileHash}${resolveOutputExtension(extension, usage)}`;
 
-  return path.posix.join("assets", "images", fileName);
+  return {
+    relativePath: path.posix.join("assets", "images", fileName),
+    version: fileHash,
+  };
 };
 
 const createOutputHref = (pageSlug: string, outputRelativePath: string): string => {
@@ -394,14 +399,14 @@ const processLocalImageVariant = async (
   outDir: string,
 ): Promise<PreparedVariant> => {
   const sourceStats = await stat(source.sourcePath);
-  const outputRelativePath = createOutputRelativePath(
+  const outputAsset = createOutputRelativePath(
     source,
     sourceStats.mtimeMs,
     usage,
     targetWidth,
     metadata.extension,
   );
-  const outputPath = path.join(outDir, ...outputRelativePath.split("/"));
+  const outputPath = path.join(outDir, ...outputAsset.relativePath.split("/"));
 
   try {
     await access(outputPath);
@@ -463,8 +468,9 @@ const processLocalImageVariant = async (
 
   return {
     height: variantDimensions.height,
-    href: outputRelativePath,
+    href: outputAsset.relativePath,
     outputPath,
+    version: outputAsset.version,
     width: variantDimensions.width,
   };
 };
@@ -613,7 +619,9 @@ export const prepareImagePipeline = async (
         createPreparedVariantKey(sourceHref, "page-social", usageOutputWidths["page-social"]),
       );
 
-      return preparedVariant?.href ?? sourceHref;
+      return preparedVariant
+        ? appendVersionQuery(preparedVariant.href, preparedVariant.version)
+        : sourceHref;
     },
     resolveStylesheetImageHref: (sourceHref) => {
       const preparedVariant = preparedVariants.get(
@@ -624,18 +632,21 @@ export const prepareImagePipeline = async (
         return sourceHref;
       }
 
-      return createStylesheetHref(preparedVariant.href);
+      return appendVersionQuery(createStylesheetHref(preparedVariant.href), preparedVariant.version);
     },
     renderContextForPage: (pageSlug) => ({
       resolveImage: (image, usage) => {
         const usageTargetWidths = getUsageTargetWidths(usage);
         const baseTargetWidth = usageTargetWidths[usageTargetWidths.length - 1];
+        const preparedVariant = preparedVariants.get(
+          createPreparedVariantKey(image.src, usage, baseTargetWidth),
+        );
         const resolved = resolvePreparedVariant(image, usage, baseTargetWidth);
 
         return {
           ...resolved,
-          src: preparedVariants.has(createPreparedVariantKey(image.src, usage, baseTargetWidth))
-            ? createOutputHref(pageSlug, resolved.src)
+          src: preparedVariant
+            ? appendVersionQuery(createOutputHref(pageSlug, resolved.src), preparedVariant.version)
             : resolved.src,
         };
       },
@@ -643,17 +654,26 @@ export const prepareImagePipeline = async (
         const thumbnailUsage = galleryColumnUsage[columns];
         const thumbnailWidth = usageOutputWidths[thumbnailUsage];
         const fullWidth = usageOutputWidths["gallery-full"];
+        const thumbnailPreparedVariant = preparedVariants.get(
+          createPreparedVariantKey(image.src, thumbnailUsage, thumbnailWidth),
+        );
+        const fullPreparedVariant = preparedVariants.get(
+          createPreparedVariantKey(image.src, "gallery-full", fullWidth),
+        );
         const thumbnail = resolvePreparedVariant(image, thumbnailUsage, thumbnailWidth);
         const full = resolvePreparedVariant(image, "gallery-full", fullWidth);
 
         return {
-          src: preparedVariants.has(createPreparedVariantKey(image.src, thumbnailUsage, thumbnailWidth))
-            ? createOutputHref(pageSlug, thumbnail.src)
+          src: thumbnailPreparedVariant
+            ? appendVersionQuery(
+                createOutputHref(pageSlug, thumbnail.src),
+                thumbnailPreparedVariant.version,
+              )
             : thumbnail.src,
           width: thumbnail.width,
           height: thumbnail.height,
-          fullSrc: preparedVariants.has(createPreparedVariantKey(image.src, "gallery-full", fullWidth))
-            ? createOutputHref(pageSlug, full.src)
+          fullSrc: fullPreparedVariant
+            ? appendVersionQuery(createOutputHref(pageSlug, full.src), fullPreparedVariant.version)
             : full.src,
           fullWidth: full.width,
           fullHeight: full.height,
@@ -670,8 +690,9 @@ export const prepareImagePipeline = async (
         const variants = targetWidths
           .flatMap((targetWidth) => {
             const variantKey = createPreparedVariantKey(image.src, usage, targetWidth);
+            const preparedVariant = preparedVariants.get(variantKey);
 
-            if (!preparedVariants.has(variantKey)) {
+            if (!preparedVariant) {
               return [];
             }
 
@@ -680,7 +701,10 @@ export const prepareImagePipeline = async (
             return [
               {
                 ...resolved,
-                src: createOutputHref(pageSlug, resolved.src),
+                src: appendVersionQuery(
+                  createOutputHref(pageSlug, resolved.src),
+                  preparedVariant.version,
+                ),
               },
             ];
           })

--- a/tests/78th-street-studios-example.test.ts
+++ b/tests/78th-street-studios-example.test.ts
@@ -57,7 +57,7 @@ describe("78th Street Studios example", () => {
         aboutHtml.indexOf("Contact 78th Street Studios"),
       );
       expect(homeHtml).toContain('data-theme="workshop"');
-      expect(homeHtml).toContain('<script src="assets/site.js" defer></script>');
+      expect(homeHtml).toContain('<script src="assets/site.js?v=');
       expect(css).toContain('--font-heading: "Source Serif 4", serif;');
       expect(css).toContain("--color-scheme: light;");
       expect(css).toContain("--primary: #c3512f;");

--- a/tests/baird-automotive-example.test.ts
+++ b/tests/baird-automotive-example.test.ts
@@ -76,7 +76,7 @@ describe("Baird Automotive example", () => {
       );
 
       expect(homeHtml).toContain('data-theme="corporate"');
-      expect(homeHtml).toContain('<script src="assets/site.js" defer></script>');
+      expect(homeHtml).toContain('<script src="assets/site.js?v=');
       expect(css).toContain('--font-heading: "IBM Plex Sans", "Helvetica Neue", sans-serif;');
       expect(css).toContain("--primary: #0f172a;");
       expect(css).toContain("--accent: #2563eb;");

--- a/tests/build-output.test.ts
+++ b/tests/build-output.test.ts
@@ -1,4 +1,5 @@
 import { access, mkdir, mkdtemp, readFile, readdir, rm, stat, writeFile } from "node:fs/promises";
+import { createHash } from "node:crypto";
 import os from "node:os";
 import path from "node:path";
 
@@ -70,6 +71,9 @@ const createNoisyPngBytes = (width: number, height: number): Promise<Buffer> => 
     .png()
     .toBuffer();
 };
+
+const createExpectedContentVersion = (contents: string | Uint8Array): string =>
+  createHash("sha1").update(contents).digest("hex").slice(0, 12);
 
 const createWebpBytes = (width: number, height: number): Promise<Buffer> =>
   sharp({
@@ -239,6 +243,28 @@ describe("buildSite output writes", () => {
       expect(secondBuild.filesRemoved).toBe(2);
       await expect(access(path.join(outDir, "assets", "site.js"))).rejects.toThrow();
       await expect(access(path.join(outDir, "about", "index.html"))).rejects.toThrow();
+    } finally {
+      await removeDirectory(outDir);
+    }
+  });
+
+  it("uses rendered CSS and JavaScript content hashes in asset query strings", async () => {
+    const outDir = await mkdtemp(path.join(os.tmpdir(), "cruftless-build-asset-versions-"));
+
+    try {
+      await buildSite(createScriptedSite(), outDir);
+
+      const css = await readFile(path.join(outDir, "assets", "site.css"), "utf8");
+      const js = await readFile(path.join(outDir, "assets", "site.js"), "utf8");
+      const homeHtml = await readFile(path.join(outDir, "index.html"), "utf8");
+      const aboutHtml = await readFile(path.join(outDir, "about", "index.html"), "utf8");
+      const cssVersion = createExpectedContentVersion(css);
+      const jsVersion = createExpectedContentVersion(js);
+
+      expect(homeHtml).toContain(`<link rel="stylesheet" href="assets/site.css?v=${cssVersion}" />`);
+      expect(homeHtml).toContain(`<script src="assets/site.js?v=${jsVersion}" defer></script>`);
+      expect(aboutHtml).toContain(`<link rel="stylesheet" href="../assets/site.css?v=${cssVersion}" />`);
+      expect(aboutHtml).toContain(`<script src="../assets/site.js?v=${jsVersion}" defer></script>`);
     } finally {
       await removeDirectory(outDir);
     }
@@ -435,16 +461,17 @@ describe("buildSite output writes", () => {
       const firstBuild = await buildSite(await loadValidatedSite(contentPath), outDir, { contentPath });
       const optimizedPreviewDir = path.join(outDir, "assets", "images");
       const optimizedPreviewName = (await readdir(optimizedPreviewDir)).find((name) =>
-        name.startsWith("local-preview-media-wide-"),
+        name.startsWith("local-preview-media-wide-1152-"),
       );
       if (!optimizedPreviewName) {
         throw new Error("missing optimized preview image");
       }
       const optimizedPreviewPath = path.join(optimizedPreviewDir, optimizedPreviewName);
       const html = await readFile(path.join(outDir, "index.html"), "utf8");
+      const optimizedPreviewVersion = createExpectedContentVersion(await readFile(optimizedPreviewPath));
 
       expect(firstBuild.filesCreated).toBeGreaterThan(0);
-      expect(html).toContain(`src="assets/images/${optimizedPreviewName}?v=`);
+      expect(html).toContain(`src="assets/images/${optimizedPreviewName}?v=${optimizedPreviewVersion}"`);
       expect(html).toContain("srcset=\"assets/images/local-preview-media-wide-480-");
       expect(html).toContain("sizes=\"(min-width: 1184px) 1152px, calc(100vw - 3rem)\"");
 
@@ -584,7 +611,9 @@ describe("buildSite output writes", () => {
       const css = await readFile(path.join(outDir, "assets", "site.css"), "utf8");
       const optimizedPreviewDir = path.join(outDir, "assets", "images");
       const optimizedImageNames = await readdir(optimizedPreviewDir);
-      const mediaOutputName = optimizedImageNames.find((name) => name.startsWith("landing-page-media-wide-"));
+      const mediaOutputName = optimizedImageNames.find((name) =>
+        name.startsWith("landing-page-media-wide-1152-"),
+      );
       const optimizedPreviewName = optimizedImageNames.find((name) =>
         name.startsWith("landing-page-page-background-2400-"),
       );
@@ -601,17 +630,25 @@ describe("buildSite output writes", () => {
         throw new Error("missing optimized social image");
       }
 
+      const mediaVersion = createExpectedContentVersion(
+        await readFile(path.join(optimizedPreviewDir, mediaOutputName)),
+      );
+      const previewVersion = createExpectedContentVersion(await readFile(optimizedPreviewPath));
+      const socialVersion = createExpectedContentVersion(
+        await readFile(path.join(optimizedPreviewDir, socialImageName)),
+      );
+
       expect((await stat(optimizedPreviewPath)).size).toBeLessThan(previewImageBytes.length);
-      expect(nestedHtml).toContain(`src="../assets/images/${mediaOutputName}?v=`);
+      expect(nestedHtml).toContain(`src="../assets/images/${mediaOutputName}?v=${mediaVersion}"`);
       expect(nestedHtml).toContain("srcset=\"../assets/images/landing-page-media-wide-480-");
       expect(nestedHtml).toContain("sizes=\"(min-width: 1184px) 1152px, calc(100vw - 3rem)\"");
       expect(nestedHtml).toContain(
-        `<meta property="og:image" content="https://launchkit.example/assets/images/${socialImageName}?v=`,
+        `<meta property="og:image" content="https://launchkit.example/assets/images/${socialImageName}?v=${socialVersion}" />`,
       );
       expect(nestedHtml).toContain(
-        `<meta name="twitter:image" content="https://launchkit.example/assets/images/${socialImageName}?v=`,
+        `<meta name="twitter:image" content="https://launchkit.example/assets/images/${socialImageName}?v=${socialVersion}" />`,
       );
-      expect(css).toContain(`url("images/${optimizedPreviewName}?v=`);
+      expect(css).toContain(`url("images/${optimizedPreviewName}?v=${previewVersion}")`);
       await expect(access(path.join(outDir, "images", "landing-page.png"))).rejects.toThrow();
     } finally {
       await removeDirectory(projectRoot);

--- a/tests/build-output.test.ts
+++ b/tests/build-output.test.ts
@@ -444,7 +444,7 @@ describe("buildSite output writes", () => {
       const html = await readFile(path.join(outDir, "index.html"), "utf8");
 
       expect(firstBuild.filesCreated).toBeGreaterThan(0);
-      expect(html).toContain(`src="assets/images/${optimizedPreviewName}"`);
+      expect(html).toContain(`src="assets/images/${optimizedPreviewName}?v=`);
       expect(html).toContain("srcset=\"assets/images/local-preview-media-wide-480-");
       expect(html).toContain("sizes=\"(min-width: 1184px) 1152px, calc(100vw - 3rem)\"");
 
@@ -602,16 +602,16 @@ describe("buildSite output writes", () => {
       }
 
       expect((await stat(optimizedPreviewPath)).size).toBeLessThan(previewImageBytes.length);
-      expect(nestedHtml).toContain(`src="../assets/images/${mediaOutputName}"`);
+      expect(nestedHtml).toContain(`src="../assets/images/${mediaOutputName}?v=`);
       expect(nestedHtml).toContain("srcset=\"../assets/images/landing-page-media-wide-480-");
       expect(nestedHtml).toContain("sizes=\"(min-width: 1184px) 1152px, calc(100vw - 3rem)\"");
       expect(nestedHtml).toContain(
-        `<meta property="og:image" content="https://launchkit.example/assets/images/${socialImageName}" />`,
+        `<meta property="og:image" content="https://launchkit.example/assets/images/${socialImageName}?v=`,
       );
       expect(nestedHtml).toContain(
-        `<meta name="twitter:image" content="https://launchkit.example/assets/images/${socialImageName}" />`,
+        `<meta name="twitter:image" content="https://launchkit.example/assets/images/${socialImageName}?v=`,
       );
-      expect(css).toContain(`url("images/${optimizedPreviewName}")`);
+      expect(css).toContain(`url("images/${optimizedPreviewName}?v=`);
       await expect(access(path.join(outDir, "images", "landing-page.png"))).rejects.toThrow();
     } finally {
       await removeDirectory(projectRoot);
@@ -686,6 +686,6 @@ describe("buildSite output writes", () => {
     const optimizedBrandImagePath = path.join(optimizedBrandDir, optimizedBrandName);
 
     expect((await stat(optimizedBrandImagePath)).size).toBeLessThan(brandImageBytes.length);
-    expect(aboutHtml).toContain(`src="../assets/images/${optimizedBrandName}"`);
+    expect(aboutHtml).toContain(`src="../assets/images/${optimizedBrandName}?v=`);
   }, 15000);
 });

--- a/tests/image-pipeline.test.ts
+++ b/tests/image-pipeline.test.ts
@@ -196,10 +196,10 @@ describe("image pipeline", () => {
 
       expect(mediaOutputStats.size).toBeLessThan(sourceStats.size);
       expect(mediaOutputMetadata.width).toBe(1024);
-      expect(homeHtml).toContain(`src="assets/images/${mediaOutputName}"`);
-      expect(homeHtml).toContain(`data-gallery-full-src="assets/images/${fullOutputName}"`);
-      expect(portfolioHtml).toContain(`src="../assets/images/${thumbOutputName}"`);
-      expect(portfolioHtml).toContain(`data-gallery-full-src="../assets/images/${fullOutputName}"`);
+      expect(homeHtml).toContain(`src="assets/images/${mediaOutputName}?v=`);
+      expect(homeHtml).toContain(`data-gallery-full-src="assets/images/${fullOutputName}?v=`);
+      expect(portfolioHtml).toContain(`src="../assets/images/${thumbOutputName}?v=`);
+      expect(portfolioHtml).toContain(`data-gallery-full-src="../assets/images/${fullOutputName}?v=`);
       await expect(readdir(path.join(outDir, "images"))).rejects.toThrow();
     } finally {
       await removeDirectory(fixture.rootDir);

--- a/tests/site-layout.test.ts
+++ b/tests/site-layout.test.ts
@@ -76,14 +76,14 @@ describe("site layout", () => {
       expect(homeHtml).toContain("Shared header");
       expect(homeHtml).toContain("Launch faster");
       expect(homeHtml).toContain("Shared footer");
-      expect(homeHtml).toContain('<link rel="stylesheet" href="assets/site.css" />');
+      expect(homeHtml).toContain('<link rel="stylesheet" href="assets/site.css?v=');
       expect(homeHtml.indexOf("Shared header")).toBeLessThan(homeHtml.indexOf("Launch faster"));
       expect(homeHtml.indexOf("Launch faster")).toBeLessThan(homeHtml.indexOf("Shared footer"));
 
       expect(pricingHtml).toContain("Shared header");
       expect(pricingHtml).toContain("Pricing FAQ");
       expect(pricingHtml).toContain("Shared footer");
-      expect(pricingHtml).toContain('<link rel="stylesheet" href="../assets/site.css" />');
+      expect(pricingHtml).toContain('<link rel="stylesheet" href="../assets/site.css?v=');
       expect(pricingHtml.indexOf("Shared header")).toBeLessThan(pricingHtml.indexOf("Pricing FAQ"));
       expect(pricingHtml.indexOf("Pricing FAQ")).toBeLessThan(pricingHtml.indexOf("Shared footer"));
     } finally {
@@ -236,8 +236,8 @@ describe("site layout", () => {
       const js = await readFile(path.join(outDir, "assets", "site.js"), "utf8");
 
       expect(homeHtml).toContain('data-js="navigation-bar"');
-      expect(homeHtml).toContain('<script src="assets/site.js" defer></script>');
-      expect(pricingHtml).toContain('<script src="../assets/site.js" defer></script>');
+      expect(homeHtml).toContain('<script src="assets/site.js?v=');
+      expect(pricingHtml).toContain('<script src="../assets/site.js?v=');
       expect(homeHtml.indexOf('class="c-navbar"')).toBeLessThan(homeHtml.indexOf("Launch faster"));
       expect(pricingHtml.indexOf('class="c-navbar"')).toBeLessThan(
         pricingHtml.indexOf("Pricing FAQ"),


### PR DESCRIPTION
## Summary
- add stable `?v=` hash query params to generated stylesheet and script URLs in built HTML
- add matching query hashes to optimized local image URLs emitted in HTML, social metadata, and generated CSS
- cover the new output contract in existing build and image pipeline tests

## Validation
- npm run validate:strict

Closes #127