### PR TITLE
Fix gallery modal close timing

### DIFF
--- a/src/components/gallery/gallery.css
+++ b/src/components/gallery/gallery.css
@@ -126,6 +126,7 @@
   place-items: center;
   padding: var(--space-lg);
   background: color-mix(in srgb, var(--bg) 90%, black 10%);
+  transition-property: background;
 }
 
 .c-gallery__dialog[hidden] {

--- a/tests/image-rich-components.browser.ts
+++ b/tests/image-rich-components.browser.ts
@@ -60,19 +60,39 @@ const runBrowserRegression = async (): Promise<void> => {
       assert.ok(dialogCaption);
 
       await desktopPage.keyboard.press("Escape");
-      await assert.doesNotReject(() =>
-        desktopPage.waitForFunction(() => {
-          const gallery = document.querySelector(".c-gallery");
-          const dialog = document.querySelector(".c-gallery__dialog");
+      const closedDialogState = await desktopPage.evaluate(() => {
+        const gallery = document.querySelector(".c-gallery");
+        const dialog = document.querySelector(".c-gallery__dialog");
+        const dialogImage = document.querySelector(".c-gallery__dialog-image");
 
-          return (
-            gallery instanceof HTMLElement &&
-            dialog instanceof HTMLElement &&
-            gallery.dataset.galleryOpen === "false" &&
-            dialog.hidden
-          );
-        }),
-      );
+        if (
+          !(gallery instanceof HTMLElement) ||
+          !(dialog instanceof HTMLElement) ||
+          !(dialogImage instanceof HTMLImageElement)
+        ) {
+          throw new Error("Expected gallery dialog to be present.");
+        }
+
+        const rect = dialog.getBoundingClientRect();
+
+        return {
+          display: getComputedStyle(dialog).display,
+          galleryOpen: gallery.dataset.galleryOpen,
+          height: rect.height,
+          hidden: dialog.hidden,
+          imageSrc: dialogImage.getAttribute("src"),
+          width: rect.width,
+        };
+      });
+
+      assert.deepEqual(closedDialogState, {
+        display: "none",
+        galleryOpen: "false",
+        height: 0,
+        hidden: true,
+        imageSrc: null,
+        width: 0,
+      });
 
       const desktopMetrics = await desktopPage.evaluate(() => {
         const imageTextInner = document.querySelector(".c-image-text__inner");


### PR DESCRIPTION
## Summary
- Prevent the gallery lightbox dialog from inheriting the global display transition
- Tighten the browser regression so closing the gallery immediately removes the modal, not just the image

## Root cause
The base stylesheet applies `transition-property: all` with `transition-behavior: allow-discrete` to every element. The gallery close handler hid the dialog and cleared the image in the same event, but the dialog display change was delayed by the global discrete transition while the image source was cleared immediately.

## Validation
- `npx tsx tests/image-rich-components.browser.ts`
- `npm run validate:strict`

Closes #130