### PR TITLE
Add hero background foreground variables

### DIFF
--- a/src/components/hero/hero.css
+++ b/src/components/hero/hero.css
@@ -9,7 +9,7 @@
 .c-hero--has-background {
   overflow: hidden;
   min-height: clamp(28rem, 62vh, 46rem);
-  color: #fff;
+  color: var(--hero-background-fg, #fff);
 }
 
 .c-hero--align-center {
@@ -47,7 +47,11 @@
 }
 
 .c-hero--has-background .c-hero__subheadline {
-  color: rgb(255 255 255 / 88%);
+  color: var(--hero-background-muted-fg, rgb(255 255 255 / 88%));
+}
+
+.c-hero--has-background .c-hero__headline {
+  color: var(--hero-background-fg, #fff);
 }
 
 .c-hero__actions {

--- a/src/themes/theme-validation.test.ts
+++ b/src/themes/theme-validation.test.ts
@@ -71,6 +71,11 @@ describe("theme validation", () => {
         ".demo { background-image: var(--site-page-background-image, none); }",
       ),
     ).toEqual([]);
+    expect(
+      findUnknownCssVarTokens(
+        ".demo { color: var(--hero-background-fg, #fff); }",
+      ),
+    ).toEqual([]);
   });
 
   it("rejects theme CSS that references unknown tokens", () => {

--- a/src/validation/theme-validation.ts
+++ b/src/validation/theme-validation.ts
@@ -5,7 +5,7 @@ import { assertExactThemeTokens, themeTokenSet } from "../themes/tokens.js";
 import type { ValidationIssue } from "./site-validation.js";
 
 const CSS_VAR_PATTERN = /var\((--[a-z0-9-]+)/gi;
-const ALLOWED_NON_THEME_CSS_VAR_PREFIXES = ["--site-"] as const;
+const ALLOWED_NON_THEME_CSS_VAR_PREFIXES = ["--site-", "--hero-"] as const;
 const DECLARATION_PATTERN = /^\s*([a-z-]+|--[a-z0-9-]+)\s*:\s*(.*)$/i;
 const DISALLOWED_CSS_PROPERTIES = new Set([
   "float",


### PR DESCRIPTION
## Summary
- make background hero headline color explicit
- expose hero foreground CSS variables with white defaults
- allow --hero-* component variables in CSS token validation

## Verification
- npm run test -- src/themes/theme-validation.test.ts src/components/hero/hero.test.ts
- npm run lint:css
- npm run lint:ts