### PR TITLE
Add WCAG accessibility validation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "cruftless-site-gen": "scripts/shared-site-gen.mjs"
       },
       "devDependencies": {
+        "@axe-core/playwright": "^4.11.2",
         "@types/node": "^22.10.2",
         "ajv": "^8.18.0",
         "ajv-formats": "^3.0.1",
@@ -34,6 +35,19 @@
       },
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/@axe-core/playwright": {
+      "version": "4.11.2",
+      "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.11.2.tgz",
+      "integrity": "sha512-iP6hfNl9G0j/SEUSo8M7D80RbcDo9KRAAfDP4IT5OHB+Wm6zUHIrm8Y51BKI+Oyqduvipf9u1hcRy57zCBKzWQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "axe-core": "~4.11.3"
+      },
+      "peerDependencies": {
+        "playwright-core": ">= 1.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -132,7 +146,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -181,7 +194,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -1934,6 +1946,16 @@
         "node": ">=0.8.0"
       }
     },
+    "node_modules/axe-core": {
+      "version": "4.11.4",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.4.tgz",
+      "integrity": "sha512-KunSNx+TVpkAw/6ULfhnx+HWRecjqZGTOyquAoWHYLRSdK1tB5Ihce1ZW+UY3fj33bYAFWPu7W/GRSmmrCGuxA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -2471,7 +2493,6 @@
       "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "mdn-data": "2.27.1",
         "source-map-js": "^1.2.1"
@@ -3437,7 +3458,6 @@
       "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@keyv/serialize": "^1.1.1"
       }
@@ -3781,7 +3801,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3871,7 +3890,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -3914,7 +3932,6 @@
       "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -4003,7 +4020,6 @@
       "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4720,7 +4736,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@csstools/css-calc": "^3.1.1",
         "@csstools/css-parser-algorithms": "^4.0.0",
@@ -5013,7 +5028,6 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -5034,7 +5048,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -5143,7 +5156,6 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -5521,7 +5533,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -36,8 +36,9 @@
     "lint:ts": "tsc --noEmit",
     "test": "vitest run",
     "test:browser": "tsx tests/navigation-bar.browser.ts && tsx tests/example-previews.browser.ts && tsx tests/image-rich-components.browser.ts && tsx tests/full-height.browser.ts && tsx tests/editor-preview-flow.browser.ts && tsx tests/site-editor-flow.browser.ts",
+    "test:wcag": "tsx src/build/wcag-accessibility-ci.ts",
     "validate:dist-links": "node scripts/validate-dist-links.mjs",
