### PR TITLE
Support linked footer credits

### DIFF
--- a/schemas/site-content.schema.json
+++ b/schemas/site-content.schema.json
@@ -1479,6 +1479,40 @@
                   "minLength": 1,
                   "maxLength": 120
                 },
+                "companyHref": {
+                  "type": "string",
+                  "format": "uri"
+                },
+                "additionalCredits": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "text": {
+                        "type": "string",
+                        "minLength": 1,
+                        "maxLength": 120
+                      },
+                      "label": {
+                        "type": "string",
+                        "minLength": 1,
+                        "maxLength": 120
+                      },
+                      "href": {
+                        "type": "string",
+                        "format": "uri"
+                      }
+                    },
+                    "required": [
+                      "text",
+                      "label",
+                      "href"
+                    ],
+                    "additionalProperties": false
+                  },
+                  "maxItems": 4,
+                  "default": []
+                },
                 "showCredit": {
                   "type": "boolean",
                   "default": true

--- a/src/build/framework.ts
+++ b/src/build/framework.ts
@@ -413,6 +413,16 @@ const renderSiteFooter = (site: SiteData): string => {
 
   const currentYear = new Date().getFullYear();
   const companyName = site.footer?.companyName ?? site.name;
+  const companyHref = site.footer?.companyHref;
+  const companyHtml = companyHref
+    ? `<a href="${escapeHtml(companyHref)}">${escapeHtml(companyName)}</a>`
+    : escapeHtml(companyName);
+  const additionalCreditsHtml = (site.footer?.additionalCredits ?? [])
+    .map(
+      (credit) =>
+        ` ${escapeHtml(credit.text)} <a href="${escapeHtml(credit.href)}">${escapeHtml(credit.label)}</a>.`,
+    )
+    .join("");
   const showCredit = site.footer?.showCredit !== false;
   const creditText = site.footer?.creditText ?? "Site created by";
   const creditLabel = site.footer?.creditLabel ?? "Site by Email";
@@ -423,7 +433,7 @@ const renderSiteFooter = (site: SiteData): string => {
 
   return [
     '<footer class="l-site-footer" role="contentinfo">',
-    `  <p>&copy; Copyright ${currentYear} ${escapeHtml(companyName)} | All Rights Reserved.${creditHtml}</p>`,
+    `  <p>&copy; Copyright ${currentYear} ${companyHtml} | All Rights Reserved.${additionalCreditsHtml}${creditHtml}</p>`,
     "</footer>",
   ].join("\n");
 };

--- a/src/schemas/site.schema.ts
+++ b/src/schemas/site.schema.ts
@@ -75,10 +75,20 @@ const siteCssVariableSchemaEntries = Object.fromEntries(
 
 export const SiteCssVariablesSchema = z.object(siteCssVariableSchemaEntries).strict();
 
+const SiteFooterCreditSchema = z
+  .object({
+    text: z.string().min(1).max(120),
+    label: z.string().min(1).max(120),
+    href: z.string().url(),
+  })
+  .strict();
+
 export const SiteFooterSchema = z
   .object({
     enabled: z.boolean().default(true),
     companyName: z.string().min(1).max(120).optional(),
+    companyHref: z.string().url().optional(),
+    additionalCredits: z.array(SiteFooterCreditSchema).max(4).default([]),
     showCredit: z.boolean().default(true),
     creditText: z.string().min(1).max(80).default("Site created by"),
     creditLabel: z.string().min(1).max(80).default("Site by Email"),

--- a/tests/build-output.test.ts
+++ b/tests/build-output.test.ts
@@ -202,6 +202,14 @@ const createFooterSite = () =>
       theme: "friendly-modern",
       footer: {
         companyName: "LaunchKit & Partners",
+        companyHref: "https://launchkit.example/about",
+        additionalCredits: [
+          {
+            text: "Built with",
+            label: "Example Tech",
+            href: "https://technology.example/",
+          },
+        ],
       },
     },
     pages: [
@@ -399,7 +407,7 @@ describe("buildSite output writes", () => {
 
       expect(html).toContain('<footer class="l-site-footer" role="contentinfo">');
       expect(html).toContain(
-        `&copy; Copyright ${currentYear} LaunchKit &amp; Partners | All Rights Reserved. Site created by <a href="https://www.sitebyemail.com/">Site by Email</a>`,
+        `&copy; Copyright ${currentYear} <a href="https://launchkit.example/about">LaunchKit &amp; Partners</a> | All Rights Reserved. Built with <a href="https://technology.example/">Example Tech</a>. Site created by <a href="https://www.sitebyemail.com/">Site by Email</a>`,
       );
       expect(css).toContain(".l-site-footer");
     } finally {


### PR DESCRIPTION
## Summary
- allow an optional link around the footer company name
- support up to four additional text-and-link credits
- preserve the existing Site by Email credit and default footer output

## Verification
- schema generation/check passed
- TypeScript check passed
- all 190 unit tests passed