### PR TITLE
Use header and footer layout components

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The current approach is to keep the authoring surface small and explicit:
 - real site migrations are treated as the proving ground, so components need to cover practical brochure-site patterns instead of abstract examples
 - themes control more than color tokens, so changing the theme can materially change spacing, typography, surfaces, and visual rhythm
 - visually rich and narrative-heavy pages are modeled with structured components such as `media`, `image-text`, `gallery`, and `prose`
-- repeated site chrome belongs in shared layout components, with `page-content` marking where each page's own sections render
+- repeated site chrome belongs in shared header and footer layout components that wrap each page's own sections
 - location-driven sites can use first-class contact, hours, store-location-hours, and Google Maps components
 - JSON Schema output keeps editing ergonomic in VS Code while preserving strict validation at build time
 
@@ -38,11 +38,9 @@ Every site file has two top-level sections:
 
 ### Shared layout
 
-If `site.layout.components` is present, those components wrap every page. One item in that layout can be:
+If `site.layout.headerComponents` or `site.layout.footerComponents` are present, those components wrap every page. Header components render before the page's own `components` array, and footer components render after it. This lets the repo reuse navigation, shared prose, calls to action, or footer content across every page without copying them into each page object.
 
-- `{ "type": "page-content" }`
-
-That slot is where each page's own `components` array is inserted. This lets the repo reuse headers, nav, shared prose, or footers across every page without copying them into each page object.
+Older content may still use `site.layout.components` with a `{ "type": "page-content" }` slot. The generator continues to read that legacy shape so existing sites can be migrated deliberately.
 
 ### Google Analytics
 
