### PR TITLE
Minify dist HTML CSS and JS

### DIFF
--- a/src/build/framework.ts
+++ b/src/build/framework.ts
@@ -30,6 +30,7 @@ import {
   type PreparedImagePipeline,
   prepareImagePipeline,
 } from "./image-pipeline.js";
+import { minifyCss, minifyHtml, minifyJs } from "./minify-output.js";
 import {
   collectSiteValidationIssues,
   type ValidationIssue,
@@ -707,8 +708,9 @@ export const buildSite = async (
   const imagePipeline = options.contentPath
     ? await prepareImagePipeline(siteContent, options.contentPath, outDir)
     : undefined;
-  const css = await renderSiteCss(siteContent, imagePipeline);
-  const js = renderSiteJs(siteContent);
+  const css = await minifyCss(await renderSiteCss(siteContent, imagePipeline));
+  const renderedJs = renderSiteJs(siteContent);
+  const js = renderedJs ? await minifyJs(renderedJs) : "";
   const cssVersion = createContentVersion(css);
   const jsVersion = js ? createContentVersion(js) : undefined;
   const expectedFiles = new Set<string>();
@@ -748,17 +750,19 @@ export const buildSite = async (
     const renderContext =
       imagePipeline?.renderContextForPage(page.slug) ?? defaultComponentRenderContext;
 
-    const documentHtml = renderSitePageDocument({
-      siteContent,
-      page,
-      renderContext,
-      stylesheetHref: pageSlugToStylesheetHref(page.slug, cssVersion),
-      scriptHref: jsVersion ? pageSlugToScriptHref(page.slug, jsVersion) : undefined,
-      socialImageUrl:
-        page.metadata?.socialImageUrl && imagePipeline
-          ? imagePipeline.resolveSocialImageUrl(page.metadata.socialImageUrl)
-          : page.metadata?.socialImageUrl,
-    });
+    const documentHtml = await minifyHtml(
+      renderSitePageDocument({
+        siteContent,
+        page,
+        renderContext,
+        stylesheetHref: pageSlugToStylesheetHref(page.slug, cssVersion),
+        scriptHref: jsVersion ? pageSlugToScriptHref(page.slug, jsVersion) : undefined,
+        socialImageUrl:
+          page.metadata?.socialImageUrl && imagePipeline
+            ? imagePipeline.resolveSocialImageUrl(page.metadata.socialImageUrl)
+            : page.metadata?.socialImageUrl,
+      }),
+    );
     const outputPath = pageSlugToOutputPath(page.slug, outDir);
     await mkdir(path.dirname(outputPath), { recursive: true });
     expectedFiles.add(outputPath);

--- a/src/build/minify-output.ts
+++ b/src/build/minify-output.ts
@@ -1,0 +1,112 @@
+import { transform, type Loader } from "esbuild";
+
+const minifyWithEsbuild = async (contents: string, loader: Loader): Promise<string> => {
+  const result = await transform(contents, {
+    loader,
+    legalComments: "none",
+    minify: true,
+  });
+
+  return result.code.trim();
+};
+
+export const minifyCss = (css: string): Promise<string> => minifyWithEsbuild(css, "css");
+
+export const minifyJs = (js: string): Promise<string> => minifyWithEsbuild(js, "js");
+
+const minifyHtmlText = (text: string): string => {
+  const collapsedText = text.replaceAll(/\s+/g, " ");
+
+  return collapsedText.trim() ? collapsedText : "";
+};
+
+const minifyHtmlMarkup = (html: string): string => {
+  const withoutComments = html.replaceAll(/<!--[\s\S]*?-->/g, "");
+  const tagPattern = /<[^>]*>/g;
+  let minifiedHtml = "";
+  let lastIndex = 0;
+
+  for (const tagMatch of withoutComments.matchAll(tagPattern)) {
+    const tag = tagMatch[0];
+    const index = tagMatch.index ?? 0;
+    minifiedHtml += minifyHtmlText(withoutComments.slice(lastIndex, index));
+    minifiedHtml += tag.trim();
+    lastIndex = index + tag.length;
+  }
+
+  minifiedHtml += minifyHtmlText(withoutComments.slice(lastIndex));
+
+  return minifiedHtml;
+};
+
+const getAttributeValue = (tag: string, attributeName: string): string | undefined => {
+  const attributePattern = new RegExp(
+    `\\s${attributeName}\\s*=\\s*(?:"([^"]*)"|'([^']*)'|([^\\s>]+))`,
+    "i",
+  );
+  const attributeMatch = tag.match(attributePattern);
+
+  return attributeMatch?.[1] ?? attributeMatch?.[2] ?? attributeMatch?.[3];
+};
+
+const isJavaScriptType = (type: string | undefined): boolean =>
+  !type ||
+  [
+    "application/ecmascript",
+    "application/javascript",
+    "application/x-ecmascript",
+    "application/x-javascript",
+    "module",
+    "text/ecmascript",
+    "text/javascript",
+  ].includes(type.trim().toLowerCase());
+
+const minifyRawElementContent = async (
+  openingTag: string,
+  tagName: string,
+  contents: string,
+): Promise<string> => {
+  if (!contents.trim()) {
+    return "";
+  }
+
+  if (tagName === "style") {
+    return minifyCss(contents);
+  }
+
+  if (tagName === "script" && !getAttributeValue(openingTag, "src")) {
+    const type = getAttributeValue(openingTag, "type");
+
+    if (isJavaScriptType(type)) {
+      return minifyJs(contents);
+    }
+  }
+
+  return contents.trim();
+};
+
+export const minifyHtml = async (html: string): Promise<string> => {
+  const rawElementPattern = /(<(script|style)\b[^>]*>)([\s\S]*?)(<\/\2>)/gi;
+  let minifiedHtml = "";
+  let lastIndex = 0;
+
+  for (const rawElementMatch of html.matchAll(rawElementPattern)) {
+    const openingTag = rawElementMatch[1] ?? "";
+    const tagName = (rawElementMatch[2] ?? "").toLowerCase();
+    const contents = rawElementMatch[3] ?? "";
+    const closingTag = rawElementMatch[4] ?? "";
+    const index = rawElementMatch.index ?? 0;
+
+    minifiedHtml += minifyHtmlMarkup(html.slice(lastIndex, index));
+    minifiedHtml += `${openingTag.trim()}${await minifyRawElementContent(
+      openingTag,
+      tagName,
+      contents,
+    )}${closingTag.trim()}`;
+    lastIndex = index + rawElementMatch[0].length;
+  }
+
+  minifiedHtml += minifyHtmlMarkup(html.slice(lastIndex));
+
+  return minifiedHtml;
+};

--- a/tests/78th-street-studios-example.test.ts
+++ b/tests/78th-street-studios-example.test.ts
@@ -65,10 +65,10 @@ describe("78th Street Studios example", () => {
       expect(js).toContain("resolveNavigationBarMode");
       expect(css).toContain("--site-page-background-image:");
       expect(css).toContain(
-        "background: var(--site-page-background-image, none) center / cover no-repeat fixed, var(--theme-pattern) fixed var(--bg);",
+        "background:var(--site-page-background-image, none) center / cover no-repeat fixed,var(--theme-pattern) fixed var(--bg);",
       );
       expect(css).toContain(
-        'url("https://78thstreetstudios.com/sites/78thstreetstudios.com/files/styles/adaptive/public/media/images/background/IMG_CFD448348658-1.jpeg?itok=FLmeLmsX")',
+        "url(https://78thstreetstudios.com/sites/78thstreetstudios.com/files/styles/adaptive/public/media/images/background/IMG_CFD448348658-1.jpeg?itok=FLmeLmsX)",
       );
     } finally {
       await rm(outDir, { recursive: true, force: true });

--- a/tests/build-output.test.ts
+++ b/tests/build-output.test.ts
@@ -270,6 +270,30 @@ describe("buildSite output writes", () => {
     }
   });
 
+  it("minifies dist CSS, JavaScript, and HTML before writing asset hash references", async () => {
+    const outDir = await mkdtemp(path.join(os.tmpdir(), "cruftless-build-minified-output-"));
+
+    try {
+      await buildSite(createScriptedSite(), outDir);
+
+      const css = await readFile(path.join(outDir, "assets", "site.css"), "utf8");
+      const js = await readFile(path.join(outDir, "assets", "site.js"), "utf8");
+      const html = await readFile(path.join(outDir, "index.html"), "utf8");
+      const cssVersion = createExpectedContentVersion(css);
+      const jsVersion = createExpectedContentVersion(js);
+
+      expect(css).not.toContain("/*");
+      expect(css).not.toContain("\n");
+      expect(js).not.toContain("/*");
+      expect(js).not.toContain("\n");
+      expect(html).not.toContain("\n");
+      expect(html).toContain(`href="assets/site.css?v=${cssVersion}"`);
+      expect(html).toContain(`src="assets/site.js?v=${jsVersion}"`);
+    } finally {
+      await removeDirectory(outDir);
+    }
+  });
+
   it("preserves configured output subtrees while removing stale generated files", async () => {
     const outDir = await mkdtemp(path.join(os.tmpdir(), "cruftless-build-preserve-"));
 
@@ -304,7 +328,7 @@ describe("buildSite output writes", () => {
       expect(html).toContain(
         '<script async src="https://www.googletagmanager.com/gtag/js?id=G-TEST1234"></script>',
       );
-      expect(html).toContain(`gtag('config', "G-TEST1234");`);
+      expect(html).toContain(`gtag("config","G-TEST1234");`);
       await expect(access(path.join(outDir, "assets", "site.js"))).rejects.toThrow();
     } finally {
       await removeDirectory(outDir);
@@ -373,7 +397,7 @@ describe("buildSite output writes", () => {
       const html = await readFile(path.join(outDir, "index.html"), "utf8");
 
       expect(html).not.toContain("googletagmanager.com/gtag/js");
-      expect(html).not.toContain("gtag('config', \"G-TEST1234\");");
+      expect(html).not.toContain("gtag(\"config\",\"G-TEST1234\");");
     } finally {
       if (previousLighthouseCi === undefined) {
         delete process.env.LIGHTHOUSE_CI;
@@ -396,7 +420,7 @@ describe("buildSite output writes", () => {
       const html = await readFile(path.join(outDir, "index.html"), "utf8");
 
       expect(html).not.toContain("googletagmanager.com/gtag/js");
-      expect(html).not.toContain("gtag('config', \"G-TEST1234\");");
+      expect(html).not.toContain("gtag(\"config\",\"G-TEST1234\");");
     } finally {
       if (previousDisableAnalytics === undefined) {
         delete process.env.CRUFTLESS_DISABLE_ANALYTICS;
@@ -648,7 +672,7 @@ describe("buildSite output writes", () => {
       expect(nestedHtml).toContain(
         `<meta name="twitter:image" content="https://launchkit.example/assets/images/${socialImageName}?v=${socialVersion}" />`,
       );
-      expect(css).toContain(`url("images/${optimizedPreviewName}?v=${previewVersion}")`);
+      expect(css).toContain(`url(images/${optimizedPreviewName}?v=${previewVersion})`);
       await expect(access(path.join(outDir, "images", "landing-page.png"))).rejects.toThrow();
     } finally {
       await removeDirectory(projectRoot);


### PR DESCRIPTION
## Summary
- Minifies generated dist CSS and JavaScript before writing and hashing assets.
- Minifies generated dist HTML, including inline analytics scripts where applicable.
- Adds focused coverage for minified dist output and hash references.

Closes #129

## Validation
- npm run validate:strict