### PR TITLE
feat: support additional hero actions

### DIFF
--- a/schemas/site-content.schema.json
+++ b/schemas/site-content.schema.json
@@ -694,6 +694,13 @@
                           "secondaryCta": {
                             "$ref": "#/definitions/SiteContent/properties/site/properties/layout/properties/headerComponents/items/anyOf/3/properties/primaryCta"
                           },
+                          "additionalCtas": {
+                            "type": "array",
+                            "items": {
+                              "$ref": "#/definitions/SiteContent/properties/site/properties/layout/properties/headerComponents/items/anyOf/3/properties/primaryCta"
+                            },
+                            "maxItems": 4
+                          },
                           "align": {
                             "type": "string",
                             "enum": [

--- a/src/components/hero/hero.render.ts
+++ b/src/components/hero/hero.render.ts
@@ -26,7 +26,7 @@ export const renderHero = (
   data: HeroData,
   renderContext: ComponentRenderContext = defaultComponentRenderContext,
 ): string => {
-  const ctas = [data.primaryCta, data.secondaryCta].filter(
+  const ctas = [data.primaryCta, data.secondaryCta, ...(data.additionalCtas ?? [])].filter(
     (cta): cta is NonNullable<typeof cta> => Boolean(cta),
   );
   const className = [

--- a/src/components/hero/hero.schema.ts
+++ b/src/components/hero/hero.schema.ts
@@ -22,13 +22,14 @@ export const HeroSchemaBase = z
     subheadline: z.string().min(1).max(240).optional(),
     primaryCta: LinkSchema.optional(),
     secondaryCta: LinkSchema.optional(),
+    additionalCtas: z.array(LinkSchema).max(4).optional(),
     align: z.enum(["start", "center"]).default("start"),
     backgroundImage: HeroBackgroundImageSchema.optional(),
   })
   .strict();
 
 export const HeroSchema = HeroSchemaBase.superRefine((value, ctx) => {
-    if (!value.primaryCta && !value.secondaryCta) {
+    if (!value.primaryCta && !value.secondaryCta && !value.additionalCtas?.length) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
         message: "At least one CTA is required",

--- a/src/components/hero/hero.test.ts
+++ b/src/components/hero/hero.test.ts
@@ -49,6 +49,26 @@ describe("HeroSchema", () => {
     expect(html).not.toContain("Custom woodworking bench");
   });
 
+  it("renders additional calls to action after the primary and secondary actions", () => {
+    const parsed = HeroSchema.parse({
+      type: "hero",
+      headline: "Choose a platform",
+      primaryCta: { label: "Android", href: "/android" },
+      secondaryCta: { label: "Windows", href: "/windows" },
+      additionalCtas: [
+        { label: "Linux", href: "/linux" },
+        { label: "macOS", href: "/macos" },
+      ],
+    });
+
+    const html = renderHero(parsed);
+
+    expect(html).toContain('c-button--primary" href="/android">Android</a>');
+    expect(html).toContain('c-button--secondary" href="/windows">Windows</a>');
+    expect(html).toContain('c-button--secondary" href="/linux">Linux</a>');
+    expect(html).toContain('c-button--secondary" href="/macos">macOS</a>');
+  });
+
   it("resolves background image paths through the render context", () => {
     const parsed = HeroSchema.parse({
       type: "hero",

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -108,7 +108,7 @@ export const ComponentSchemaBase = z.discriminatedUnion("type", [
 
 export const ComponentSchema = ComponentSchemaBase.superRefine((value, ctx) => {
   if (value.type === "hero") {
-    if (!value.primaryCta && !value.secondaryCta) {
+    if (!value.primaryCta && !value.secondaryCta && !value.additionalCtas?.length) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
         message: "At least one CTA is required",


### PR DESCRIPTION
## Summary
- allow up to four additional structured hero CTAs
- render additional actions after the existing primary/secondary pair
- preserve the existing requirement that a hero has at least one CTA
- regenerate the strict JSON schema

## Verification
- hero component tests: 6 passed
- TypeScript check passed
- generated schema check passed
- git diff --check passed