### PR TITLE
Keep footer credit phrases intact

### DIFF
--- a/src/build/framework.ts
+++ b/src/build/framework.ts
@@ -420,7 +420,7 @@ const renderSiteFooter = (site: SiteData): string => {
   const additionalCreditsHtml = (site.footer?.additionalCredits ?? [])
     .map(
       (credit) =>
-        ` ${escapeHtml(credit.text)} <a href="${escapeHtml(credit.href)}">${escapeHtml(credit.label)}</a>.`,
+        `&#32;<span class="l-site-footer__credit">${escapeHtml(credit.text)} <a href="${escapeHtml(credit.href)}">${escapeHtml(credit.label)}</a>.</span>`,
     )
     .join("");
   const showCredit = site.footer?.showCredit !== false;
@@ -428,7 +428,7 @@ const renderSiteFooter = (site: SiteData): string => {
   const creditLabel = site.footer?.creditLabel ?? "Site by Email";
   const creditHref = site.footer?.creditHref ?? "https://www.sitebyemail.com/";
   const creditHtml = showCredit
-    ? ` ${escapeHtml(creditText)} <a href="${escapeHtml(creditHref)}">${escapeHtml(creditLabel)}</a>`
+    ? `&#32;<span class="l-site-footer__credit">${escapeHtml(creditText)} <a href="${escapeHtml(creditHref)}">${escapeHtml(creditLabel)}</a>.</span>`
     : "";
 
   return [

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -126,10 +126,15 @@ button:focus-visible {
   margin-inline: auto;
 }
 
+.l-site-footer__credit {
+  white-space: nowrap;
+}
+
 .l-site-footer a {
   color: inherit;
   font-weight: 600;
   text-decoration: underline;
+  white-space: nowrap;
 }
 
 .l-site-footer a:hover {

--- a/tests/build-output.test.ts
+++ b/tests/build-output.test.ts
@@ -407,7 +407,7 @@ describe("buildSite output writes", () => {
 
       expect(html).toContain('<footer class="l-site-footer" role="contentinfo">');
       expect(html).toContain(
-        `&copy; Copyright ${currentYear} <a href="https://launchkit.example/about">LaunchKit &amp; Partners</a> | All Rights Reserved. Built with <a href="https://technology.example/">Example Tech</a>. Site created by <a href="https://www.sitebyemail.com/">Site by Email</a>`,
+        `&copy; Copyright ${currentYear} <a href="https://launchkit.example/about">LaunchKit &amp; Partners</a> | All Rights Reserved.&#32;<span class="l-site-footer__credit">Built with <a href="https://technology.example/">Example Tech</a>.</span>&#32;<span class="l-site-footer__credit">Site created by <a href="https://www.sitebyemail.com/">Site by Email</a>.</span>`,
       );
       expect(css).toContain(".l-site-footer");
     } finally {
@@ -425,7 +425,7 @@ describe("buildSite output writes", () => {
       const currentYear = new Date().getFullYear();
 
       expect(html).toContain(
-        `&copy; Copyright ${currentYear} LaunchKit | All Rights Reserved. Site created by <a href="https://www.sitebyemail.com/">Site by Email</a>`,
+        `&copy; Copyright ${currentYear} LaunchKit | All Rights Reserved.&#32;<span class="l-site-footer__credit">Site created by <a href="https://www.sitebyemail.com/">Site by Email</a>.</span>`,
       );
     } finally {
       await removeDirectory(outDir);


### PR DESCRIPTION
## Summary
- keep each linked footer credit phrase together while allowing sentence-level wrapping
- add terminal punctuation to the Site by Email credit
- cover generated HTML output

## Verification
- 18/18 focused build-output tests pass
- isolated watch-mode test passes (full suite had one load-related watch timeout; 189/190 otherwise passed)
- TypeScript and CSS lint pass
- independently reviewed at mobile, intermediate, and desktop widths with no residual defects