-    "validate:strict": "npm run schema:check && npm run lint:ts && npm run lint:css && npm run test && npm run test:browser && npm run validate && npm run validate:example:78th && npm run validate:example:baird && npm run validate:examples && npm run build && npm run build:example:78th && npm run build:example:baird && npm run build:examples && npm run validate:dist-links",
+    "validate:strict": "npm run schema:check && npm run lint:ts && npm run lint:css && npm run test && npm run test:browser && npm run validate && npm run validate:example:78th && npm run validate:example:baird && npm run validate:examples && npm run build && npm run build:example:78th && npm run build:example:baird && npm run build:examples && npm run test:wcag && npm run validate:dist-links",
     "check": "npm run validate:strict"
   },
   "dependencies": {
@@ -45,6 +46,7 @@
     "zod": "^3.23.8"
   },
   "devDependencies": {
+    "@axe-core/playwright": "^4.11.2",
     "@types/node": "^22.10.2",
     "ajv": "^8.18.0",
     "ajv-formats": "^3.0.1",

--- a/src/build/framework.ts
+++ b/src/build/framework.ts
@@ -415,11 +415,13 @@ const renderPageBodyHtml = (
   renderContext: ComponentRenderContext = defaultComponentRenderContext,
 ): string => {
   const layoutComponents = siteContent.site.layout?.components;
+  const renderMain = (innerHtml: string): string =>
+    `<main id="main-content" class="l-page" tabindex="-1">\n${innerHtml}\n</main>`;
 
   if (!layoutComponents) {
-    return `<main class="l-page">\n${page.components
-      .map((component) => renderComponent(component, renderContext))
-      .join("\n")}\n</main>`;
+    return renderMain(
+      page.components.map((component) => renderComponent(component, renderContext)).join("\n"),
+    );
   }
 
   return layoutComponents
@@ -428,7 +430,7 @@ const renderPageBodyHtml = (
         const pageContentHtml = page.components
           .map((component) => renderComponent(component, renderContext))
           .join("\n");
-        return `<main class="l-page">\n${pageContentHtml}\n</main>`;
+        return renderMain(pageContentHtml);
       }
 
       return renderComponent(layoutComponent, renderContext);

--- a/src/build/wcag-accessibility-ci.ts
+++ b/src/build/wcag-accessibility-ci.ts
@@ -1,0 +1,109 @@
+import { existsSync } from "node:fs";
+import { readdir } from "node:fs/promises";
+import path from "node:path";
+
+import { AxeBuilder } from "@axe-core/playwright";
+import { chromium } from "playwright";
+
+import { createStaticServer } from "./static-server.js";
+
+const repoRoot = process.cwd();
+const distDir = path.join(repoRoot, "dist");
+const wcagTags = ["wcag2a", "wcag2aa", "wcag21a", "wcag21aa", "wcag22aa"];
+const maxReportedNodesPerViolation = 3;
+
+const collectHtmlFiles = async (directoryPath: string): Promise<string[]> => {
+  const entries = await readdir(directoryPath, { withFileTypes: true });
+  const nestedPaths = await Promise.all(
+    entries.map(async (entry) => {
+      const entryPath = path.join(directoryPath, entry.name);
+
+      if (entry.isDirectory()) {
+        return collectHtmlFiles(entryPath);
+      }
+
+      return entry.isFile() && entry.name.endsWith(".html") ? [entryPath] : [];
+    }),
+  );
+
+  return nestedPaths.flat();
+};
+
+const filePathToUrlPath = (filePath: string): string => {
+  const relativePath = path.relative(distDir, filePath).split(path.sep).join("/");
+  return `/${relativePath}`;
+};
+
+type AxeViolation = Awaited<ReturnType<AxeBuilder["analyze"]>>["violations"][number];
+
+const formatViolation = (pagePath: string, violation: AxeViolation): string[] => {
+  const helpUrl = violation.helpUrl ? ` (${violation.helpUrl})` : "";
+  const lines = [
+    `${pagePath}: ${violation.id} [${violation.impact ?? "unknown"}] ${violation.help}${helpUrl}`,
+  ];
+
+  violation.nodes.slice(0, maxReportedNodesPerViolation).forEach((node) => {
+    lines.push(`  - ${node.target.join(", ")}: ${node.failureSummary ?? "No failure summary."}`);
+  });
+
+  if (violation.nodes.length > maxReportedNodesPerViolation) {
+    lines.push(`  - ...and ${violation.nodes.length - maxReportedNodesPerViolation} more node(s)`);
+  }
+
+  return lines;
+};
+
+const main = async (): Promise<void> => {
+  if (!existsSync(distDir)) {
+    throw new Error(`Missing build output at ${path.relative(repoRoot, distDir)}. Run npm run build first.`);
+  }
+
+  const htmlFiles = (await collectHtmlFiles(distDir)).sort();
+
+  if (htmlFiles.length === 0) {
+    throw new Error(`No HTML files found in ${path.relative(repoRoot, distDir)}.`);
+  }
+
+  const server = await createStaticServer(distDir);
+  const browser = await chromium.launch();
+  const violations: string[] = [];
+
+  try {
+    for (const htmlFile of htmlFiles) {
+      const pagePath = filePathToUrlPath(htmlFile);
+      const context = await browser.newContext();
+      const page = await context.newPage();
+
+      try {
+        await page.goto(`${server.origin}${pagePath}`, {
+          waitUntil: "networkidle",
+        });
+
+        const results = await new AxeBuilder({ page }).withTags(wcagTags).analyze();
+        violations.push(...results.violations.flatMap((violation) => formatViolation(pagePath, violation)));
+      } finally {
+        await context.close();
+      }
+    }
+  } finally {
+    await browser.close();
+    await server.close();
+  }
+
+  if (violations.length > 0) {
+    throw new Error(`WCAG accessibility checks failed:\n- ${violations.join("\n- ")}`);
+  }
+
+  console.log(`WCAG accessibility checks passed for ${htmlFiles.length} page(s).`);
+};
+
+try {
+  await main();
+} catch (error) {
+  if (error instanceof Error) {
+    console.error(error.message);
+    process.exit(1);
+  }
+
+  throw error;
+}

--- a/src/components/contact/contact.render.ts
+++ b/src/components/contact/contact.render.ts
@@ -19,18 +19,19 @@ const renderMultilineAddress = (address: string): string =>
   escapeHtml(address.trim()).replace(/\r?\n/g, "<br />");
 
 const renderContactItem = (label: string, valueHtml: string, href?: string): string => {
-  const tag = href ? "a" : "div";
-  const hrefAttr = href ? ` href="${escapeHtml(href)}"` : "";
   const classes = ["c-contact__item", "l-item"];
   if (href) {
     classes.push("c-contact__item--link");
   }
+  const renderedValue = href
+    ? `<a class="c-contact__link" href="${escapeHtml(href)}">${valueHtml}</a>`
+    : valueHtml;
 
   return [
-    `      <${tag} class="${classes.join(" ")}"${hrefAttr}>`,
+    `      <div class="${classes.join(" ")}">`,
     `        <dt class="c-contact__label">${escapeHtml(label)}</dt>`,
-    `        <dd class="c-contact__value">${valueHtml}</dd>`,
-    `      </${tag}>`,
+    `        <dd class="c-contact__value">${renderedValue}</dd>`,
+    "      </div>",
   ].join("\n");
 };
 

--- a/src/renderer/render-page.ts
+++ b/src/renderer/render-page.ts
@@ -90,6 +90,7 @@ export const renderPageDocument = ({
     scriptHref ? `    <script src="${escapeHtml(scriptHref)}" defer></script>` : "",
     "  </head>",
     `  <body data-theme="${escapeHtml(site.theme)}">`,
+    '    <a class="skip-link" href="#main-content">Skip to content</a>',
     indent(bodyHtml),
     "  </body>",
     "</html>",

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -37,22 +37,36 @@ body {
 
 .skip-link {
   position: fixed;
-  top: var(--space-sm);
-  left: var(--space-sm);
+  top: 0;
+  left: 0;
   z-index: 1000;
-  transform: translateY(calc(-100% - var(--space-md)));
-  padding: var(--space-xs) var(--space-sm);
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  overflow: hidden;
   border-radius: var(--radius);
   background: var(--text);
   color: var(--bg);
   font-family: var(--font-heading);
   font-weight: 700;
   text-decoration: none;
+  white-space: nowrap;
+  opacity: 0;
+  transform: translate(-100%, -100%);
+  transition-property: opacity, transform;
 }
 
+.skip-link:focus,
 .skip-link:focus-visible {
-  transform: translateY(0);
+  top: var(--space-sm);
+  left: var(--space-sm);
+  width: auto;
+  height: auto;
+  padding: var(--space-xs) var(--space-sm);
+  overflow: visible;
   color: var(--bg);
+  opacity: 1;
+  transform: translate(0, 0);
 }
 
 h1,

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -35,6 +35,26 @@ body {
   color: var(--text);
 }
 
+.skip-link {
+  position: fixed;
+  top: var(--space-sm);
+  left: var(--space-sm);
+  z-index: 1000;
+  transform: translateY(calc(-100% - var(--space-md)));
+  padding: var(--space-xs) var(--space-sm);
+  border-radius: var(--radius);
+  background: var(--text);
+  color: var(--bg);
+  font-family: var(--font-heading);
+  font-weight: 700;
+  text-decoration: none;
+}
+
+.skip-link:focus-visible {
+  transform: translateY(0);
+  color: var(--bg);
+}
+
 h1,
 h2,
 h3,

--- a/src/themes/workshop.ts
+++ b/src/themes/workshop.ts
@@ -6,7 +6,7 @@ export const workshopTheme = createThemeDefinition(
     "--bg": "#fffbf4",
     "--text": "#2b1d12",
     "--muted": "#6b4f3b",
-    "--primary": "#c3512f",
+    "--primary": "#be4d2b",
     "--primary-fg": "#ffffff",
     "--accent": "#2f6f4e",
     "--accent-fg": "#ffffff",

--- a/tests/78th-street-studios-example.test.ts
+++ b/tests/78th-street-studios-example.test.ts
@@ -60,7 +60,7 @@ describe("78th Street Studios example", () => {
       expect(homeHtml).toContain('<script src="assets/site.js?v=');
       expect(css).toContain('--font-heading: "Source Serif 4", serif;');
       expect(css).toContain("--color-scheme: light;");
-      expect(css).toContain("--primary: #c3512f;");
+      expect(css).toContain("--primary: #be4d2b;");
       expect(css).toContain("--accent: #2f6f4e;");
       expect(js).toContain("resolveNavigationBarMode");
       expect(css).toContain("--site-page-background-image:");

--- a/tests/build-output.test.ts
+++ b/tests/build-output.test.ts
@@ -294,6 +294,21 @@ describe("buildSite output writes", () => {
     }
   });
 
+  it("renders a skip link to the main page content", async () => {
+    const outDir = await mkdtemp(path.join(os.tmpdir(), "cruftless-build-skip-link-"));
+
+    try {
+      await buildSite(createStaticSite(), outDir);
+
+      const html = await readFile(path.join(outDir, "index.html"), "utf8");
+
+      expect(html).toContain('<a class="skip-link" href="#main-content">Skip to content</a>');
+      expect(html).toContain('<main id="main-content" class="l-page" tabindex="-1">');
+    } finally {
+      await removeDirectory(outDir);
+    }
+  });
+
   it("preserves configured output subtrees while removing stale generated files", async () => {
     const outDir = await mkdtemp(path.join(os.tmpdir(), "cruftless-build-preserve-"));
 

--- a/tests/build-output.test.ts
+++ b/tests/build-output.test.ts
@@ -301,9 +301,20 @@ describe("buildSite output writes", () => {
       await buildSite(createStaticSite(), outDir);
 
       const html = await readFile(path.join(outDir, "index.html"), "utf8");
+      const css = await readFile(path.join(outDir, "assets", "site.css"), "utf8");
 
       expect(html).toContain('<a class="skip-link" href="#main-content">Skip to content</a>');
       expect(html).toContain('<main id="main-content" class="l-page" tabindex="-1">');
+      expect(css).toContain(".skip-link{");
+      expect(css).toContain("width:1px");
+      expect(css).toContain("height:1px");
+      expect(css).toContain("overflow:hidden");
+      expect(css).toContain("opacity:0");
+      expect(css).toContain("transform:translate(-100%,-100%)");
+      expect(css).toContain(".skip-link:focus,.skip-link:focus-visible{");
+      expect(css).toContain("overflow:visible");
+      expect(css).toContain("opacity:1");
+      expect(css).toContain("transform:translate(0)");
     } finally {
       await removeDirectory(outDir);
     }

--- a/tests/site-editor-flow.browser.ts
+++ b/tests/site-editor-flow.browser.ts
@@ -138,13 +138,32 @@ const runBrowserRegression = async (): Promise<void> => {
     });
     await page.locator("button", { hasText: "Pick media" }).first().click();
     await page.locator(".media-picker-item", { hasText: "images/hero image.svg" }).click();
-    await page.waitForFunction(() => {
-      const image = document.querySelector(".media-preview-image");
+    try {
+      await page.waitForFunction(() => {
+        const field = document.querySelector("[data-testid='field-pageBackgroundImageUrl']");
+        const image = document.querySelector(".media-preview-image");
 
-      return image instanceof HTMLImageElement
-        && image.currentSrc.includes("hero%20image.svg")
-        && image.naturalWidth > 0;
-    });
+        return field instanceof HTMLInputElement
+          && decodeURIComponent(field.value).includes("hero image.svg")
+          && image instanceof HTMLImageElement
+          && image.complete;
+      });
+    } catch (error) {
+      const mediaPreviewSnapshot = await page.evaluate(() => {
+        const field = document.querySelector("[data-testid='field-pageBackgroundImageUrl']");
+        const image = document.querySelector(".media-preview-image");
+
+        return {
+          fieldValue: field instanceof HTMLInputElement ? field.value : null,
+          imageComplete: image instanceof HTMLImageElement ? image.complete : null,
+          imageCurrentSrc: image instanceof HTMLImageElement ? image.currentSrc : null,
+        };
+      });
+
+      throw new Error(`Timed out waiting for selected media preview: ${JSON.stringify(mediaPreviewSnapshot)}`, {
+        cause: error,
+      });
+    }
     await page.locator("[data-testid='field-brandText']").fill("SiblingKit Nav");
     await page
       .frameLocator("[data-testid='preview-frame']")

--- a/tests/site-editor-flow.browser.ts
+++ b/tests/site-editor-flow.browser.ts
@@ -211,6 +211,12 @@ const runBrowserRegression = async (): Promise<void> => {
       .frameLocator("[data-testid='preview-frame']")
       .locator("body")
       .evaluate(() => window.scrollTo(0, 240));
+    await page.waitForFunction(() => {
+      const iframe = document.querySelector("[data-testid='preview-frame']");
+      return iframe instanceof HTMLIFrameElement
+        && iframe.contentWindow !== null
+        && iframe.contentWindow.scrollY > 0;
+    });
     const scrollPositions = await page.evaluate(() => {
       const editorPanel = document.querySelector(".editor-panel");
 


### PR DESCRIPTION
## Summary
- add a Playwright/axe WCAG A/AA scan for built dist HTML and include it in validate:strict
- add a global skip link/main-content target to generated pages
- fix generated contact description-list markup and darken the workshop primary color to clear AA contrast
- make the editor media-preview browser assertion wait on the selected field value and completed preview image
- make the editor preview scroll assertion wait until the frame has actually scrolled

Closes #133

## Validation
- npm run validate:strict