### PR TITLE
Tighten mobile hero scaling

### DIFF
--- a/src/components/hero/hero.css
+++ b/src/components/hero/hero.css
@@ -64,3 +64,47 @@
 .c-hero--align-center .c-hero__actions {
   justify-content: center;
 }
+
+@media (width <= 40rem) {
+  body[data-theme="high-vis-service"] {
+    background: var(--site-page-background-image, none) center / cover no-repeat fixed,
+      repeating-linear-gradient(
+        -45deg,
+        rgb(255 212 0 / 8%) 0 0.75rem,
+        transparent 0.75rem 1.75rem
+      ) fixed var(--bg);
+  }
+
+  .c-hero {
+    min-height: auto;
+  }
+
+  .c-hero--has-background {
+    min-height: clamp(22rem, 48vh, 31rem);
+  }
+
+  .c-hero__body {
+    gap: var(--space-md);
+  }
+
+  .c-hero__headline,
+  .c-hero__subheadline,
+  .c-hero__actions {
+    padding-inline: var(--space-sm);
+  }
+
+  .c-hero__headline {
+    font-size: clamp(var(--size-2xl), 7vw, var(--size-3xl));
+    line-height: 1.05;
+    letter-spacing: 0;
+  }
+
+  .c-hero__subheadline {
+    font-size: var(--size-lg);
+    line-height: 1.35;
+  }
+
+  .c-hero__actions {
+    gap: var(--space-sm);
+  }
+}

--- a/tests/site-layout.test.ts
+++ b/tests/site-layout.test.ts
@@ -158,6 +158,55 @@ describe("site layout", () => {
     }
   });
 
+  it("emits mobile hero polish rules for generated first viewports", async () => {
+    const outDir = await mkdtemp(path.join(os.tmpdir(), "cruftless-hero-mobile-"));
+    const site = SiteContentSchema.parse({
+      site: {
+        name: "LaunchKit",
+        baseUrl: "https://launchkit.example",
+        theme: "high-vis-service",
+      },
+      pages: [
+        {
+          slug: "/",
+          title: "Home",
+          components: [
+            {
+              type: "hero",
+              headline: "Zero-Residue Cleaning, 24-Hour Water Help",
+              subheadline:
+                "Licensed, insured, established in 1998, and IICRC certified.",
+              primaryCta: {
+                label: "Call now",
+                href: "tel:+15555550123",
+              },
+              backgroundImage: {
+                src: "/content/images/hero.jpg",
+                alt: "Carpet cleaning result",
+              },
+            },
+          ],
+        },
+      ],
+    });
+
+    try {
+      await buildSite(site, outDir);
+
+      const css = await readFile(path.join(outDir, "assets", "site.css"), "utf8");
+
+      expect(css).toContain("@media(width<=40rem)");
+      expect(css).toContain('body[data-theme=high-vis-service]');
+      expect(css).toContain(".c-hero--has-background{min-height:clamp(22rem,48vh,31rem)}");
+      expect(css).toContain(
+        ".c-hero__headline{font-size:clamp(var(--size-2xl),7vw,var(--size-3xl))",
+      );
+      expect(css).toContain(".c-hero__subheadline{font-size:var(--size-lg);line-height:1.35}");
+    } finally {
+      await rm(outDir, { recursive: true, force: true });
+    }
+  });
+
   it("renders a shared navigation bar and emits its measured-collapse runtime", async () => {
     const outDir = await mkdtemp(path.join(os.tmpdir(), "cruftless-navbar-layout-"));
     const site = SiteContentSchema.parse({


### PR DESCRIPTION
## Summary

Improves the shared hero component's mobile polish so generated refreshes do not feel oversized in the first viewport.

## Changes

- Adds mobile-only hero rules for widths `<= 40rem`:
  - background heroes use a shorter mobile min-height: `clamp(22rem, 48vh, 31rem)`
  - headline scale is reduced to `clamp(var(--size-2xl), 7vw, var(--size-3xl))`
  - subheadline line-height/size is tightened
  - hero body/action spacing is reduced
  - negative headline letter spacing is removed on mobile
- Softens the `high-vis-service` diagonal page pattern on small screens with a scoped `body[data-theme="high-vis-service"]` background override.
- Adds a build-level test that verifies the generated CSS contains the mobile hero polish rules.

## Runtime Verification

Rebuilt the real Dan Patch refresh that triggered the SiteRefresh visual-QA feedback:

```powershell
node scripts/shared-site-gen.mjs build F:\Refreshes\danpatchcarpetcleaning-com
```

Then captured an iPhone 15 Pro Max viewport screenshot with Playwright and checked computed metrics:

- viewport: `430 x 932`
- no horizontal overflow: `scrollWidth = 430`, `clientWidth = 430`
- hero height: `447.36px`
- hero min-height: `447.36px`
- headline font-size: `30.1px`
- headline line-height: `31.605px`
- subheadline font-size: `18px`
- high-vis background pattern opacity reduced to `rgba(255, 212, 0, 0.08)`

Screenshot inspected locally:

`F:\SiteRefresh\site-images\refresh-visual-reviews\danpatch-after-mobile-hero-polish-smaller.png`

The hero is still visually prominent, but the first viewport now has a more restrained type scale and brings the next section into view sooner.

## Tests

Passed:

- `cmd /c npm run lint:ts`
- `cmd /c npm run lint:css`
- `cmd /c npx vitest run tests/site-layout.test.ts`

Full `cmd /c npm run test` was also run. It currently fails on unrelated pre-existing slideshow work in the dirty repository state: the component registry includes `slideshow`, but README/theme example expectations have not been updated. This PR does not touch those files.