### PR TITLE
Fix narrow desktop navbar menu

### DIFF
--- a/src/components/navigation-bar/navigation-bar.runtime.test.ts
+++ b/src/components/navigation-bar/navigation-bar.runtime.test.ts
@@ -109,6 +109,7 @@ class FakeDocument {
 
 class FakeWindow {
   readonly listeners = new Map<string, Array<() => void>>();
+  matchesNarrowViewport = false;
 
   getComputedStyle(): { columnGap: string; gap: string } {
     return {
@@ -121,6 +122,13 @@ class FakeWindow {
     const listeners = this.listeners.get(eventName) ?? [];
     listeners.push(listener);
     this.listeners.set(eventName, listeners);
+  }
+
+  matchMedia(query: string): { matches: boolean; media: string } {
+    return {
+      matches: query === "(max-width: 40rem)" && this.matchesNarrowViewport,
+      media: query,
+    };
   }
 }
 
@@ -253,5 +261,42 @@ describe("resolveNavigationBarMode", () => {
     expect(navbar.dataset.navigationBarOpen).toBe("false");
     expect(panel.hidden).toBe(true);
     expect(button.getAttribute("aria-expanded")).toBe("false");
+  });
+
+  it("opens the menu when the CSS narrow-viewport breakpoint forces the button visible", () => {
+    FakeResizeObserver.instances = [];
+
+    const { button, document, navbar, panel, row, window } = createNavigationBarFixture();
+    const runNavigationRuntime = new Function(
+      "document",
+      "window",
+      "ResizeObserver",
+      "HTMLElement",
+      "HTMLButtonElement",
+      navigationBarRuntimeScript,
+    );
+
+    row.clientWidth = 760;
+    window.matchesNarrowViewport = true;
+
+    runNavigationRuntime(
+      document,
+      window,
+      FakeResizeObserver,
+      FakeElement,
+      FakeButtonElement,
+    );
+
+    document.readyState = "complete";
+    document.dispatchEvent("DOMContentLoaded");
+
+    expect(navbar.dataset.navigationBarMode).toBe("collapsed");
+    expect(panel.hidden).toBe(true);
+
+    button.dispatchEvent("click");
+
+    expect(navbar.dataset.navigationBarOpen).toBe("true");
+    expect(panel.hidden).toBe(false);
+    expect(button.getAttribute("aria-expanded")).toBe("true");
   });
 });

--- a/src/components/navigation-bar/navigation-bar.runtime.ts
+++ b/src/components/navigation-bar/navigation-bar.runtime.ts
@@ -48,6 +48,9 @@ const resolveNavigationBarMode = ({ containerWidth, brandingWidth, navWidth, gap
 const setupNavigationBarsSource = /* JavaScript */ `
 const setupNavigationBars = () => {
   const navbars = document.querySelectorAll(".c-navbar[data-js='navigation-bar']");
+  const narrowViewportQuery = "(max-width: 40rem)";
+  const isNarrowViewport = () =>
+    typeof window.matchMedia === "function" && window.matchMedia(narrowViewportQuery).matches;
 
   navbars.forEach((navbar) => {
     if (!(navbar instanceof HTMLElement)) {
@@ -86,12 +89,14 @@ const setupNavigationBars = () => {
       const gap = Number.parseFloat(styles.columnGap || styles.gap || "0");
       const brandingWidth = brand instanceof HTMLElement ? brand.getBoundingClientRect().width : 0;
       const navWidth = measure.scrollWidth;
-      const mode = resolveNavigationBarMode({
-        containerWidth: row.clientWidth,
-        brandingWidth,
-        navWidth,
-        gap,
-      });
+      const mode = isNarrowViewport()
+        ? "collapsed"
+        : resolveNavigationBarMode({
+            containerWidth: row.clientWidth,
+            brandingWidth,
+            navWidth,
+            gap,
+          });
 
       navbar.dataset.navigationBarMode = mode;
 


### PR DESCRIPTION
## Summary
- force navbar collapsed mode when the same narrow viewport breakpoint as the CSS menu button is active
- keep measured inline/collapsed behavior for wider viewports
- add a regression test covering a narrow viewport where links would otherwise measure as fitting inline

## Tests
- cmd /c npx vitest run src/components/navigation-bar/navigation-bar.runtime.test.ts
- cmd /c npm run lint:ts