@@ -109,10 +107,10 @@ This is the rough shape of a site file:
       "companyName": "LaunchKit"
     },
     "layout": {
-      "components": [
-        { "type": "navigation-bar", "brandText": "LaunchKit", "links": [] },
-        { "type": "page-content" }
-      ]
+      "headerComponents": [
+        { "type": "navigation-bar", "brandText": "LaunchKit", "links": [] }
+      ],
+      "footerComponents": []
     }
   },
   "pages": [
@@ -345,7 +343,7 @@ If you change the schema, component registry, theme tokens, renderer behavior, o
 - `src/themes/`: theme definitions and theme CSS emission
 - `src/build/`: CLI entrypoints for build, validation, examples, and schema generation
 - `src/schemas/`: Zod schemas and JSON Schema generation helpers
-- `src/layout/`: shared layout logic, including the `page-content` slot
+- `src/layout/`: shared layout logic for site-level header and footer components, plus legacy `page-content` slot support
 - `tests/`: repo-level tests
 - `docs/`: supporting prompts and workflow docs
 - `reports/`: write-ups from migration experiments and mapping work

--- a/content/examples/78th-street-studios.json
+++ b/content/examples/78th-street-studios.json
@@ -5,7 +5,7 @@
     "theme": "workshop",
     "pageBackgroundImageUrl": "https://78thstreetstudios.com/sites/78thstreetstudios.com/files/styles/adaptive/public/media/images/background/IMG_CFD448348658-1.jpeg?itok=FLmeLmsX",
     "layout": {
-      "components": [
+      "headerComponents": [
         {
           "type": "navigation-bar",
           "brandText": "78th Street Studios",
@@ -35,10 +35,9 @@
           "paragraphs": [
             "Use About for the building story, Art Tours for guided visits, Maps for directions, Rent Space for private events, and Press for coverage."
           ]
-        },
-        {
-          "type": "page-content"
-        },
+        }
+      ],
+      "footerComponents": [
         {
           "type": "cta-band",
           "headline": "Third Fridays return on Friday, April 17, 2026",

--- a/content/examples/baird-automotive.json
+++ b/content/examples/baird-automotive.json
@@ -4,7 +4,7 @@
     "baseUrl": "https://www.bairdautomotive.com",
     "theme": "corporate",
     "layout": {
-      "components": [
+      "headerComponents": [
         {
           "type": "navigation-bar",
           "brandText": "Baird Automotive",
@@ -30,10 +30,9 @@
               "href": "/baird-automotive/contact"
             }
           ]
-        },
-        {
-          "type": "page-content"
-        },
+        }
+      ],
+      "footerComponents": [
         {
           "type": "cta-band",
           "headline": "Book service or plan your visit",

--- a/content/examples/themes/brutalism.json
+++ b/content/examples/themes/brutalism.json
@@ -4,7 +4,7 @@
     "baseUrl": "https://example.com/examples/brutalism/",
     "theme": "brutalism",
     "layout": {
-      "components": [
+      "headerComponents": [
         {
           "type": "navigation-bar",
           "brandText": "Brutalism",
@@ -30,10 +30,9 @@
           "paragraphs": [
             "Use the shared layout wrapper to verify how global sections look in the brutalism theme."
           ]
-        },
-        {
-          "type": "page-content"
-        },
+        }
+      ],
+      "footerComponents": [
         {
           "type": "prose",
           "title": "Shared theme footer",

--- a/content/examples/themes/corporate.json
+++ b/content/examples/themes/corporate.json
@@ -4,7 +4,7 @@
     "baseUrl": "https://example.com/examples/corporate/",
     "theme": "corporate",
     "layout": {
-      "components": [
+      "headerComponents": [
         {
           "type": "navigation-bar",
           "brandText": "Corporate",
@@ -30,10 +30,9 @@
           "paragraphs": [
             "Use the shared layout wrapper to verify how global sections look in the corporate theme."
           ]
-        },
-        {
-          "type": "page-content"
-        },
+        }
+      ],
+      "footerComponents": [
         {
           "type": "prose",
           "title": "Shared theme footer",

--- a/content/examples/themes/dark-mode-professional.json
+++ b/content/examples/themes/dark-mode-professional.json
@@ -4,7 +4,7 @@
     "baseUrl": "https://example.com/examples/dark-mode-professional/",
     "theme": "dark-mode-professional",
     "layout": {
-      "components": [
+      "headerComponents": [
         {
           "type": "navigation-bar",
           "brandText": "Dark Mode Professional",
@@ -30,10 +30,9 @@
           "paragraphs": [
             "Use the shared layout wrapper to verify how global sections look in the dark-mode-professional theme."
           ]
-        },
-        {
-          "type": "page-content"
-        },
+        }
+      ],
+      "footerComponents": [
         {
           "type": "prose",
           "title": "Shared theme footer",

--- a/content/examples/themes/friendly-modern.json
+++ b/content/examples/themes/friendly-modern.json
@@ -4,7 +4,7 @@
     "baseUrl": "https://example.com/examples/friendly-modern/",
     "theme": "friendly-modern",
     "layout": {
-      "components": [
+      "headerComponents": [
         {
           "type": "navigation-bar",
           "brandText": "Friendly Modern",
@@ -30,10 +30,9 @@
           "paragraphs": [
             "Use the shared layout wrapper to verify how global sections look in the friendly-modern theme."
           ]
-        },
-        {
-          "type": "page-content"
-        },
+        }
+      ],
+      "footerComponents": [
         {
           "type": "prose",
           "title": "Shared theme footer",

--- a/content/examples/themes/heritage-local.json
+++ b/content/examples/themes/heritage-local.json
@@ -4,7 +4,7 @@
     "baseUrl": "https://example.com/examples/heritage-local/",
     "theme": "heritage-local",
     "layout": {
-      "components": [
+      "headerComponents": [
         {
           "type": "navigation-bar",
           "brandText": "Heritage Local",
@@ -30,10 +30,9 @@
           "paragraphs": [
             "Use the shared layout wrapper to verify how global sections look in the heritage-local theme."
           ]
-        },
-        {
-          "type": "page-content"
-        },
+        }
+      ],
+      "footerComponents": [
         {
           "type": "prose",
           "title": "Shared theme footer",

--- a/content/examples/themes/high-vis-service.json
+++ b/content/examples/themes/high-vis-service.json
@@ -4,7 +4,7 @@
     "baseUrl": "https://example.com/examples/high-vis-service/",
     "theme": "high-vis-service",
     "layout": {
-      "components": [
+      "headerComponents": [
         {
           "type": "navigation-bar",
           "brandText": "High-Vis Service",
@@ -30,10 +30,9 @@
           "paragraphs": [
             "Use the shared layout wrapper to verify how global sections look in the high-vis-service theme."
           ]
-        },
-        {
-          "type": "page-content"
-        },
+        }
+      ],
+      "footerComponents": [
         {
           "type": "prose",
           "title": "Shared theme footer",

--- a/content/examples/themes/index.json
+++ b/content/examples/themes/index.json
@@ -4,7 +4,7 @@
     "baseUrl": "https://example.com/examples/",
     "theme": "corporate",
     "layout": {
-      "components": [
+      "headerComponents": [
         {
           "type": "navigation-bar",
           "brandText": "Theme Previews",
@@ -22,11 +22,9 @@
               "href": "/examples/"
             }
           ]
-        },
-        {
-          "type": "page-content"
         }
-      ]
+      ],
+      "footerComponents": []
     }
   },
   "pages": [

--- a/content/examples/themes/wellness-calm.json
+++ b/content/examples/themes/wellness-calm.json
@@ -4,7 +4,7 @@
     "baseUrl": "https://example.com/examples/wellness-calm/",
     "theme": "wellness-calm",
     "layout": {
-      "components": [
+      "headerComponents": [
         {
           "type": "navigation-bar",
           "brandText": "Wellness Calm",
@@ -30,10 +30,9 @@
           "paragraphs": [
             "Use the shared layout wrapper to verify how global sections look in the wellness-calm theme."
           ]
-        },
-        {
-          "type": "page-content"
-        },
+        }
+      ],
+      "footerComponents": [
         {
           "type": "prose",
           "title": "Shared theme footer",

--- a/content/examples/themes/workshop.json
+++ b/content/examples/themes/workshop.json
@@ -4,7 +4,7 @@
     "baseUrl": "https://example.com/examples/workshop/",
     "theme": "workshop",
     "layout": {
-      "components": [
+      "headerComponents": [
         {
           "type": "navigation-bar",
           "brandText": "Workshop",
@@ -30,10 +30,9 @@
           "paragraphs": [
             "Use the shared layout wrapper to verify how global sections look in the workshop theme."
           ]
-        },
-        {
-          "type": "page-content"
-        },
+        }
+      ],
+      "footerComponents": [
         {
           "type": "prose",
           "title": "Shared theme footer",

--- a/content/site.json
+++ b/content/site.json
@@ -4,7 +4,7 @@
     "baseUrl": "https://launchkit.example",
     "theme": "brutalism",
     "layout": {
-      "components": [
+      "headerComponents": [
         {
           "type": "navigation-bar",
           "brandText": "LaunchKit",
@@ -26,10 +26,9 @@
           "paragraphs": [
             "Start each page with the same clear promise, navigation, and brand voice."
           ]
-        },
-        {
-          "type": "page-content"
-        },
+        }
+      ],
+      "footerComponents": [
         {
           "type": "prose",
           "title": "Shared site footer",

--- a/schemas/site-content.schema.json
+++ b/schemas/site-content.schema.json
@@ -232,641 +232,30 @@
             "layout": {
               "type": "object",
               "properties": {
-                "components": {
+                "headerComponents": {
                   "type": "array",
                   "items": {
                     "anyOf": [
                       {
-                        "anyOf": [
-                          {
-                            "type": "object",
-                            "properties": {
-                              "type": {
-                                "type": "string",
-                                "const": "before-after"
-                              },
-                              "title": {
-                                "type": "string",
-                                "minLength": 1,
-                                "maxLength": 120
-                              },
-                              "lead": {
-                                "type": "string",
-                                "minLength": 1,
-                                "maxLength": 280
-                              },
-                              "before": {
-                                "type": "object",
-                                "properties": {
-                                  "src": {
-                                    "type": "string",
-                                    "minLength": 1,
-                                    "maxLength": 2048
-                                  },
-                                  "alt": {
-                                    "type": "string",
-                                    "minLength": 1,
-                                    "maxLength": 200
-                                  },
-                                  "caption": {
-                                    "type": "string",
-                                    "minLength": 1,
-                                    "maxLength": 280
-                                  },
-                                  "width": {
-                                    "type": "integer",
-                                    "exclusiveMinimum": 0,
-                                    "maximum": 10000
-                                  },
-                                  "height": {
-                                    "type": "integer",
-                                    "exclusiveMinimum": 0,
-                                    "maximum": 10000
-                                  },
-                                  "label": {
-                                    "type": "string",
-                                    "minLength": 1,
-                                    "maxLength": 40
-                                  }
-                                },
-                                "required": [
-                                  "src",
-                                  "alt",
-                                  "label"
-                                ],
-                                "additionalProperties": false
-                              },
-                              "after": {
-                                "$ref": "#/definitions/SiteContent/properties/site/properties/layout/properties/components/items/anyOf/0/anyOf/0/properties/before"
-                              }
-                            },
-                            "required": [
-                              "type",
-                              "title",
-                              "before",
-                              "after"
-                            ],
-                            "additionalProperties": false
+                        "type": "object",
+                        "properties": {
+                          "type": {
+                            "type": "string",
+                            "const": "before-after"
                           },
-                          {
-                            "type": "object",
-                            "properties": {
-                              "type": {
-                                "type": "string",
-                                "const": "contact"
-                              },
-                              "title": {
-                                "type": "string",
-                                "minLength": 1,
-                                "maxLength": 120
-                              },
-                              "address": {
-                                "type": "string",
-                                "minLength": 1,
-                                "maxLength": 280
-                              },
-                              "phone": {
-                                "type": "string",
-                                "minLength": 7,
-                                "maxLength": 40
-                              },
-                              "email": {
-                                "type": "string",
-                                "format": "email",
-                                "maxLength": 254
-                              }
-                            },
-                            "required": [
-                              "type",
-                              "address"
-                            ],
-                            "additionalProperties": false
+                          "title": {
+                            "type": "string",
+                            "minLength": 1,
+                            "maxLength": 120
                           },
-                          {
-                            "type": "object",
-                            "properties": {
-                              "type": {
-                                "type": "string",
-                                "const": "contact-form"
-                              },
-                              "mode": {
-                                "type": "string",
-                                "enum": [
-                                  "production",
-                                  "demo"
-                                ]
-                              },
-                              "title": {
-                                "type": "string",
-                                "minLength": 1,
-                                "maxLength": 120
-                              },
-                              "intro": {
-                                "type": "string",
-                                "minLength": 1,
-                                "maxLength": 280
-                              },
-                              "action": {
-                                "type": "string",
-                                "minLength": 1,
-                                "maxLength": 2048
-                              },
-                              "submitLabel": {
-                                "type": "string",
-                                "minLength": 1,
-                                "maxLength": 40
-                              },
-                              "subject": {
-                                "type": "string",
-                                "minLength": 1,
-                                "maxLength": 120
-                              },
-                              "deliveryNote": {
-                                "type": "string",
-                                "minLength": 1,
-                                "maxLength": 200
-                              }
-                            },
-                            "required": [
-                              "type",
-                              "mode",
-                              "title",
-                              "action",
-                              "submitLabel"
-                            ],
-                            "additionalProperties": false
+                          "lead": {
+                            "type": "string",
+                            "minLength": 1,
+                            "maxLength": 280
                           },
-                          {
+                          "before": {
                             "type": "object",
                             "properties": {
-                              "type": {
-                                "type": "string",
-                                "const": "cta-band"
-                              },
-                              "headline": {
-                                "type": "string",
-                                "minLength": 1,
-                                "maxLength": 120
-                              },
-                              "body": {
-                                "type": "string",
-                                "minLength": 1,
-                                "maxLength": 240
-                              },
-                              "primaryCta": {
-                                "type": "object",
-                                "properties": {
-                                  "label": {
-                                    "type": "string",
-                                    "minLength": 1
-                                  },
-                                  "href": {
-                                    "type": "string",
-                                    "minLength": 1,
-                                    "maxLength": 2048,
-                                    "pattern": "^(?:(?:https?|ftp):\\/\\/[^/?#\\s<>\"`]+(?:[/?#][^\\s<>\"`]*)?|mailto:[^\\s<>\"`?#]+(?:\\?[^\\s<>\"`]*)?|tel:\\+?[0-9A-Za-z().-]+(?:;[A-Za-z0-9-]+=[^;\\s<>\"`]*)*|sms:\\+?[0-9A-Za-z().-]+(?:\\?[^\\s<>\"`]*)?|(?!(?:(?:https?|ftp|mailto|tel|sms|javascript|data|vbscript):))[a-z][a-z0-9+.-]*:[^\\s<>\"`]+|\\/\\/[^/?#\\s<>\"`]+(?:[/?#][^\\s<>\"`]*)?|\\/(?!\\/)[^\\s<>\"`]*|\\.{1,2}\\/[^\\s<>\"`]*|[#?][^\\s<>\"`]*)$"
-                                  },
-                                  "target": {
-                                    "type": "string",
-                                    "enum": [
-                                      "_self",
-                                      "_blank"
-                                    ]
-                                  }
-                                },
-                                "required": [
-                                  "label",
-                                  "href"
-                                ],
-                                "additionalProperties": false
-                              },
-                              "secondaryCta": {
-                                "$ref": "#/definitions/SiteContent/properties/site/properties/layout/properties/components/items/anyOf/0/anyOf/3/properties/primaryCta"
-                              }
-                            },
-                            "required": [
-                              "type",
-                              "headline",
-                              "primaryCta"
-                            ],
-                            "additionalProperties": false
-                          },
-                          {
-                            "type": "object",
-                            "properties": {
-                              "type": {
-                                "type": "string",
-                                "const": "faq"
-                              },
-                              "title": {
-                                "type": "string",
-                                "minLength": 1,
-                                "maxLength": 120
-                              },
-                              "items": {
-                                "type": "array",
-                                "items": {
-                                  "type": "object",
-                                  "properties": {
-                                    "question": {
-                                      "type": "string",
-                                      "minLength": 1,
-                                      "maxLength": 140
-                                    },
-                                    "answer": {
-                                      "type": "string",
-                                      "minLength": 1,
-                                      "maxLength": 320
-                                    }
-                                  },
-                                  "required": [
-                                    "question",
-                                    "answer"
-                                  ],
-                                  "additionalProperties": false
-                                },
-                                "minItems": 1,
-                                "maxItems": 8
-                              }
-                            },
-                            "required": [
-                              "type",
-                              "title",
-                              "items"
-                            ],
-                            "additionalProperties": false
-                          },
-                          {
-                            "type": "object",
-                            "properties": {
-                              "type": {
-                                "type": "string",
-                                "const": "feature-grid"
-                              },
-                              "title": {
-                                "type": "string",
-                                "minLength": 1,
-                                "maxLength": 120
-                              },
-                              "lead": {
-                                "type": "string",
-                                "minLength": 1,
-                                "maxLength": 280
-                              },
-                              "columns": {
-                                "type": "string",
-                                "enum": [
-                                  "1",
-                                  "2",
-                                  "3",
-                                  "4"
-                                ],
-                                "default": "3"
-                              },
-                              "items": {
-                                "type": "array",
-                                "items": {
-                                  "type": "object",
-                                  "properties": {
-                                    "title": {
-                                      "type": "string",
-                                      "minLength": 1,
-                                      "maxLength": 120
-                                    },
-                                    "body": {
-                                      "type": "string",
-                                      "minLength": 1,
-                                      "maxLength": 320
-                                    },
-                                    "image": {
-                                      "type": "object",
-                                      "properties": {
-                                        "src": {
-                                          "$ref": "#/definitions/SiteContent/properties/site/properties/layout/properties/components/items/anyOf/0/anyOf/0/properties/before/properties/src"
-                                        },
-                                        "alt": {
-                                          "$ref": "#/definitions/SiteContent/properties/site/properties/layout/properties/components/items/anyOf/0/anyOf/0/properties/before/properties/alt"
-                                        },
-                                        "caption": {
-                                          "$ref": "#/definitions/SiteContent/properties/site/properties/layout/properties/components/items/anyOf/0/anyOf/0/properties/before/properties/caption"
-                                        },
-                                        "width": {
-                                          "$ref": "#/definitions/SiteContent/properties/site/properties/layout/properties/components/items/anyOf/0/anyOf/0/properties/before/properties/width"
-                                        },
-                                        "height": {
-                                          "$ref": "#/definitions/SiteContent/properties/site/properties/layout/properties/components/items/anyOf/0/anyOf/0/properties/before/properties/height"
-                                        }
-                                      },
-                                      "required": [
-                                        "src",
-                                        "alt"
-                                      ],
-                                      "additionalProperties": false
-                                    },
-                                    "imageLayout": {
-                                      "type": "string",
-                                      "enum": [
-                                        "inline",
-                                        "stacked"
-                                      ]
-                                    },
-                                    "cta": {
-                                      "$ref": "#/definitions/SiteContent/properties/site/properties/layout/properties/components/items/anyOf/0/anyOf/3/properties/primaryCta"
-                                    },
-                                    "selected": {
-                                      "type": "boolean"
-                                    }
-                                  },
-                                  "required": [
-                                    "title"
-                                  ],
-                                  "additionalProperties": false
-                                },
-                                "minItems": 1,
-                                "maxItems": 99
-                              }
-                            },
-                            "required": [
-                              "type",
-                              "title",
-                              "items"
-                            ],
-                            "additionalProperties": false
-                          },
-                          {
-                            "type": "object",
-                            "properties": {
-                              "type": {
-                                "type": "string",
-                                "const": "gallery"
-                              },
-                              "title": {
-                                "type": "string",
-                                "minLength": 1,
-                                "maxLength": 120
-                              },
-                              "lead": {
-                                "type": "string",
-                                "minLength": 1,
-                                "maxLength": 280
-                              },
-                              "columns": {
-                                "type": "string",
-                                "enum": [
-                                  "2",
-                                  "3",
-                                  "4"
-                                ],
-                                "default": "3"
-                              },
-                              "images": {
-                                "type": "array",
-                                "items": {
-                                  "$ref": "#/definitions/SiteContent/properties/site/properties/layout/properties/components/items/anyOf/0/anyOf/5/properties/items/items/properties/image"
-                                },
-                                "minItems": 2,
-                                "maxItems": 24
-                              }
-                            },
-                            "required": [
-                              "type",
-                              "title",
-                              "images"
-                            ],
-                            "additionalProperties": false
-                          },
-                          {
-                            "type": "object",
-                            "properties": {
-                              "type": {
-                                "type": "string",
-                                "const": "google-maps"
-                              },
-                              "embedUrl": {
-                                "type": "string",
-                                "format": "uri",
-                                "maxLength": 2048
-                              },
-                              "title": {
-                                "type": "string",
-                                "minLength": 1,
-                                "maxLength": 120
-                              },
-                              "caption": {
-                                "type": "string",
-                                "minLength": 1,
-                                "maxLength": 280
-                              },
-                              "size": {
-                                "type": "string",
-                                "enum": [
-                                  "content",
-                                  "wide"
-                                ],
-                                "default": "wide"
-                              }
-                            },
-                            "required": [
-                              "type",
-                              "embedUrl",
-                              "title"
-                            ],
-                            "additionalProperties": false
-                          },
-                          {
-                            "type": "object",
-                            "properties": {
-                              "type": {
-                                "type": "string",
-                                "const": "hero"
-                              },
-                              "headline": {
-                                "type": "string",
-                                "minLength": 1,
-                                "maxLength": 120
-                              },
-                              "subheadline": {
-                                "type": "string",
-                                "minLength": 1,
-                                "maxLength": 240
-                              },
-                              "primaryCta": {
-                                "$ref": "#/definitions/SiteContent/properties/site/properties/layout/properties/components/items/anyOf/0/anyOf/3/properties/primaryCta"
-                              },
-                              "secondaryCta": {
-                                "$ref": "#/definitions/SiteContent/properties/site/properties/layout/properties/components/items/anyOf/0/anyOf/3/properties/primaryCta"
-                              },
-                              "align": {
-                                "type": "string",
-                                "enum": [
-                                  "start",
-                                  "center"
-                                ],
-                                "default": "start"
-                              },
-                              "backgroundImage": {
-                                "type": "object",
-                                "properties": {
-                                  "src": {
-                                    "type": "string",
-                                    "minLength": 1,
-                                    "maxLength": 2048
-                                  },
-                                  "alt": {
-                                    "type": "string",
-                                    "minLength": 1,
-                                    "maxLength": 200
-                                  },
-                                  "position": {
-                                    "type": "string",
-                                    "minLength": 1,
-                                    "maxLength": 80,
-                                    "pattern": "^[a-z0-9% .-]+$",
-                                    "default": "center"
-                                  }
-                                },
-                                "required": [
-                                  "src"
-                                ],
-                                "additionalProperties": false
-                              }
-                            },
-                            "required": [
-                              "type",
-                              "headline"
-                            ],
-                            "additionalProperties": false,
-                            "anyOf": [
-                              {
-                                "required": [
-                                  "primaryCta"
-                                ]
-                              },
-                              {
-                                "required": [
-                                  "secondaryCta"
-                                ]
-                              }
-                            ]
-                          },
-                          {
-                            "type": "object",
-                            "properties": {
-                              "type": {
-                                "type": "string",
-                                "const": "hours"
-                              },
-                              "title": {
-                                "type": "string",
-                                "minLength": 1,
-                                "maxLength": 120
-                              },
-                              "entries": {
-                                "type": "array",
-                                "items": {
-                                  "type": "object",
-                                  "properties": {
-                                    "day": {
-                                      "type": "string",
-                                      "enum": [
-                                        "Monday",
-                                        "Tuesday",
-                                        "Wednesday",
-                                        "Thursday",
-                                        "Friday",
-                                        "Saturday",
-                                        "Sunday",
-                                        "Holiday",
-                                        "Holidays",
-                                        "Emergency Service"
-                                      ]
-                                    },
-                                    "open": {
-                                      "type": "string",
-                                      "pattern": "(?:0?[1-9]|1[0-2])(?::[0-5]\\d)?\\s?(?:AM|PM)|Closed"
-                                    },
-                                    "close": {
-                                      "type": "string",
-                                      "pattern": "(?:0?[1-9]|1[0-2])(?::[0-5]\\d)?\\s?(?:AM|PM)|Closed"
-                                    }
-                                  },
-                                  "required": [
-                                    "day",
-                                    "open",
-                                    "close"
-                                  ],
-                                  "additionalProperties": false
-                                },
-                                "minItems": 1,
-                                "maxItems": 16
-                              }
-                            },
-                            "required": [
-                              "type",
-                              "entries"
-                            ],
-                            "additionalProperties": false
-                          },
-                          {
-                            "type": "object",
-                            "properties": {
-                              "type": {
-                                "type": "string",
-                                "const": "image-text"
-                              },
-                              "eyebrow": {
-                                "type": "string",
-                                "minLength": 1,
-                                "maxLength": 40
-                              },
-                              "title": {
-                                "type": "string",
-                                "minLength": 1,
-                                "maxLength": 120
-                              },
-                              "paragraphs": {
-                                "type": "array",
-                                "items": {
-                                  "type": "string",
-                                  "minLength": 1,
-                                  "maxLength": 600
-                                },
-                                "minItems": 1,
-                                "maxItems": 4
-                              },
-                              "image": {
-                                "$ref": "#/definitions/SiteContent/properties/site/properties/layout/properties/components/items/anyOf/0/anyOf/5/properties/items/items/properties/image"
-                              },
-                              "imagePosition": {
-                                "type": "string",
-                                "enum": [
-                                  "start",
-                                  "end"
-                                ],
-                                "default": "end"
-                              },
-                              "primaryCta": {
-                                "$ref": "#/definitions/SiteContent/properties/site/properties/layout/properties/components/items/anyOf/0/anyOf/3/properties/primaryCta"
-                              },
-                              "secondaryCta": {
-                                "$ref": "#/definitions/SiteContent/properties/site/properties/layout/properties/components/items/anyOf/0/anyOf/3/properties/primaryCta"
-                              }
-                            },
-                            "required": [
-                              "type",
-                              "title",
-                              "paragraphs",
-                              "image"
-                            ],
-                            "additionalProperties": false
-                          },
-                          {
-                            "type": "object",
-                            "properties": {
-                              "type": {
-                                "type": "string",
-                                "const": "media"
-                              },
                               "src": {
                                 "type": "string",
                                 "minLength": 1,
@@ -874,19 +263,13 @@
                               },
                               "alt": {
                                 "type": "string",
+                                "minLength": 1,
                                 "maxLength": 200
                               },
                               "caption": {
                                 "type": "string",
                                 "minLength": 1,
                                 "maxLength": 280
-                              },
-                              "loading": {
-                                "type": "string",
-                                "enum": [
-                                  "eager",
-                                  "lazy"
-                                ]
                               },
                               "width": {
                                 "type": "integer",
@@ -898,67 +281,278 @@
                                 "exclusiveMinimum": 0,
                                 "maximum": 10000
                               },
-                              "size": {
+                              "label": {
                                 "type": "string",
-                                "enum": [
-                                  "content",
-                                  "wide"
-                                ],
-                                "default": "wide"
+                                "minLength": 1,
+                                "maxLength": 40
                               }
                             },
                             "required": [
-                              "type",
-                              "src"
+                              "src",
+                              "alt",
+                              "label"
                             ],
                             "additionalProperties": false
                           },
-                          {
+                          "after": {
+                            "$ref": "#/definitions/SiteContent/properties/site/properties/layout/properties/headerComponents/items/anyOf/0/properties/before"
+                          }
+                        },
+                        "required": [
+                          "type",
+                          "title",
+                          "before",
+                          "after"
+                        ],
+                        "additionalProperties": false
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "type": {
+                            "type": "string",
+                            "const": "contact"
+                          },
+                          "title": {
+                            "type": "string",
+                            "minLength": 1,
+                            "maxLength": 120
+                          },
+                          "address": {
+                            "type": "string",
+                            "minLength": 1,
+                            "maxLength": 280
+                          },
+                          "phone": {
+                            "type": "string",
+                            "minLength": 7,
+                            "maxLength": 40
+                          },
+                          "email": {
+                            "type": "string",
+                            "format": "email",
+                            "maxLength": 254
+                          }
+                        },
+                        "required": [
+                          "type",
+                          "address"
+                        ],
+                        "additionalProperties": false
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "type": {
+                            "type": "string",
+                            "const": "contact-form"
+                          },
+                          "mode": {
+                            "type": "string",
+                            "enum": [
+                              "production",
+                              "demo"
+                            ]
+                          },
+                          "title": {
+                            "type": "string",
+                            "minLength": 1,
+                            "maxLength": 120
+                          },
+                          "intro": {
+                            "type": "string",
+                            "minLength": 1,
+                            "maxLength": 280
+                          },
+                          "action": {
+                            "type": "string",
+                            "minLength": 1,
+                            "maxLength": 2048
+                          },
+                          "submitLabel": {
+                            "type": "string",
+                            "minLength": 1,
+                            "maxLength": 40
+                          },
+                          "subject": {
+                            "type": "string",
+                            "minLength": 1,
+                            "maxLength": 120
+                          },
+                          "deliveryNote": {
+                            "type": "string",
+                            "minLength": 1,
+                            "maxLength": 200
+                          }
+                        },
+                        "required": [
+                          "type",
+                          "mode",
+                          "title",
+                          "action",
+                          "submitLabel"
+                        ],
+                        "additionalProperties": false
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "type": {
+                            "type": "string",
+                            "const": "cta-band"
+                          },
+                          "headline": {
+                            "type": "string",
+                            "minLength": 1,
+                            "maxLength": 120
+                          },
+                          "body": {
+                            "type": "string",
+                            "minLength": 1,
+                            "maxLength": 240
+                          },
+                          "primaryCta": {
                             "type": "object",
                             "properties": {
-                              "type": {
+                              "label": {
                                 "type": "string",
-                                "const": "logo-strip"
+                                "minLength": 1
                               },
-                              "title": {
-                                "type": "string",
-                                "minLength": 1,
-                                "maxLength": 120
-                              },
-                              "lead": {
+                              "href": {
                                 "type": "string",
                                 "minLength": 1,
-                                "maxLength": 280
+                                "maxLength": 2048,
+                                "pattern": "^(?:(?:https?|ftp):\\/\\/[^/?#\\s<>\"`]+(?:[/?#][^\\s<>\"`]*)?|mailto:[^\\s<>\"`?#]+(?:\\?[^\\s<>\"`]*)?|tel:\\+?[0-9A-Za-z().-]+(?:;[A-Za-z0-9-]+=[^;\\s<>\"`]*)*|sms:\\+?[0-9A-Za-z().-]+(?:\\?[^\\s<>\"`]*)?|(?!(?:(?:https?|ftp|mailto|tel|sms|javascript|data|vbscript):))[a-z][a-z0-9+.-]*:[^\\s<>\"`]+|\\/\\/[^/?#\\s<>\"`]+(?:[/?#][^\\s<>\"`]*)?|\\/(?!\\/)[^\\s<>\"`]*|\\.{1,2}\\/[^\\s<>\"`]*|[#?][^\\s<>\"`]*)$"
                               },
-                              "logos": {
-                                "type": "array",
-                                "items": {
+                              "target": {
+                                "type": "string",
+                                "enum": [
+                                  "_self",
+                                  "_blank"
+                                ]
+                              }
+                            },
+                            "required": [
+                              "label",
+                              "href"
+                            ],
+                            "additionalProperties": false
+                          },
+                          "secondaryCta": {
+                            "$ref": "#/definitions/SiteContent/properties/site/properties/layout/properties/headerComponents/items/anyOf/3/properties/primaryCta"
+                          }
+                        },
+                        "required": [
+                          "type",
+                          "headline",
+                          "primaryCta"
+                        ],
+                        "additionalProperties": false
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "type": {
+                            "type": "string",
+                            "const": "faq"
+                          },
+                          "title": {
+                            "type": "string",
+                            "minLength": 1,
+                            "maxLength": 120
+                          },
+                          "items": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "question": {
+                                  "type": "string",
+                                  "minLength": 1,
+                                  "maxLength": 140
+                                },
+                                "answer": {
+                                  "type": "string",
+                                  "minLength": 1,
+                                  "maxLength": 320
+                                }
+                              },
+                              "required": [
+                                "question",
+                                "answer"
+                              ],
+                              "additionalProperties": false
+                            },
+                            "minItems": 1,
+                            "maxItems": 8
+                          }
+                        },
+                        "required": [
+                          "type",
+                          "title",
+                          "items"
+                        ],
+                        "additionalProperties": false
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "type": {
+                            "type": "string",
+                            "const": "feature-grid"
+                          },
+                          "title": {
+                            "type": "string",
+                            "minLength": 1,
+                            "maxLength": 120
+                          },
+                          "lead": {
+                            "type": "string",
+                            "minLength": 1,
+                            "maxLength": 280
+                          },
+                          "columns": {
+                            "type": "string",
+                            "enum": [
+                              "1",
+                              "2",
+                              "3",
+                              "4"
+                            ],
+                            "default": "3"
+                          },
+                          "items": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "title": {
+                                  "type": "string",
+                                  "minLength": 1,
+                                  "maxLength": 120
+                                },
+                                "body": {
+                                  "type": "string",
+                                  "minLength": 1,
+                                  "maxLength": 320
+                                },
+                                "image": {
                                   "type": "object",
                                   "properties": {
                                     "src": {
-                                      "type": "string",
-                                      "minLength": 1,
-                                      "maxLength": 2048
+                                      "$ref": "#/definitions/SiteContent/properties/site/properties/layout/properties/headerComponents/items/anyOf/0/properties/before/properties/src"
                                     },
                                     "alt": {
-                                      "type": "string",
-                                      "minLength": 1,
-                                      "maxLength": 200
+                                      "$ref": "#/definitions/SiteContent/properties/site/properties/layout/properties/headerComponents/items/anyOf/0/properties/before/properties/alt"
                                     },
-                                    "href": {
-                                      "type": "string",
-                                      "minLength": 1,
-                                      "maxLength": 2048
+                                    "caption": {
+                                      "$ref": "#/definitions/SiteContent/properties/site/properties/layout/properties/headerComponents/items/anyOf/0/properties/before/properties/caption"
                                     },
                                     "width": {
-                                      "type": "integer",
-                                      "exclusiveMinimum": 0,
-                                      "maximum": 10000
+                                      "$ref": "#/definitions/SiteContent/properties/site/properties/layout/properties/headerComponents/items/anyOf/0/properties/before/properties/width"
                                     },
                                     "height": {
-                                      "type": "integer",
-                                      "exclusiveMinimum": 0,
-                                      "maximum": 10000
+                                      "$ref": "#/definitions/SiteContent/properties/site/properties/layout/properties/headerComponents/items/anyOf/0/properties/before/properties/height"
                                     }
                                   },
                                   "required": [
@@ -967,469 +561,189 @@
                                   ],
                                   "additionalProperties": false
                                 },
-                                "minItems": 2,
-                                "maxItems": 24
-                              }
-                            },
-                            "required": [
-                              "type",
-                              "title",
-                              "logos"
-                            ],
-                            "additionalProperties": false
-                          },
-                          {
-                            "type": "object",
-                            "properties": {
-                              "type": {
-                                "type": "string",
-                                "const": "navigation-bar"
-                              },
-                              "brandText": {
-                                "type": "string",
-                                "minLength": 1,
-                                "maxLength": 80
-                              },
-                              "brandImage": {
-                                "type": "object",
-                                "properties": {
-                                  "src": {
-                                    "type": "string",
-                                    "minLength": 1,
-                                    "maxLength": 2048
-                                  },
-                                  "alt": {
-                                    "type": "string",
-                                    "minLength": 1,
-                                    "maxLength": 200
-                                  }
-                                },
-                                "required": [
-                                  "src",
-                                  "alt"
-                                ],
-                                "additionalProperties": false
-                              },
-                              "links": {
-                                "type": "array",
-                                "items": {
-                                  "$ref": "#/definitions/SiteContent/properties/site/properties/layout/properties/components/items/anyOf/0/anyOf/3/properties/primaryCta"
-                                },
-                                "minItems": 1,
-                                "maxItems": 12
-                              }
-                            },
-                            "required": [
-                              "type",
-                              "links"
-                            ],
-                            "additionalProperties": false
-                          },
-                          {
-                            "type": "object",
-                            "properties": {
-                              "type": {
-                                "type": "string",
-                                "const": "prose"
-                              },
-                              "title": {
-                                "type": "string",
-                                "minLength": 1,
-                                "maxLength": 120
-                              },
-                              "lead": {
-                                "type": "string",
-                                "minLength": 1,
-                                "maxLength": 280
-                              },
-                              "paragraphs": {
-                                "type": "array",
-                                "items": {
+                                "imageLayout": {
                                   "type": "string",
-                                  "minLength": 1,
-                                  "maxLength": 1200
+                                  "enum": [
+                                    "inline",
+                                    "stacked"
+                                  ]
                                 },
-                                "minItems": 1,
-                                "maxItems": 12
-                              }
-                            },
-                            "required": [
-                              "type",
-                              "paragraphs"
-                            ],
-                            "additionalProperties": false
-                          },
-                          {
-                            "type": "object",
-                            "properties": {
-                              "type": {
-                                "type": "string",
-                                "const": "store-location-hours"
-                              },
-                              "title": {
-                                "type": "string",
-                                "minLength": 1,
-                                "maxLength": 120
-                              },
-                              "embedUrl": {
-                                "type": "string",
-                                "format": "uri",
-                                "maxLength": 2048
-                              },
-                              "mapTitle": {
-                                "type": "string",
-                                "minLength": 1,
-                                "maxLength": 120
-                              },
-                              "address": {
-                                "type": "string",
-                                "minLength": 1,
-                                "maxLength": 280
-                              },
-                              "phone": {
-                                "type": "string",
-                                "minLength": 7,
-                                "maxLength": 40
-                              },
-                              "email": {
-                                "type": "string",
-                                "format": "email",
-                                "maxLength": 254
-                              },
-                              "hours": {
-                                "type": "array",
-                                "items": {
-                                  "$ref": "#/definitions/SiteContent/properties/site/properties/layout/properties/components/items/anyOf/0/anyOf/9/properties/entries/items"
+                                "cta": {
+                                  "$ref": "#/definitions/SiteContent/properties/site/properties/layout/properties/headerComponents/items/anyOf/3/properties/primaryCta"
                                 },
-                                "minItems": 1,
-                                "maxItems": 16
-                              }
+                                "selected": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "title"
+                              ],
+                              "additionalProperties": false
                             },
-                            "required": [
-                              "type",
-                              "embedUrl",
-                              "mapTitle",
-                              "address",
-                              "hours"
-                            ],
-                            "additionalProperties": false
-                          },
-                          {
-                            "type": "object",
-                            "properties": {
-                              "type": {
-                                "type": "string",
-                                "const": "testimonials"
-                              },
-                              "title": {
-                                "type": "string",
-                                "minLength": 1,
-                                "maxLength": 120
-                              },
-                              "lead": {
-                                "type": "string",
-                                "minLength": 1,
-                                "maxLength": 280
-                              },
-                              "items": {
-                                "type": "array",
-                                "items": {
-                                  "type": "object",
-                                  "properties": {
-                                    "quote": {
-                                      "type": "string",
-                                      "minLength": 1,
-                                      "maxLength": 600
-                                    },
-                                    "name": {
-                                      "type": "string",
-                                      "minLength": 1,
-                                      "maxLength": 80
-                                    },
-                                    "role": {
-                                      "type": "string",
-                                      "minLength": 1,
-                                      "maxLength": 80
-                                    },
-                                    "company": {
-                                      "type": "string",
-                                      "minLength": 1,
-                                      "maxLength": 80
-                                    },
-                                    "image": {
-                                      "$ref": "#/definitions/SiteContent/properties/site/properties/layout/properties/components/items/anyOf/0/anyOf/5/properties/items/items/properties/image"
-                                    }
-                                  },
-                                  "required": [
-                                    "quote",
-                                    "name"
-                                  ],
-                                  "additionalProperties": false
-                                },
-                                "minItems": 1,
-                                "maxItems": 9
-                              }
-                            },
-                            "required": [
-                              "type",
-                              "title",
-                              "items"
-                            ],
-                            "additionalProperties": false
+                            "minItems": 1,
+                            "maxItems": 99
                           }
+                        },
+                        "required": [
+                          "type",
+                          "title",
+                          "items"
                         ],
+                        "additionalProperties": false
+                      },
+                      {
                         "type": "object",
                         "properties": {
                           "type": {
                             "type": "string",
+                            "const": "gallery"
+                          },
+                          "title": {
+                            "type": "string",
+                            "minLength": 1,
+                            "maxLength": 120
+                          },
+                          "lead": {
+                            "type": "string",
+                            "minLength": 1,
+                            "maxLength": 280
+                          },
+                          "columns": {
+                            "type": "string",
                             "enum": [
-                              "before-after",
-                              "contact",
-                              "contact-form",
-                              "cta-band",
-                              "faq",
-                              "feature-grid",
-                              "gallery",
-                              "google-maps",
-                              "hero",
-                              "hours",
-                              "image-text",
-                              "media",
-                              "logo-strip",
-                              "navigation-bar",
-                              "prose",
-                              "store-location-hours",
-                              "testimonials"
+                              "2",
+                              "3",
+                              "4"
                             ],
-                            "description": "Component type. This selects which properties are valid for the object."
+                            "default": "3"
+                          },
+                          "images": {
+                            "type": "array",
+                            "items": {
+                              "$ref": "#/definitions/SiteContent/properties/site/properties/layout/properties/headerComponents/items/anyOf/5/properties/items/items/properties/image"
+                            },
+                            "minItems": 2,
+                            "maxItems": 24
                           }
                         },
                         "required": [
-                          "type"
+                          "type",
+                          "title",
+                          "images"
                         ],
-                        "defaultSnippets": [
-                          {
-                            "label": "Component shell",
-                            "description": "Insert a component object with a type placeholder.",
-                            "body": {
-                              "type": "$1"
-                            }
+                        "additionalProperties": false
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "type": {
+                            "type": "string",
+                            "const": "google-maps"
                           },
-                          {
-                            "label": "Before After",
-                            "description": "Insert a before-after component with required fields.",
-                            "body": {
-                              "type": "before-after",
-                              "title": "$2",
-                              "before": {
-                                "src": "$3",
-                                "alt": "$4",
-                                "label": "$5"
+                          "embedUrl": {
+                            "type": "string",
+                            "format": "uri",
+                            "maxLength": 2048
+                          },
+                          "title": {
+                            "type": "string",
+                            "minLength": 1,
+                            "maxLength": 120
+                          },
+                          "caption": {
+                            "type": "string",
+                            "minLength": 1,
+                            "maxLength": 280
+                          },
+                          "size": {
+                            "type": "string",
+                            "enum": [
+                              "content",
+                              "wide"
+                            ],
+                            "default": "wide"
+                          }
+                        },
+                        "required": [
+                          "type",
+                          "embedUrl",
+                          "title"
+                        ],
+                        "additionalProperties": false
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "type": {
+                            "type": "string",
+                            "const": "hero"
+                          },
+                          "headline": {
+                            "type": "string",
+                            "minLength": 1,
+                            "maxLength": 120
+                          },
+                          "subheadline": {
+                            "type": "string",
+                            "minLength": 1,
+                            "maxLength": 240
+                          },
+                          "primaryCta": {
+                            "$ref": "#/definitions/SiteContent/properties/site/properties/layout/properties/headerComponents/items/anyOf/3/properties/primaryCta"
+                          },
+                          "secondaryCta": {
+                            "$ref": "#/definitions/SiteContent/properties/site/properties/layout/properties/headerComponents/items/anyOf/3/properties/primaryCta"
+                          },
+                          "align": {
+                            "type": "string",
+                            "enum": [
+                              "start",
+                              "center"
+                            ],
+                            "default": "start"
+                          },
+                          "backgroundImage": {
+                            "type": "object",
+                            "properties": {
+                              "src": {
+                                "type": "string",
+                                "minLength": 1,
+                                "maxLength": 2048
                               },
-                              "after": {
-                                "src": "$6",
-                                "alt": "$7",
-                                "label": "$8"
+                              "alt": {
+                                "type": "string",
+                                "minLength": 1,
+                                "maxLength": 200
+                              },
+                              "position": {
+                                "type": "string",
+                                "minLength": 1,
+                                "maxLength": 80,
+                                "pattern": "^[a-z0-9% .-]+$",
+                                "default": "center"
                               }
-                            }
+                            },
+                            "required": [
+                              "src"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "required": [
+                          "type",
+                          "headline"
+                        ],
+                        "additionalProperties": false,
+                        "anyOf": [
+                          {
+                            "required": [
+                              "primaryCta"
+                            ]
                           },
                           {
-                            "label": "Contact",
-                            "description": "Insert a contact component with required fields.",
-                            "body": {
-                              "type": "contact",
-                              "address": "$2"
-                            }
-                          },
-                          {
-                            "label": "Contact Form",
-                            "description": "Insert a contact-form component with required fields.",
-                            "body": {
-                              "type": "contact-form",
-                              "mode": "${2|production,demo|}",
-                              "title": "$3",
-                              "action": "$4",
-                              "submitLabel": "$5"
-                            }
-                          },
-                          {
-                            "label": "Cta Band",
-                            "description": "Insert a cta-band component with required fields.",
-                            "body": {
-                              "type": "cta-band",
-                              "headline": "$2",
-                              "primaryCta": {
-                                "label": "$3",
-                                "href": "$4"
-                              }
-                            }
-                          },
-                          {
-                            "label": "Faq",
-                            "description": "Insert a faq component with required fields.",
-                            "body": {
-                              "type": "faq",
-                              "title": "$2",
-                              "items": [
-                                {
-                                  "question": "$3",
-                                  "answer": "$4"
-                                }
-                              ]
-                            }
-                          },
-                          {
-                            "label": "Feature Grid",
-                            "description": "Insert a feature-grid component with required fields.",
-                            "body": {
-                              "type": "feature-grid",
-                              "title": "$2",
-                              "items": [
-                                {
-                                  "title": "$3"
-                                }
-                              ]
-                            }
-                          },
-                          {
-                            "label": "Gallery",
-                            "description": "Insert a gallery component with required fields.",
-                            "body": {
-                              "type": "gallery",
-                              "title": "$2",
-                              "images": [
-                                {
-                                  "src": "$3",
-                                  "alt": "$4"
-                                }
-                              ]
-                            }
-                          },
-                          {
-                            "label": "Google Maps",
-                            "description": "Insert a google-maps component with required fields.",
-                            "body": {
-                              "type": "google-maps",
-                              "embedUrl": "$2",
-                              "title": "$3"
-                            }
-                          },
-                          {
-                            "label": "Hero",
-                            "description": "Insert a hero component with required fields.",
-                            "body": {
-                              "type": "hero",
-                              "headline": "$2",
-                              "primaryCta": {
-                                "label": "$3",
-                                "href": "$4"
-                              }
-                            }
-                          },
-                          {
-                            "label": "Hours",
-                            "description": "Insert a hours component with required fields.",
-                            "body": {
-                              "type": "hours",
-                              "entries": [
-                                {
-                                  "day": "${2|Monday,Tuesday,Wednesday,Thursday,Friday,Saturday,Sunday,Holiday,Holidays,Emergency Service|}",
-                                  "open": "$3",
-                                  "close": "$4"
-                                }
-                              ]
-                            }
-                          },
-                          {
-                            "label": "Image Text",
-                            "description": "Insert a image-text component with required fields.",
-                            "body": {
-                              "type": "image-text",
-                              "title": "$2",
-                              "paragraphs": [
-                                "$3"
-                              ],
-                              "image": {
-                                "src": "$4",
-                                "alt": "$5"
-                              }
-                            }
-                          },
-                          {
-                            "label": "Media",
-                            "description": "Insert a media component with required fields.",
-                            "body": {
-                              "type": "media",
-                              "src": "$2"
-                            }
-                          },
-                          {
-                            "label": "Logo Strip",
-                            "description": "Insert a logo-strip component with required fields.",
-                            "body": {
-                              "type": "logo-strip",
-                              "title": "$2",
-                              "logos": [
-                                {
-                                  "src": "$3",
-                                  "alt": "$4"
-                                }
-                              ]
-                            }
-                          },
-                          {
-                            "label": "Navigation Bar",
-                            "description": "Insert a navigation-bar component with required fields.",
-                            "body": {
-                              "type": "navigation-bar",
-                              "links": [
-                                {
-                                  "label": "$2",
-                                  "href": "$3"
-                                }
-                              ]
-                            }
-                          },
-                          {
-                            "label": "Prose",
-                            "description": "Insert a prose component with required fields.",
-                            "body": {
-                              "type": "prose",
-                              "paragraphs": [
-                                "$2"
-                              ]
-                            }
-                          },
-                          {
-                            "label": "Store Location Hours",
-                            "description": "Insert a store-location-hours component with required fields.",
-                            "body": {
-                              "type": "store-location-hours",
-                              "embedUrl": "$2",
-                              "mapTitle": "$3",
-                              "address": "$4",
-                              "hours": [
-                                {
-                                  "day": "${5|Monday,Tuesday,Wednesday,Thursday,Friday,Saturday,Sunday,Holiday,Holidays,Emergency Service|}",
-                                  "open": "$6",
-                                  "close": "$7"
-                                }
-                              ]
-                            }
-                          },
-                          {
-                            "label": "Testimonials",
-                            "description": "Insert a testimonials component with required fields.",
-                            "body": {
-                              "type": "testimonials",
-                              "title": "$2",
-                              "items": [
-                                {
-                                  "quote": "$3",
-                                  "name": "$4"
-                                }
-                              ]
-                            }
+                            "required": [
+                              "secondaryCta"
+                            ]
                           }
                         ]
                       },
@@ -1438,11 +752,426 @@
                         "properties": {
                           "type": {
                             "type": "string",
-                            "const": "page-content"
+                            "const": "hours"
+                          },
+                          "title": {
+                            "type": "string",
+                            "minLength": 1,
+                            "maxLength": 120
+                          },
+                          "entries": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "day": {
+                                  "type": "string",
+                                  "enum": [
+                                    "Monday",
+                                    "Tuesday",
+                                    "Wednesday",
+                                    "Thursday",
+                                    "Friday",
+                                    "Saturday",
+                                    "Sunday",
+                                    "Holiday",
+                                    "Holidays",
+                                    "Emergency Service"
+                                  ]
+                                },
+                                "open": {
+                                  "type": "string",
+                                  "pattern": "(?:0?[1-9]|1[0-2])(?::[0-5]\\d)?\\s?(?:AM|PM)|Closed"
+                                },
+                                "close": {
+                                  "type": "string",
+                                  "pattern": "(?:0?[1-9]|1[0-2])(?::[0-5]\\d)?\\s?(?:AM|PM)|Closed"
+                                }
+                              },
+                              "required": [
+                                "day",
+                                "open",
+                                "close"
+                              ],
+                              "additionalProperties": false
+                            },
+                            "minItems": 1,
+                            "maxItems": 16
                           }
                         },
                         "required": [
-                          "type"
+                          "type",
+                          "entries"
+                        ],
+                        "additionalProperties": false
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "type": {
+                            "type": "string",
+                            "const": "image-text"
+                          },
+                          "eyebrow": {
+                            "type": "string",
+                            "minLength": 1,
+                            "maxLength": 40
+                          },
+                          "title": {
+                            "type": "string",
+                            "minLength": 1,
+                            "maxLength": 120
+                          },
+                          "paragraphs": {
+                            "type": "array",
+                            "items": {
+                              "type": "string",
+                              "minLength": 1,
+                              "maxLength": 600
+                            },
+                            "minItems": 1,
+                            "maxItems": 4
+                          },
+                          "image": {
+                            "$ref": "#/definitions/SiteContent/properties/site/properties/layout/properties/headerComponents/items/anyOf/5/properties/items/items/properties/image"
+                          },
+                          "imagePosition": {
+                            "type": "string",
+                            "enum": [
+                              "start",
+                              "end"
+                            ],
+                            "default": "end"
+                          },
+                          "primaryCta": {
+                            "$ref": "#/definitions/SiteContent/properties/site/properties/layout/properties/headerComponents/items/anyOf/3/properties/primaryCta"
+                          },
+                          "secondaryCta": {
+                            "$ref": "#/definitions/SiteContent/properties/site/properties/layout/properties/headerComponents/items/anyOf/3/properties/primaryCta"
+                          }
+                        },
+                        "required": [
+                          "type",
+                          "title",
+                          "paragraphs",
+                          "image"
+                        ],
+                        "additionalProperties": false
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "type": {
+                            "type": "string",
+                            "const": "media"
+                          },
+                          "src": {
+                            "type": "string",
+                            "minLength": 1,
+                            "maxLength": 2048
+                          },
+                          "alt": {
+                            "type": "string",
+                            "maxLength": 200
+                          },
+                          "caption": {
+                            "type": "string",
+                            "minLength": 1,
+                            "maxLength": 280
+                          },
+                          "loading": {
+                            "type": "string",
+                            "enum": [
+                              "eager",
+                              "lazy"
+                            ]
+                          },
+                          "width": {
+                            "type": "integer",
+                            "exclusiveMinimum": 0,
+                            "maximum": 10000
+                          },
+                          "height": {
+                            "type": "integer",
+                            "exclusiveMinimum": 0,
+                            "maximum": 10000
+                          },
+                          "size": {
+                            "type": "string",
+                            "enum": [
+                              "content",
+                              "wide"
+                            ],
+                            "default": "wide"
+                          }
+                        },
+                        "required": [
+                          "type",
+                          "src"
+                        ],
+                        "additionalProperties": false
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "type": {
+                            "type": "string",
+                            "const": "logo-strip"
+                          },
+                          "title": {
+                            "type": "string",
+                            "minLength": 1,
+                            "maxLength": 120
+                          },
+                          "lead": {
+                            "type": "string",
+                            "minLength": 1,
+                            "maxLength": 280
+                          },
+                          "logos": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "src": {
+                                  "type": "string",
+                                  "minLength": 1,
+                                  "maxLength": 2048
+                                },
+                                "alt": {
+                                  "type": "string",
+                                  "minLength": 1,
+                                  "maxLength": 200
+                                },
+                                "href": {
+                                  "type": "string",
+                                  "minLength": 1,
+                                  "maxLength": 2048
+                                },
+                                "width": {
+                                  "type": "integer",
+                                  "exclusiveMinimum": 0,
+                                  "maximum": 10000
+                                },
+                                "height": {
+                                  "type": "integer",
+                                  "exclusiveMinimum": 0,
+                                  "maximum": 10000
+                                }
+                              },
+                              "required": [
+                                "src",
+                                "alt"
+                              ],
+                              "additionalProperties": false
+                            },
+                            "minItems": 2,
+                            "maxItems": 24
+                          }
+                        },
+                        "required": [
+                          "type",
+                          "title",
+                          "logos"
+                        ],
+                        "additionalProperties": false
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "type": {
+                            "type": "string",
+                            "const": "navigation-bar"
+                          },
+                          "brandText": {
+                            "type": "string",
+                            "minLength": 1,
+                            "maxLength": 80
+                          },
+                          "brandImage": {
+                            "type": "object",
+                            "properties": {
+                              "src": {
+                                "type": "string",
+                                "minLength": 1,
+                                "maxLength": 2048
+                              },
+                              "alt": {
+                                "type": "string",
+                                "minLength": 1,
+                                "maxLength": 200
+                              }
+                            },
+                            "required": [
+                              "src",
+                              "alt"
+                            ],
+                            "additionalProperties": false
+                          },
+                          "links": {
+                            "type": "array",
+                            "items": {
+                              "$ref": "#/definitions/SiteContent/properties/site/properties/layout/properties/headerComponents/items/anyOf/3/properties/primaryCta"
+                            },
+                            "minItems": 1,
+                            "maxItems": 12
+                          }
+                        },
+                        "required": [
+                          "type",
+                          "links"
+                        ],
+                        "additionalProperties": false
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "type": {
+                            "type": "string",
+                            "const": "prose"
+                          },
+                          "title": {
+                            "type": "string",
+                            "minLength": 1,
+                            "maxLength": 120
+                          },
+                          "lead": {
+                            "type": "string",
+                            "minLength": 1,
+                            "maxLength": 280
+                          },
+                          "paragraphs": {
+                            "type": "array",
+                            "items": {
+                              "type": "string",
+                              "minLength": 1,
+                              "maxLength": 1200
+                            },
+                            "minItems": 1,
+                            "maxItems": 12
+                          }
+                        },
+                        "required": [
+                          "type",
+                          "paragraphs"
+                        ],
+                        "additionalProperties": false
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "type": {
+                            "type": "string",
+                            "const": "store-location-hours"
+                          },
+                          "title": {
+                            "type": "string",
+                            "minLength": 1,
+                            "maxLength": 120
+                          },
+                          "embedUrl": {
+                            "type": "string",
+                            "format": "uri",
+                            "maxLength": 2048
+                          },
+                          "mapTitle": {
+                            "type": "string",
+                            "minLength": 1,
+                            "maxLength": 120
+                          },
+                          "address": {
+                            "type": "string",
+                            "minLength": 1,
+                            "maxLength": 280
+                          },
+                          "phone": {
+                            "type": "string",
+                            "minLength": 7,
+                            "maxLength": 40
+                          },
+                          "email": {
+                            "type": "string",
+                            "format": "email",
+                            "maxLength": 254
+                          },
+                          "hours": {
+                            "type": "array",
+                            "items": {
+                              "$ref": "#/definitions/SiteContent/properties/site/properties/layout/properties/headerComponents/items/anyOf/9/properties/entries/items"
+                            },
+                            "minItems": 1,
+                            "maxItems": 16
+                          }
+                        },
+                        "required": [
+                          "type",
+                          "embedUrl",
+                          "mapTitle",
+                          "address",
+                          "hours"
+                        ],
+                        "additionalProperties": false
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "type": {
+                            "type": "string",
+                            "const": "testimonials"
+                          },
+                          "title": {
+                            "type": "string",
+                            "minLength": 1,
+                            "maxLength": 120
+                          },
+                          "lead": {
+                            "type": "string",
+                            "minLength": 1,
+                            "maxLength": 280
+                          },
+                          "items": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "quote": {
+                                  "type": "string",
+                                  "minLength": 1,
+                                  "maxLength": 600
+                                },
+                                "name": {
+                                  "type": "string",
+                                  "minLength": 1,
+                                  "maxLength": 80
+                                },
+                                "role": {
+                                  "type": "string",
+                                  "minLength": 1,
+                                  "maxLength": 80
+                                },
+                                "company": {
+                                  "type": "string",
+                                  "minLength": 1,
+                                  "maxLength": 80
+                                },
+                                "image": {
+                                  "$ref": "#/definitions/SiteContent/properties/site/properties/layout/properties/headerComponents/items/anyOf/5/properties/items/items/properties/image"
+                                }
+                              },
+                              "required": [
+                                "quote",
+                                "name"
+                              ],
+                              "additionalProperties": false
+                            },
+                            "minItems": 1,
+                            "maxItems": 9
+                          }
+                        },
+                        "required": [
+                          "type",
+                          "title",
+                          "items"
                         ],
                         "additionalProperties": false
                       }
@@ -1468,8 +1197,7 @@
                           "navigation-bar",
                           "prose",
                           "store-location-hours",
-                          "testimonials",
-                          "page-content"
+                          "testimonials"
                         ],
                         "description": "Component type. This selects which properties are valid for the object."
                       }
@@ -1700,22 +1428,43 @@
                             }
                           ]
                         }
+                      }
+                    ]
+                  },
+                  "default": []
+                },
+                "footerComponents": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/SiteContent/properties/site/properties/layout/properties/headerComponents/items"
+                  },
+                  "default": []
+                },
+                "components": {
+                  "type": "array",
+                  "items": {
+                    "anyOf": [
+                      {
+                        "$ref": "#/definitions/SiteContent/properties/site/properties/layout/properties/headerComponents/items"
                       },
                       {
-                        "label": "Page Content",
-                        "description": "Insert a page-content component with required fields.",
-                        "body": {
-                          "type": "page-content"
-                        }
+                        "type": "object",
+                        "properties": {
+                          "type": {
+                            "type": "string",
+                            "const": "page-content"
+                          }
+                        },
+                        "required": [
+                          "type"
+                        ],
+                        "additionalProperties": false
                       }
                     ]
                   },
                   "minItems": 1
                 }
               },
-              "required": [
-                "components"
-              ],
               "additionalProperties": false
             },
             "footer": {
@@ -1801,7 +1550,7 @@
               "components": {
                 "type": "array",
                 "items": {
-                  "$ref": "#/definitions/SiteContent/properties/site/properties/layout/properties/components/items/anyOf/0"
+                  "$ref": "#/definitions/SiteContent/properties/site/properties/layout/properties/headerComponents/items"
                 },
                 "minItems": 1
               }

--- a/src/build/framework.ts
+++ b/src/build/framework.ts
@@ -13,7 +13,7 @@ import {
   defaultComponentRenderContext,
   type ComponentRenderContext,
 } from "../components/render-context.js";
-import { isPageContentSlot } from "../layout/page-layout.js";
+import { resolveSiteLayoutComponents } from "../layout/page-layout.js";
 import {
   SiteContentSchema,
   type SiteData,
@@ -106,7 +106,9 @@ const getComponentTypeForIssue = (
   const isSiteLayoutComponentPath =
     pathSegments[0] === "site" &&
     pathSegments[1] === "layout" &&
-    pathSegments[2] === "components" &&
+    (pathSegments[2] === "components" ||
+      pathSegments[2] === "headerComponents" ||
+      pathSegments[2] === "footerComponents") &&
     typeof pathSegments[3] === "number";
 
   if (!isPageComponentPath && !isSiteLayoutComponentPath) {
@@ -365,11 +367,13 @@ const renderSiteCss = async (
 
 const collectUsedComponentTypes = (siteContent: SiteContentData): Set<ComponentType> => {
   const componentTypes = new Set<ComponentType>();
+  const layoutComponents = resolveSiteLayoutComponents(siteContent.site);
 
-  siteContent.site.layout?.components.forEach((component) => {
-    if (component.type !== "page-content") {
-      componentTypes.add(component.type);
-    }
+  layoutComponents.headerComponents.forEach((component) => {
+    componentTypes.add(component.type);
+  });
+  layoutComponents.footerComponents.forEach((component) => {
+    componentTypes.add(component.type);
   });
 
   siteContent.pages.forEach((page) => {
@@ -437,33 +441,20 @@ const renderPageBodyHtml = (
   page: SiteContentData["pages"][number],
   renderContext: ComponentRenderContext = defaultComponentRenderContext,
 ): string => {
-  const layoutComponents = siteContent.site.layout?.components;
+  const layoutComponents = resolveSiteLayoutComponents(siteContent.site);
   const footerHtml = renderSiteFooter(siteContent.site);
   const renderMain = (innerHtml: string): string =>
     `<main id="main-content" class="l-page" tabindex="-1">\n${innerHtml}\n</main>`;
+  const pageMainHtml = renderMain(
+    page.components.map((component) => renderComponent(component, renderContext)).join("\n"),
+  );
 
-  if (!layoutComponents) {
-    const mainHtml = renderMain(
-      page.components.map((component) => renderComponent(component, renderContext)).join("\n"),
-    );
-
-    return [mainHtml, footerHtml].filter(Boolean).join("\n");
-  }
-
-  const layoutHtml = layoutComponents
-    .map((layoutComponent) => {
-      if (isPageContentSlot(layoutComponent)) {
-        const pageContentHtml = page.components
-          .map((component) => renderComponent(component, renderContext))
-          .join("\n");
-        return renderMain(pageContentHtml);
-      }
-
-      return renderComponent(layoutComponent, renderContext);
-    })
-    .join("\n");
-
-  return [layoutHtml, footerHtml].filter(Boolean).join("\n");
+  return [
+    ...layoutComponents.headerComponents.map((component) => renderComponent(component, renderContext)),
+    pageMainHtml,
+    ...layoutComponents.footerComponents.map((component) => renderComponent(component, renderContext)),
+    footerHtml,
+  ].filter(Boolean).join("\n");
 };
 
 const renderSitePageDocument = ({

--- a/src/build/image-pipeline.ts
+++ b/src/build/image-pipeline.ts
@@ -11,6 +11,7 @@ import type {
   ResolvedImageData,
   ResponsiveImageData,
 } from "../components/render-context.js";
+import { resolveSiteLayoutComponents } from "../layout/page-layout.js";
 import type { SiteContentData } from "../schemas/site.schema.js";
 import { appendVersionQuery, createContentVersion } from "./asset-version.js";
 
@@ -315,12 +316,13 @@ const collectImageUsages = (
     addUsage(["site", "pageBackgroundImageUrl"], siteContent.site.pageBackgroundImageUrl, "page-background");
   }
 
-  siteContent.site.layout?.components.forEach((component, componentIndex) => {
-    if (component.type === "page-content") {
-      return;
-    }
+  const layoutComponents = resolveSiteLayoutComponents(siteContent.site);
 
-    visitComponent(component, ["site", "layout", "components", componentIndex]);
+  layoutComponents.headerComponents.forEach((component, componentIndex) => {
+    visitComponent(component, ["site", "layout", "headerComponents", componentIndex]);
+  });
+  layoutComponents.footerComponents.forEach((component, componentIndex) => {
+    visitComponent(component, ["site", "layout", "footerComponents", componentIndex]);
   });
 
   siteContent.pages.forEach((page, pageIndex) => {

--- a/src/editor/static/app.jsx
+++ b/src/editor/static/app.jsx
@@ -567,11 +567,17 @@ const SiteEditor = ({ browser, config, draft, refreshPreview, setDraft, validati
   const enableSharedLayout = () => {
     setDraft((currentDraft) =>
       setAtPath(currentDraft, [...sitePath, "layout"], {
-        components: [{ type: "page-content" }],
+        headerComponents: [],
+        footerComponents: [],
       }),
     );
     refreshPreview();
   };
+  const layout = draft.site.layout;
+  const hasSharedLayout = Boolean(layout);
+  const hasLegacySharedLayout = Boolean(layout?.components);
+  const headerComponents = layout?.headerComponents ?? [];
+  const footerComponents = layout?.footerComponents ?? [];
 
   return (
     <>
@@ -661,19 +667,42 @@ const SiteEditor = ({ browser, config, draft, refreshPreview, setDraft, validati
           />
         </div>
       </div>
-      {draft.site.layout?.components ? (
-        <ComponentListEditor
-          browser={browser}
-          config={config}
-          draft={draft}
-          components={draft.site.layout.components}
-          componentsPath={["site", "layout", "components"]}
-          mode="layout"
-          setDraft={setDraft}
-          refreshPreview={refreshPreview}
-          title="Shared Layout Components"
-          validationErrors={validationErrors}
-        />
+      {hasSharedLayout ? (
+        <>
+          {hasLegacySharedLayout ? (
+            <div className="card">
+              <h2>Legacy Shared Layout</h2>
+              <div className="hint">
+                This file still uses layout.components. It will render, but use header and footer
+                components for new shared layout edits.
+              </div>
+            </div>
+          ) : null}
+          <ComponentListEditor
+            browser={browser}
+            config={config}
+            draft={draft}
+            components={headerComponents}
+            componentsPath={["site", "layout", "headerComponents"]}
+            mode="layout"
+            setDraft={setDraft}
+            refreshPreview={refreshPreview}
+            title="Header Components"
+            validationErrors={validationErrors}
+          />
+          <ComponentListEditor
+            browser={browser}
+            config={config}
+            draft={draft}
+            components={footerComponents}
+            componentsPath={["site", "layout", "footerComponents"]}
+            mode="layout"
+            setDraft={setDraft}
+            refreshPreview={refreshPreview}
+            title="Footer Components"
+            validationErrors={validationErrors}
+          />
+        </>
       ) : (
         <div className="card">
           <div className="list-item-header">
@@ -958,15 +987,11 @@ const ComponentListEditor = ({
   validationErrors,
 }) => {
   const componentTypeRef = useRef(null);
-  const componentTypeOptions =
-    mode === "layout" ? ["page-content", ...config.componentTypes] : config.componentTypes;
+  const componentTypeOptions = config.componentTypes;
 
   const addComponent = () => {
     const componentType = componentTypeRef.current?.value ?? "prose";
-    const nextComponent =
-      componentType === "page-content"
-        ? { type: "page-content" }
-        : clone(config.componentSpecs[componentType].defaults);
+    const nextComponent = clone(config.componentSpecs[componentType].defaults);
 
     setDraft((currentDraft) => {
       const nextDraft = clone(currentDraft);
@@ -982,12 +1007,10 @@ const ComponentListEditor = ({
         <h2>{title}</h2>
         <div className="component-add-row">
           <div className="grow">
-            <select ref={componentTypeRef} defaultValue={mode === "layout" ? "page-content" : "prose"}>
+            <select ref={componentTypeRef} defaultValue="prose">
               {componentTypeOptions.map((componentType) => (
                 <option key={componentType} value={componentType}>
-                  {componentType === "page-content"
-                    ? "Page Content Slot"
-                    : config.componentSpecs[componentType].title}
+                  {config.componentSpecs[componentType].title}
                 </option>
               ))}
             </select>

--- a/src/layout/page-layout.ts
+++ b/src/layout/page-layout.ts
@@ -19,33 +19,91 @@ export const countPageContentSlots = (
   components: readonly SiteLayoutComponentData[],
 ): number => components.filter((component) => isPageContentSlot(component)).length;
 
+const hasModernLayoutComponents = (site: SiteData): boolean =>
+  Boolean(
+    site.layout &&
+      ((site.layout.headerComponents?.length ?? 0) > 0 ||
+        (site.layout.footerComponents?.length ?? 0) > 0 ||
+        !site.layout.components),
+  );
+
+export const hasMixedLayoutComponentModels = (site: SiteData): boolean =>
+  Boolean(
+    site.layout?.components &&
+      ((site.layout.headerComponents?.length ?? 0) > 0 ||
+        (site.layout.footerComponents?.length ?? 0) > 0),
+  );
+
+export const splitLegacyLayoutComponents = (
+  components: readonly SiteLayoutComponentData[],
+): { footerComponents: ComponentData[]; headerComponents: ComponentData[] } => {
+  const slotIndex = components.findIndex((component) => isPageContentSlot(component));
+
+  if (slotIndex < 0) {
+    return {
+      headerComponents: [],
+      footerComponents: [],
+    };
+  }
+
+  return {
+    headerComponents: components
+      .slice(0, slotIndex)
+      .filter((component): component is ComponentData => !isPageContentSlot(component)),
+    footerComponents: components
+      .slice(slotIndex + 1)
+      .filter((component): component is ComponentData => !isPageContentSlot(component)),
+  };
+};
+
+export const resolveSiteLayoutComponents = (
+  site: SiteData,
+): { footerComponents: readonly ComponentData[]; headerComponents: readonly ComponentData[] } => {
+  if (!site.layout) {
+    return {
+      headerComponents: [],
+      footerComponents: [],
+    };
+  }
+
+  if (hasModernLayoutComponents(site) || hasMixedLayoutComponentModels(site)) {
+    return {
+      headerComponents: site.layout.headerComponents ?? [],
+      footerComponents: site.layout.footerComponents ?? [],
+    };
+  }
+
+  return splitLegacyLayoutComponents(site.layout.components ?? []);
+};
+
 export const resolvePageComponentEntries = (
   site: SiteData,
   page: PageData,
   pageIndex: number,
 ): ResolvedPageComponentEntry[] => {
-  const layoutComponents = site.layout?.components;
+  const layoutComponents = resolveSiteLayoutComponents(site);
 
-  if (!layoutComponents) {
+  if (layoutComponents.headerComponents.length === 0 && layoutComponents.footerComponents.length === 0) {
     return page.components.map((component, componentIndex) => ({
       component,
       path: ["pages", pageIndex, "components", componentIndex],
     }));
   }
 
-  return layoutComponents.flatMap((component, layoutIndex) =>
-    isPageContentSlot(component)
-      ? page.components.map((pageComponent, componentIndex) => ({
-          component: pageComponent,
-          path: ["pages", pageIndex, "components", componentIndex],
-        }))
-      : [
-          {
-            component,
-            path: ["site", "layout", "components", layoutIndex],
-          },
-        ],
-  );
+  return [
+    ...layoutComponents.headerComponents.map((component, componentIndex) => ({
+      component,
+      path: ["site", "layout", "headerComponents", componentIndex],
+    })),
+    ...page.components.map((component, componentIndex) => ({
+      component,
+      path: ["pages", pageIndex, "components", componentIndex],
+    })),
+    ...layoutComponents.footerComponents.map((component, componentIndex) => ({
+      component,
+      path: ["site", "layout", "footerComponents", componentIndex],
+    })),
+  ];
 };
 
 export const resolvePageComponents = (

--- a/src/schemas/site.schema.ts
+++ b/src/schemas/site.schema.ts
@@ -63,7 +63,9 @@ export const SiteLayoutComponentSchema = z.union([ComponentSchema, PageContentSl
 
 export const SiteLayoutSchema = z
   .object({
-    components: z.array(SiteLayoutComponentSchema).min(1),
+    headerComponents: z.array(ComponentSchema).default([]),
+    footerComponents: z.array(ComponentSchema).default([]),
+    components: z.array(SiteLayoutComponentSchema).min(1).optional(),
   })
   .strict();
 

--- a/src/validation/site-validation.ts
+++ b/src/validation/site-validation.ts
@@ -1,5 +1,6 @@
 import {
   countPageContentSlots,
+  hasMixedLayoutComponentModels,
   resolvePageComponentEntries,
 } from "../layout/page-layout.js";
 import type { SiteContentData } from "../schemas/site.schema.js";
@@ -20,11 +21,18 @@ export const collectSiteValidationIssues = (
   const hasValidLayoutSlotCount =
     !layoutComponents || countPageContentSlots(layoutComponents) === 1;
 
+  if (hasMixedLayoutComponentModels(siteContent.site)) {
+    issues.push({
+      path: ["site", "layout"],
+      message: "site layout cannot mix legacy 'components' with headerComponents or footerComponents",
+    });
+  }
+
   if (layoutComponents) {
     if (!hasValidLayoutSlotCount) {
       issues.push({
         path: ["site", "layout", "components"],
-        message: "site layout must include exactly one 'page-content' slot",
+        message: "legacy site layout components must include exactly one 'page-content' slot",
       });
     }
   }
@@ -43,7 +51,7 @@ export const collectSiteValidationIssues = (
 
     let heroCount = 0;
     const resolvedEntries =
-      hasValidLayoutSlotCount
+      hasValidLayoutSlotCount && !hasMixedLayoutComponentModels(siteContent.site)
         ? resolvePageComponentEntries(siteContent.site, page, pageIndex)
         : page.components.map((component, componentIndex) => ({
             component,

--- a/tests/78th-street-studios-example.test.ts
+++ b/tests/78th-street-studios-example.test.ts
@@ -16,7 +16,8 @@ describe("78th Street Studios example", () => {
     const siteContent = await loadValidatedSite(exampleContentPath);
 
     expect(siteContent.site.name).toBe("78th Street Studios");
-    expect(siteContent.site.layout?.components).toBeDefined();
+    expect(siteContent.site.layout?.headerComponents).toBeDefined();
+    expect(siteContent.site.layout?.footerComponents).toBeDefined();
     expect(siteContent.pages.map((page) => page.slug)).toEqual(["/", "/about"]);
 
     const outDir = await mkdtemp(path.join(os.tmpdir(), "78th-street-studios-"));

--- a/tests/baird-automotive-example.test.ts
+++ b/tests/baird-automotive-example.test.ts
@@ -14,7 +14,8 @@ describe("Baird Automotive example", () => {
 
     expect(siteContent.site.name).toBe("Baird Automotive");
     expect(siteContent.site.theme).toBe("corporate");
-    expect(siteContent.site.layout?.components).toBeDefined();
+    expect(siteContent.site.layout?.headerComponents).toBeDefined();
+    expect(siteContent.site.layout?.footerComponents).toBeDefined();
     expect(siteContent.pages.map((page) => page.slug)).toEqual([
       "/",
       "/our-story",

--- a/tests/build-output.test.ts
+++ b/tests/build-output.test.ts
@@ -99,7 +99,7 @@ const createScriptedSite = () =>
       baseUrl: "https://launchkit.example",
       theme: "friendly-modern",
       layout: {
-        components: [
+        headerComponents: [
           {
             type: "navigation-bar",
             brandText: "LaunchKit",
@@ -110,10 +110,8 @@ const createScriptedSite = () =>
               },
             ],
           },
-          {
-            type: "page-content",
-          },
         ],
+        footerComponents: [],
       },
     },
     pages: [
@@ -843,7 +841,7 @@ describe("buildSite output writes", () => {
         baseUrl: "https://launchkit.example",
         theme: "friendly-modern",
         layout: {
-          components: [
+          headerComponents: [
             {
               type: "navigation-bar",
               brandText: "LaunchKit",
@@ -858,10 +856,8 @@ describe("buildSite output writes", () => {
                 },
               ],
             },
-            {
-              type: "page-content",
-            },
           ],
+          footerComponents: [],
         },
       },
       pages: [
@@ -880,7 +876,7 @@ describe("buildSite output writes", () => {
     };
 
     await writeFile(contentPath, `${JSON.stringify(siteContent, null, 2)}\n`, "utf8");
-    await buildSite(siteContent as Parameters<typeof buildSite>[0], outDir, { contentPath });
+    await buildSite(SiteContentSchema.parse(siteContent), outDir, { contentPath });
 
     const aboutHtml = await readFile(path.join(outDir, "about", "index.html"), "utf8");
     const optimizedBrandDir = path.join(outDir, "assets", "images");

--- a/tests/full-height.browser.ts
+++ b/tests/full-height.browser.ts
@@ -20,7 +20,7 @@ const createShortPageFixture = () =>
       baseUrl: "https://launchkit.example",
       theme: "friendly-modern",
       layout: {
-        components: [
+        headerComponents: [
           {
             type: "navigation-bar",
             brandText: "LaunchKit",
@@ -35,10 +35,8 @@ const createShortPageFixture = () =>
               },
             ],
           },
-          {
-            type: "page-content",
-          },
         ],
+        footerComponents: [],
       },
     },
     pages: [

--- a/tests/navigation-bar.browser.ts
+++ b/tests/navigation-bar.browser.ts
@@ -28,7 +28,7 @@ const createNavigationBarFixture = () =>
       baseUrl: "https://launchkit.example",
       theme: "friendly-modern",
       layout: {
-        components: [
+        headerComponents: [
           {
             type: "navigation-bar",
             brandText: "LaunchKit Enterprise",
@@ -51,10 +51,8 @@ const createNavigationBarFixture = () =>
               },
             ],
           },
-          {
-            type: "page-content",
-          },
         ],
+        footerComponents: [],
       },
     },
     pages: [

--- a/tests/site-editor-flow.browser.ts
+++ b/tests/site-editor-flow.browser.ts
@@ -20,7 +20,7 @@ const createDraft = (
       baseUrl: "https://launchkit.example",
       theme: "friendly-modern",
       layout: {
-        components: [
+        headerComponents: [
           {
             type: "navigation-bar",
             brandText: siteName,
@@ -31,10 +31,8 @@ const createDraft = (
               },
             ],
           },
-          {
-            type: "page-content",
-          },
         ],
+        footerComponents: [],
       },
     },
     pages: [
@@ -287,7 +285,7 @@ const runBrowserRegression = async (): Promise<void> => {
     const savedDraft = SiteContentSchema.parse(JSON.parse(await readFile(siblingContentPath, "utf8")));
     const firstSavedComponent = savedDraft.pages[1]?.components[0];
     const secondSavedComponent = savedDraft.pages[1]?.components[1];
-    const sharedNav = savedDraft.site.layout?.components[0];
+    const sharedNav = savedDraft.site.layout?.headerComponents[0];
 
     if (firstSavedComponent?.type !== "cta-band" || secondSavedComponent?.type !== "prose") {
       throw new Error("Expected the saved about page components to be reordered.");

--- a/tests/site-json-schema.test.ts
+++ b/tests/site-json-schema.test.ts
@@ -161,13 +161,11 @@ describe("site JSON schema", async () => {
       buildSiteContentJsonSchema() as JsonSchemaValue,
     );
     const pageComponentTypes = [...componentTypeNames].sort();
-    const layoutComponentTypes = [...componentTypeNames, "page-content"].sort();
     const componentTypeSets = componentUnionSchemas.map((schema) =>
       [...((schema.properties as JsonSchemaObject).type as JsonSchemaObject).enum as string[]].sort(),
     );
 
     expect(componentTypeSets).toContainEqual(pageComponentTypes);
-    expect(componentTypeSets).toContainEqual(layoutComponentTypes);
   });
 
   it("generates default snippets for component unions", () => {

--- a/tests/site-layout.test.ts
+++ b/tests/site-layout.test.ts
@@ -16,15 +16,14 @@ describe("site layout", () => {
         baseUrl: "https://launchkit.example",
         theme: "friendly-modern",
         layout: {
-          components: [
+          headerComponents: [
             {
               type: "prose",
               title: "Shared header",
               paragraphs: ["This introduction appears on every page."],
             },
-            {
-              type: "page-content",
-            },
+          ],
+          footerComponents: [
             {
               type: "prose",
               title: "Shared footer",
@@ -99,16 +98,14 @@ describe("site layout", () => {
         baseUrl: "https://launchkit.example",
         theme: "friendly-modern",
         layout: {
-          components: [
+          headerComponents: [
             {
               type: "prose",
               title: "Shared header",
               paragraphs: ["This introduction appears on every page."],
             },
-            {
-              type: "page-content",
-            },
           ],
+          footerComponents: [],
         },
       },
       pages: [
@@ -169,7 +166,7 @@ describe("site layout", () => {
         baseUrl: "https://launchkit.example",
         theme: "friendly-modern",
         layout: {
-          components: [
+          headerComponents: [
             {
               type: "navigation-bar",
               brandText: "LaunchKit",
@@ -188,10 +185,8 @@ describe("site layout", () => {
                 },
               ],
             },
-            {
-              type: "page-content",
-            },
           ],
+          footerComponents: [],
         },
       },
       pages: [

--- a/tests/site-validation.test.ts
+++ b/tests/site-validation.test.ts
@@ -63,7 +63,34 @@ describe("collectSiteValidationIssues", () => {
     expect(issues.some((issue) => issue.message.includes("only one hero"))).toBe(true);
   });
 
-  it("requires a shared site layout to include exactly one page-content slot", () => {
+  it("allows shared header and footer layout components without a page-content slot", () => {
+    const validLayoutSite = SiteContentSchema.parse({
+      ...validSite,
+      site: {
+        ...validSite.site,
+        layout: {
+          headerComponents: [
+            {
+              type: "prose",
+              title: "Shared intro",
+              paragraphs: ["This shows up before every page."],
+            },
+          ],
+          footerComponents: [
+            {
+              type: "prose",
+              title: "Shared footer",
+              paragraphs: ["This shows up after every page."],
+            },
+          ],
+        },
+      },
+    });
+
+    expect(collectSiteValidationIssues(validLayoutSite)).toEqual([]);
+  });
+
+  it("requires a legacy shared site layout to include exactly one page-content slot", () => {
     const invalidSite = SiteContentSchema.parse({
       ...validSite,
       site: {
@@ -83,12 +110,12 @@ describe("collectSiteValidationIssues", () => {
     expect(collectSiteValidationIssues(invalidSite)).toEqual([
       {
         path: ["site", "layout", "components"],
-        message: "site layout must include exactly one 'page-content' slot",
+        message: "legacy site layout components must include exactly one 'page-content' slot",
       },
     ]);
   });
 
-  it("rejects shared site layouts with more than one page-content slot", () => {
+  it("rejects legacy shared site layouts with more than one page-content slot", () => {
     const invalidSite = SiteContentSchema.parse({
       ...validSite,
       site: {
@@ -114,7 +141,37 @@ describe("collectSiteValidationIssues", () => {
     expect(collectSiteValidationIssues(invalidSite)).toEqual([
       {
         path: ["site", "layout", "components"],
-        message: "site layout must include exactly one 'page-content' slot",
+        message: "legacy site layout components must include exactly one 'page-content' slot",
+      },
+    ]);
+  });
+
+  it("rejects layouts that mix legacy and header or footer component models", () => {
+    const invalidSite = SiteContentSchema.parse({
+      ...validSite,
+      site: {
+        ...validSite.site,
+        layout: {
+          headerComponents: [
+            {
+              type: "prose",
+              title: "Shared intro",
+              paragraphs: ["This shows up before every page."],
+            },
+          ],
+          components: [
+            {
+              type: "page-content",
+            },
+          ],
+        },
+      },
+    });
+
+    expect(collectSiteValidationIssues(invalidSite)).toEqual([
+      {
+        path: ["site", "layout"],
+        message: "site layout cannot mix legacy 'components' with headerComponents or footerComponents",
       },
     ]);
   });
@@ -125,7 +182,7 @@ describe("collectSiteValidationIssues", () => {
       site: {
         ...validSite.site,
         layout: {
-          components: [
+          headerComponents: [
             {
               type: "hero",
               headline: "Shared site hero",
@@ -134,10 +191,8 @@ describe("collectSiteValidationIssues", () => {
                 href: "/learn-more",
               },
             },
-            {
-              type: "page-content",
-            },
           ],
+          footerComponents: [],
         },
       },
     });

--- a/tests/theme-examples.test.ts
+++ b/tests/theme-examples.test.ts
@@ -121,10 +121,11 @@ describe("theme examples", () => {
         const siteContent = SiteContentSchema.parse(JSON.parse(rawJson) as unknown);
         const page = siteContent.pages[0];
         const componentTypes = page.components.map((component) => component.type);
-        const layoutComponents = siteContent.site.layout?.components ?? [];
-        const sharedComponentTypes = layoutComponents
-          .filter((component) => component.type !== "page-content")
-          .map((component) => component.type);
+        const headerComponents = siteContent.site.layout?.headerComponents ?? [];
+        const footerComponents = siteContent.site.layout?.footerComponents ?? [];
+        const sharedComponentTypes = [...headerComponents, ...footerComponents].map(
+          (component) => component.type,
+        );
         const allComponentTypes = Array.from(
           new Set([...componentTypes, ...sharedComponentTypes]),
         ).sort();
@@ -132,7 +133,6 @@ describe("theme examples", () => {
         expect(siteContent.site.theme).toBe(themeName);
         expect(siteContent.pages).toHaveLength(1);
         expect(allComponentTypes).toEqual([...componentTypeNames].sort());
-        expect(layoutComponents.map((component) => component.type)).toContain("page-content");
         expect(sharedComponentTypes).toContain("navigation-bar");
         expect(sharedComponentTypes.length).toBeGreaterThan(0);
 


### PR DESCRIPTION
## Summary
- replace new shared layout authoring with explicit `headerComponents` and `footerComponents`
- keep legacy `layout.components` + `page-content` readable so existing refresh sites can migrate deliberately
- update rendering, image collection, validation, editor controls, docs, fixtures, and generated schema

## Tests
- `cmd /c npm run schema:check`
- `cmd /c npx vitest run tests/site-layout.test.ts tests/site-validation.test.ts tests/site-json-schema.test.ts tests/theme-examples.test.ts`
- `cmd /c npm run lint:ts`
- `cmd /c npm run lint:css`
- `cmd /c npm test`
- `cmd /c npx tsx tests/site-editor-flow.browser.ts`