### PR TITLE
Add hero background image support

### DIFF
--- a/schemas/site-content.schema.json
+++ b/schemas/site-content.schema.json
@@ -703,6 +703,32 @@
                                   "center"
                                 ],
                                 "default": "start"
+                              },
+                              "backgroundImage": {
+                                "type": "object",
+                                "properties": {
+                                  "src": {
+                                    "type": "string",
+                                    "minLength": 1,
+                                    "maxLength": 2048
+                                  },
+                                  "alt": {
+                                    "type": "string",
+                                    "minLength": 1,
+                                    "maxLength": 200
+                                  },
+                                  "position": {
+                                    "type": "string",
+                                    "minLength": 1,
+                                    "maxLength": 80,
+                                    "pattern": "^[a-z0-9% .-]+$",
+                                    "default": "center"
+                                  }
+                                },
+                                "required": [
+                                  "src"
+                                ],
+                                "additionalProperties": false
                               }
                             },
                             "required": [

--- a/src/build/image-pipeline.ts
+++ b/src/build/image-pipeline.ts
@@ -26,6 +26,7 @@ const usageOutputWidths: Record<ComponentImageUsage, number> = {
   "gallery-thumb-2": 720,
   "gallery-thumb-3": 560,
   "gallery-thumb-4": 420,
+  "hero-background": 2400,
   "image-text": 1200,
   "page-background": 2400,
   "page-social": 1200,
@@ -275,6 +276,11 @@ const collectImageUsages = (
           addUsage([...pathSegments, "images", imageIndex], image.src, "gallery-full");
         });
         return;
+      case "hero":
+        if (component.backgroundImage) {
+          addUsage([...pathSegments, "backgroundImage"], component.backgroundImage.src, "hero-background");
+        }
+        return;
       case "image-text":
         addUsage([...pathSegments, "image"], component.image.src, "image-text");
         return;
@@ -331,7 +337,12 @@ const collectImageUsages = (
 };
 
 const resolveOutputExtension = (extension: string, usage: ComponentImageUsage): string => {
-  if (usage === "page-background" || usage === "media-content" || usage === "media-wide") {
+  if (
+    usage === "page-background" ||
+    usage === "hero-background" ||
+    usage === "media-content" ||
+    usage === "media-wide"
+  ) {
     return ".avif";
   }
 
@@ -427,7 +438,7 @@ const processLocalImageVariant = async (
       outputBytes = sourceBytes;
     } else if (metadata.isRaster) {
       const transformer = sharp(sourceBytes).rotate();
-      outputBytes = await (usage === "page-background"
+      outputBytes = await (usage === "page-background" || usage === "hero-background"
         ? transformer
             .resize({
               fit: "inside",

--- a/src/components/hero/hero.css
+++ b/src/components/hero/hero.css
@@ -6,6 +6,12 @@
   text-align: left;
 }
 
+.c-hero--has-background {
+  overflow: hidden;
+  min-height: clamp(28rem, 62vh, 46rem);
+  color: #fff;
+}
+
 .c-hero--align-center {
   text-align: center;
 }
@@ -38,6 +44,10 @@
   color: var(--muted);
   max-width: 54rem;
   line-height: 1.4;
+}
+
+.c-hero--has-background .c-hero__subheadline {
+  color: rgb(255 255 255 / 88%);
 }
 
 .c-hero__actions {

--- a/src/components/hero/hero.render.ts
+++ b/src/components/hero/hero.render.ts
@@ -1,8 +1,19 @@
 import type { HeroData } from "./hero.schema.js";
 import { escapeHtml } from "../../renderer/escape-html.js";
+import {
+  defaultComponentRenderContext,
+  type ComponentRenderContext,
+} from "../render-context.js";
+
+const escapeCssSingleQuotedString = (value: string): string =>
+  value
+    .replace(/\\/gu, "\\\\")
+    .replace(/'/gu, "\\'")
+    .replace(/[\n\r\f]/gu, "");
 
 export const heroClassNames = [
   "c-hero",
+  "c-hero--has-background",
   "c-hero--align-start",
   "c-hero--align-center",
   "c-hero__body",
@@ -11,10 +22,31 @@ export const heroClassNames = [
   "c-hero__actions",
 ] as const;
 
-export const renderHero = (data: HeroData): string => {
+export const renderHero = (
+  data: HeroData,
+  renderContext: ComponentRenderContext = defaultComponentRenderContext,
+): string => {
   const ctas = [data.primaryCta, data.secondaryCta].filter(
     (cta): cta is NonNullable<typeof cta> => Boolean(cta),
   );
+  const className = [
+    "c-hero",
+    "l-container",
+    "l-section",
+    "l-section--hero",
+    `c-hero--align-${escapeHtml(data.align)}`,
+    data.backgroundImage ? "c-hero--has-background" : "",
+  ]
+    .filter(Boolean)
+    .join(" ");
+  const resolvedBackgroundImage = data.backgroundImage
+    ? renderContext.resolveImage(data.backgroundImage, "hero-background")
+    : undefined;
+  const backgroundStyle = data.backgroundImage && resolvedBackgroundImage
+    ? ` style="background-image: linear-gradient(90deg, rgb(0 0 0 / 72%), rgb(0 0 0 / 38%) 54%, rgb(0 0 0 / 18%)), url('${escapeHtml(
+        escapeCssSingleQuotedString(resolvedBackgroundImage.src),
+      )}'); background-position: center, ${escapeHtml(data.backgroundImage.position)}; background-size: auto, cover; background-repeat: no-repeat;"`
+    : "";
 
   const actionHtml = ctas
     .map((cta, index) => {
@@ -27,7 +59,7 @@ export const renderHero = (data: HeroData): string => {
     .join("");
 
   return [
-    `<section class="c-hero l-container l-section l-section--hero c-hero--align-${escapeHtml(data.align)}">`,
+    `<section class="${className}"${backgroundStyle}>`,
     '  <div class="c-hero__body">',
     `    <h1 class="c-hero__headline">${escapeHtml(data.headline)}</h1>`,
     data.subheadline

--- a/src/components/hero/hero.schema.ts
+++ b/src/components/hero/hero.schema.ts
@@ -2,6 +2,19 @@ import { z } from "zod";
 
 import { LinkSchema } from "../../schemas/shared.js";
 
+export const HeroBackgroundImageSchema = z
+  .object({
+    src: z.string().min(1).max(2048),
+    alt: z.string().min(1).max(200).optional(),
+    position: z
+      .string()
+      .min(1)
+      .max(80)
+      .regex(/^[a-z0-9% .-]+$/iu, "position must be a safe CSS background-position value")
+      .default("center"),
+  })
+  .strict();
+
 export const HeroSchemaBase = z
   .object({
     type: z.literal("hero"),
@@ -10,6 +23,7 @@ export const HeroSchemaBase = z
     primaryCta: LinkSchema.optional(),
     secondaryCta: LinkSchema.optional(),
     align: z.enum(["start", "center"]).default("start"),
+    backgroundImage: HeroBackgroundImageSchema.optional(),
   })
   .strict();
 

--- a/src/components/hero/hero.test.ts
+++ b/src/components/hero/hero.test.ts
@@ -26,6 +26,73 @@ describe("HeroSchema", () => {
     expect(html).not.toContain("<faster>");
   });
 
+  it("renders an optional background image on the hero section", () => {
+    const parsed = HeroSchema.parse({
+      type: "hero",
+      headline: "Built for custom rooms",
+      primaryCta: {
+        label: "Call now",
+        href: "tel:+15555555555",
+      },
+      backgroundImage: {
+        src: "/content/images/generated-hero.png",
+        alt: "Custom woodworking bench",
+        position: "center 35%",
+      },
+    });
+
+    const html = renderHero(parsed);
+
+    expect(html).toContain("c-hero--has-background");
+    expect(html).toContain("url('/content/images/generated-hero.png')");
+    expect(html).toContain("background-position: center, center 35%");
+    expect(html).not.toContain("Custom woodworking bench");
+  });
+
+  it("resolves background image paths through the render context", () => {
+    const parsed = HeroSchema.parse({
+      type: "hero",
+      headline: "Built for custom rooms",
+      primaryCta: {
+        label: "Call now",
+        href: "tel:+15555555555",
+      },
+      backgroundImage: {
+        src: "/content/images/generated-hero.png",
+      },
+    });
+
+    const html = renderHero(parsed, {
+      resolveImage: () => ({
+        src: "assets/images/generated-hero-hero-background-2400.avif?v=1234",
+      }),
+      resolveGalleryImage: () => ({
+        src: "",
+      }),
+    });
+
+    expect(html).toContain(
+      "url('assets/images/generated-hero-hero-background-2400.avif?v=1234')",
+    );
+  });
+
+  it("rejects unsafe background positioning", () => {
+    const parsed = HeroSchema.safeParse({
+      type: "hero",
+      headline: "Built for custom rooms",
+      primaryCta: {
+        label: "Call now",
+        href: "tel:+15555555555",
+      },
+      backgroundImage: {
+        src: "/content/images/generated-hero.png",
+        position: "center; color: red",
+      },
+    });
+
+    expect(parsed.success).toBe(false);
+  });
+
   it("rejects unknown fields and missing CTAs", () => {
     const extraField = HeroSchema.safeParse({
       type: "hero",

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -212,7 +212,7 @@ export const componentDefinitions: readonly ComponentDefinition[] = [
   },
   {
     type: "hero",
-    render: (data) => renderHero(HeroSchema.parse(data)),
+    render: (data, renderContext) => renderHero(HeroSchema.parse(data), renderContext),
     cssPath: fileURLToPath(new URL("./hero/hero.css", import.meta.url)),
     classNames: heroClassNames,
   },
@@ -297,7 +297,7 @@ export const renderComponent = (
     case "google-maps":
       return renderGoogleMaps(data);
     case "hero":
-      return renderHero(data);
+      return renderHero(data, renderContext);
     case "hours":
       return renderHours(data);
     case "image-text":

--- a/src/components/render-context.ts
+++ b/src/components/render-context.ts
@@ -8,6 +8,7 @@ export const componentImageUsageNames = [
   "gallery-thumb-2",
   "gallery-thumb-3",
   "gallery-thumb-4",
+  "hero-background",
   "image-text",
   "page-background",
   "page-social",


### PR DESCRIPTION
## Summary
- add optional hero backgroundImage schema support
- render hero backgrounds inline with page-relative localized asset URLs
- collect hero background images in the image pipeline and generated schema

## Verification
- npm run test -- src/components/hero/hero.test.ts tests/site-json-schema.test.ts
- npm run lint:ts
- npm run lint:css
- npm run schema:check